### PR TITLE
[#95] [#110] 

### DIFF
--- a/src/components/core/blocks/Header/MicrocartIcon.vue
+++ b/src/components/core/blocks/Header/MicrocartIcon.vue
@@ -2,18 +2,18 @@
   <div class="microcart-icon">
       Core Microcart
       <!-- Total items in cart -->
-      {{ totalItems }}
+      {{ totals.quantity }}
   </div>
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 export default {
   name: 'microcart-icon',
   computed: {
-    totalItems () {
-      // return this.$store.getters.totals.quantity
-      return 3
-    }
+    ...mapGetters({
+      totals: 'cart/totals'
+    })
   }
 }
 </script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,7 +5,19 @@ Vue.use(VueRouter)
 
 const router = new VueRouter({
   mode: 'history',
-  base: __dirname
+  base: __dirname,
+  scrollBehavior: (to, from, savedPosition) => {
+    if (to.hash) {
+      return {
+        selector: to.hash
+      }
+    }
+    if (savedPosition) {
+      return savedPosition
+    } else {
+      return {x: 0, y: 0}
+    }
+  }
 }) // routes are registered by themes or modules - here is only global router instance
 
 export default router

--- a/src/themes/default/App.vue
+++ b/src/themes/default/App.vue
@@ -56,25 +56,23 @@ export default {
 <style src="./css/border.css"></style>
 
 <style>
+html,
+body {
+  height: 100%;
+}
 body {
   margin: 0;
   padding: 0;
-  overflow: hidden;
 }
 a {
   text-decoration: none;
 }
-#app {
-  max-height: 100vh;
-  overflow-x: hidden;
-  overflow-y: auto;
-}
-#app.no-scroll {
+#app.noScroll {
+  height: 100%;
   overflow: hidden;
 }
 #viewport {
   width: 100%;
-  min-height: 100vh;
   position: relative;
   overflow-x: hidden;
 }

--- a/src/themes/default/App.vue
+++ b/src/themes/default/App.vue
@@ -54,6 +54,7 @@ export default {
 <style src="./css/padding.css"></style>
 <style src="./css/text.css"></style>
 <style src="./css/border.css"></style>
+<style src="./css/visibility.scss"></style>
 
 <style>
 html,

--- a/src/themes/default/App.vue
+++ b/src/themes/default/App.vue
@@ -54,7 +54,8 @@ export default {
 <style src="./css/padding.css"></style>
 <style src="./css/text.css"></style>
 <style src="./css/border.css"></style>
-<style src="./css/visibility.scss"></style>
+<style src="./css/layout.scss" lang="scss"></style>
+<style src="./css/visibility.scss" lang="scss"></style>
 
 <style>
 html,
@@ -68,7 +69,7 @@ body {
 a {
   text-decoration: none;
 }
-#app.noScroll {
+#app.no-scroll {
   height: 100%;
   overflow: hidden;
 }

--- a/src/themes/default/components/core/blocks/Header/MicrocartIcon.vue
+++ b/src/themes/default/components/core/blocks/Header/MicrocartIcon.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="microcart-icon" @click="toggleMicrocart">
     <i class="material-icons md-18">shopping_cart</i>
+    <span class="minicart-count" v-cloak>{{totals.quantity}}</span>
   </div>
 </template>
 
@@ -9,11 +10,6 @@ import { coreComponent } from 'lib/themes'
 import EventBus from 'src/event-bus/event-bus'
 
 export default {
-  data () {
-    return {
-      total: 3
-    }
-  },
   methods: {
     toggleMicrocart () {
       EventBus.$emit('toggle-microcart')
@@ -27,5 +23,21 @@ export default {
 <style scoped>
   .microcart-icon {
     display: inline-flex;
+  }
+
+  .minicart-count {
+    position: relative;
+    display: flex;
+    top: -5px;
+    left: -5px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    justify-content: center;
+    align-items: center;
+    font-size: 10px;
+    font-weight: 700;
+    background-color: #8e8e8e;
+    color: #fff;
   }
 </style>

--- a/src/themes/default/components/core/blocks/Header/MicrocartIcon.vue
+++ b/src/themes/default/components/core/blocks/Header/MicrocartIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="microcart-icon" @click="toggleMicrocart">
     <i class="material-icons md-18">shopping_cart</i>
-    <span class="minicart-count" v-cloak>{{totals.quantity}}</span>
+    <span class="minicart-count l-center-vh brdr-circle fs-10 weight-700 bg-gray c-white" v-cloak>{{totals.quantity}}</span>
   </div>
 </template>
 
@@ -27,17 +27,9 @@ export default {
 
   .minicart-count {
     position: relative;
-    display: flex;
     top: -5px;
     left: -5px;
     width: 16px;
     height: 16px;
-    border-radius: 50%;
-    justify-content: center;
-    align-items: center;
-    font-size: 10px;
-    font-weight: 700;
-    background-color: #8e8e8e;
-    color: #fff;
   }
 </style>

--- a/src/themes/default/css/color.css
+++ b/src/themes/default/css/color.css
@@ -6,6 +6,10 @@
     background-color: #333;
 }
 
+.bg-gray {
+    background-color: #8E8E8E;
+}
+
 .bg-lightgray {
     background-color: #F2F2F2;
 }
@@ -18,9 +22,12 @@
     background-color: transparent;
 }
 
-
 .c-white {
     color: white;
+}
+
+.c-gray {
+    color: #8E8E8E;
 }
 
 .c-lightgray {

--- a/src/themes/default/css/layout.scss
+++ b/src/themes/default/css/layout.scss
@@ -1,0 +1,6 @@
+// vertical/horizontal center alignment
+.l-center-vh {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/themes/default/css/text.css
+++ b/src/themes/default/css/text.css
@@ -73,6 +73,14 @@ h6, .h6 {
     font-weight: 400;
 }
 
+.weight-700 {
+    font-weight: 700;
+}
+
 .lh-30 {
     line-height: 30px;
+}
+
+.fs-10 {
+    font-size: 10px;
 }

--- a/src/themes/default/css/visibility.scss
+++ b/src/themes/default/css/visibility.scss
@@ -1,0 +1,3 @@
+[v-cloak] {
+  display: none;
+}


### PR DESCRIPTION
Closes: #95  #110 . Sorry for resolving two issues in one PR. Next time I will make it by feature branches. 

According to #110. Counter circle has background #BDBDBD on figma. But right now each button icon in header has 60% opacity. So #BDBDBD was too bright. Instead of this I changed it on #8E8E8E to make it a little darker 

<img width="516" alt="zrzut ekranu 2017-10-17 o 17 27 41" src="https://user-images.githubusercontent.com/7935392/31673961-d19edb70-b360-11e7-80c4-20dfd33ca28f.png">
