### PR TITLE
[#157] Microcart / parse updated qty to integer instead of string

### DIFF
--- a/src/themes/default/components/core/blocks/Microcart/Product.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Product.vue
@@ -11,7 +11,7 @@
           <div><span class="h6 c-darkgray">Qty</span> 
           <span class="h6 weight-400" :class="{ hidden: isEditing }">{{ product.quantity }}</span>
           <span :class="{ hidden: !isEditing }">
-            <input class="h6" type="number" v-model="qty">
+            <input class="h6" type="number" v-model.number="qty">
           </span>
           </div>
         </div>


### PR DESCRIPTION
I think this may be related with #157. 

When you update qty of product on microcart the number was parse to string. It caused problem for example with counting totals. You can guess what is the result when you add number + string ;-) 

We have 2 solutions. Parsing to Int when qty is updating in  updateQuantity method or just use vue directive. I picked the second one. https://vuejs.org/v2/guide/forms.html#number

We should think about validation and parsing when we are working with v-model and forms. 