### PR TITLE
[#138][#155] Simplified router logic for components with/without mixing and filter/breadcrumbs multiplication fixed

### DIFF
--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -20,23 +20,19 @@ router.onReady(() => {
       return next()
     }
     Promise.all(activated.map(c => { // TODO: update me for mixins support
-      if (c.mixins) {
-        const components = Array.from(c.mixins)
-        components.push(c)
-        Promise.all(components.map(SubComponent => {
-          if (SubComponent.asyncData) {
-            console.log(SubComponent)
-            return SubComponent.asyncData({
-              store,
-              route: to
-            })
-          }
-        })).then(() => {
-          next()
-        }).catch(next)
-      } else {
+      const components = c.mixins ? Array.from(c.mixins) : []
+      components.push(c)
+      Promise.all(components.map(SubComponent => {
+        if (SubComponent.asyncData) {
+          console.log(SubComponent)
+          return SubComponent.asyncData({
+            store,
+            route: to
+          })
+        }
+      })).then(() => {
         next()
-      }
+      }).catch(next)
     }))
   })
   app.$mount('#app')

--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -24,7 +24,6 @@ router.onReady(() => {
       components.push(c)
       Promise.all(components.map(SubComponent => {
         if (SubComponent.asyncData) {
-          console.log(SubComponent)
           return SubComponent.asyncData({
             store,
             route: to

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -11,6 +11,7 @@ import ProductTile from '../components/core/ProductTile.vue'
 export default {
   name: 'Home',
   beforeMount () {
+    this.$store.dispatch('category/reset')
   },
   components: {
     ProductTile,

--- a/src/pages/Product.vue
+++ b/src/pages/Product.vue
@@ -12,14 +12,19 @@ import { optionLabel } from 'src/store/modules/attribute'
 import EventBus from 'src/event-bus/event-bus'
 
 function fetchData (store, route) {
+  store.dispatch('product/reset')
   return store.dispatch('product/single', { fieldName: 'id', value: route.params.id }).then((product) => {
     let subloaders = []
     if (product) {
       let setbrcmb = (path) => {
-        path.push({
-          slug: store.state.category.current.slug,
-          name: store.state.category.current.name
-        }) // current category at the end
+        if (path.findIndex(itm => {
+          return itm.slug === store.state.category.current.slug
+        }) < 0) {
+          path.push({
+            slug: store.state.category.current.slug,
+            name: store.state.category.current.name
+          }) // current category at the end
+        }
         store.state.product.breadcrumbs.routes = breadCrumbRoutes(path) // TODO: change to store.commit call?
       }
       // TODO: Fix it when product is enterd from outside the category page

--- a/src/server-entry.js
+++ b/src/server-entry.js
@@ -10,21 +10,19 @@ export default context => {
         return reject({ code: 404 })
       }
       Promise.all(matchedComponents.map(Component => {
-        if (Component.mixins) {
-          const components = Array.from(Component.mixins)
-          components.push(Component)
-          Promise.all(components.map(SubComponent => {
-            if (SubComponent.asyncData) {
-              return SubComponent.asyncData({
-                store,
-                route: router.currentRoute
-              })
-            }
-          })).then(() => {
-            context.state = store.state
-            resolve(app)
-          }).catch(reject)
-        }
+        const components = Component.mixins ? Array.from(Component.mixins) : []
+        components.push(Component)
+        Promise.all(components.map(SubComponent => {
+          if (SubComponent.asyncData) {
+            return SubComponent.asyncData({
+              store,
+              route: router.currentRoute
+            })
+          }
+        })).then(() => {
+          context.state = store.state
+          resolve(app)
+        }).catch(reject)
       }))
     }, reject)
   })

--- a/src/store/modules/category.js
+++ b/src/store/modules/category.js
@@ -17,6 +17,15 @@ const getters = {
 
 // actions
 const actions = {
+
+  /**
+   * Reset current category and path
+   * @param {Object} context
+   */
+  reset (context) {
+    context.commit(types.CATEGORY_UPD_CURRENT_CATEGORY_PATH, [])
+    context.commit(types.CATEGORY_UPD_CURRENT_CATEGORY, {})
+  },
   /**
    * Load categories within specified parent
    * @param {Object} commit promise

--- a/src/store/modules/product.js
+++ b/src/store/modules/product.js
@@ -18,6 +18,14 @@ const getters = {
 const actions = {
 
   /**
+   * Reset current configuration and selected variatnts
+   */
+  reset (context) {
+    context.state.product_selected_variant = null
+    context.state.current_configuration = {}
+    context.state.current_options = {color: [], size: []}
+  },
+  /**
    * Search ElasticSearch catalog of products using simple text query
    * Use bodybuilder to build the query, aggregations etc: http://bodybuilder.js.org/
    * @param {Object} query elasticSearch request body


### PR DESCRIPTION
Regarding https://github.com/DivanteLtd/vue-storefront/pull/149. I've simplified the logic to support all use cases