### PR TITLE
[#160] Title/description tags support

### DIFF
--- a/src/index.template.html
+++ b/src/index.template.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>vue-storefront</title>
+    <title>{{ state.meta.title }}</title>
+    <meta name="description" content="{{ state.meta.description }}">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
     <meta name="theme-color" content="#f60">

--- a/src/lib/meta.js
+++ b/src/lib/meta.js
@@ -1,0 +1,46 @@
+function getMeta (vm) {
+  const { meta } = vm.$options
+  if (meta) {
+    return typeof meta === 'function'
+      ? meta.call(vm)
+      : meta
+  }
+}
+
+const clientMeta = {
+  mounted () {
+    this.setMeta()
+  },
+  // SSR support for components without any async data
+  // Meta tags can be passed by router.meta object
+  asyncData ({ store, route }) {
+    return new Promise((resolve, reject) => {
+      if (typeof route.meta.title !== 'undefined') {
+        store.commit('meta/title', route.meta.title)
+      }
+      if (typeof route.meta.description !== 'undefined') {
+        store.commit('meta/description', route.meta.description)
+      }
+      return resolve()
+    })
+  },
+  methods: {
+    setMeta () {
+      const meta = getMeta(this)
+
+      if (typeof meta !== 'undefined') {
+        if (meta.title) {
+          document.title = meta.title + this.$store.state.meta.suffix
+          this.$store.commit('meta/title', meta.title)
+        }
+
+        if (meta.description) {
+          document.querySelector('meta[name="description"]').setAttribute('content', meta.description)
+          this.$store.commit('meta/description', meta.description)
+        }
+      }
+    }
+  }
+}
+
+export default clientMeta

--- a/src/pages/Category.vue
+++ b/src/pages/Category.vue
@@ -8,6 +8,7 @@
 import builder from 'bodybuilder'
 
 import { breadCrumbRoutes } from 'src/lib/filters'
+import Meta from 'src/lib/meta'
 import EventBus from 'src/event-bus/event-bus'
 import Sidebar from '../components/core/blocks/Category/Sidebar.vue'
 import ProductListing from '../components/core/ProductListing.vue'
@@ -97,6 +98,12 @@ function filterData ({ populateAggregations = false, filters = [], searchProduct
 
 export default {
   name: 'category',
+  mixins: [Meta],
+  meta () {
+    return {
+      title: this.$store.state.category.current.name
+    }
+  },
   methods: {
     fetchData ({ store, route }) {
       let self = this
@@ -124,6 +131,7 @@ export default {
       store.dispatch('category/list', {}).then((categories) => {
         store.dispatch('category/single', { key: 'slug', value: slug }).then((category) => {
           store.state.category.breadcrumbs.routes = breadCrumbRoutes(store.state.category.current_path)
+          self.setMeta()
 
           if (!self.category) {
             self.$router.push('/')
@@ -147,6 +155,7 @@ export default {
         }).then((attrs) => {
           store.dispatch('category/single', { key: 'slug', value: route.params.slug }).then((parentCategory) => {
             console.log('Loading products list in SSR')
+            store.dispatch('meta/set', { title: store.state.category.current.name })
             filterData({ searchProductQuery: baseFilterQuery(defaultFilters, parentCategory), populateAggregations: true, store: store, route: route, ofset: 0, pageSize: 50, filters: defaultFilters }).then((res) => {
               store.state.category.breadcrumbs.routes = breadCrumbRoutes(store.state.category.current_path)
               return resolve()

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -5,18 +5,23 @@
 </template>
 
 <script>
+import Meta from 'src/lib/meta'
 import MainSlider from '../components/core/blocks/MainSlider/MainSlider.vue'
 import ProductTile from '../components/core/ProductTile.vue'
 
 export default {
   name: 'Home',
+  meta: {
+    title: 'Home Page'
+  },
   beforeMount () {
     this.$store.dispatch('category/reset')
   },
   components: {
     ProductTile,
     MainSlider
-  }
+  },
+  mixins: [Meta]
 }
 </script>
 

--- a/src/pages/Product.vue
+++ b/src/pages/Product.vue
@@ -6,6 +6,7 @@
 
 <script>
 import Breadcrumbs from '../components/core/Breadcrumbs.vue'
+import Meta from 'src/lib/meta'
 import AddToCart from '../components/core/AddToCart.vue'
 import { breadCrumbRoutes } from 'src/lib/filters'
 import { optionLabel } from 'src/store/modules/attribute'
@@ -25,6 +26,7 @@ function fetchData (store, route) {
             name: store.state.category.current.name
           }) // current category at the end
         }
+        store.dispatch('meta/set', { title: product.name })
         store.state.product.breadcrumbs.routes = breadCrumbRoutes(path) // TODO: change to store.commit call?
       }
       // TODO: Fix it when product is enterd from outside the category page
@@ -148,10 +150,16 @@ export default {
       // TO-DO: Variants should be in product object
     }
   },
+  meta () {
+    return {
+      title: this.product.name
+    }
+  },
   components: {
     Breadcrumbs,
     AddToCart
-  }
+  },
+  mixins: [Meta]
 }
 </script>
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -48,6 +48,7 @@ import cart from './modules/cart'
 import user from './modules/user'
 import payment from './modules/payment'
 import shipping from './modules/shipping'
+import meta from './modules/meta'
 import ui from './modules/ui-store'
 import homepage from './modules/homepage'
 import social from './modules/social-tiles'
@@ -93,6 +94,7 @@ export default new Vuex.Store({
     user,
     payment,
     shipping,
+    meta,
     ui,
     homepage,
     social

--- a/src/store/modules/meta.js
+++ b/src/store/modules/meta.js
@@ -1,0 +1,38 @@
+const state = {
+  title: 'Vue Storefront',
+  description: 'Vue Storefront is a standalone PWA storefront for your eCommerce, possible to connect with any eCommerce backend (eg. Magento, Prestashop or Shopware) through the API.',
+  suffix: ' - Vue Storefront'
+}
+
+const getters = {
+  meta (state) {
+    return {
+      title: state.title,
+      description: state.description
+    }
+  }
+}
+
+const actions = {
+  set ({commit}, meta) {
+    commit('title', typeof meta.title !== 'undefined' ? meta.title : state.title)
+    commit('description', typeof meta.description !== 'undefined' ? meta.description : state.description)
+  }
+}
+
+const mutations = {
+  title (state, title) {
+    state.title = title + state.suffix
+  },
+  description (state, description) {
+    state.description = description
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+}

--- a/src/themes/default/index.js
+++ b/src/themes/default/index.js
@@ -8,7 +8,7 @@ const routes = [
     { path: '/', component: Home },
     { name: 'category', path: '/c/:slug', component: Category },
     { name: 'product', path: '/p/:id/:slug', component: Product },
-    { name: 'legal', path: '/legal', component: Static, props: {page: 'lorem', title: 'Legal Notice'} },
+    { name: 'legal', path: '/legal', component: Static, props: {page: 'lorem', title: 'Legal Notice'}, meta: {title: 'Legal Notice', description: 'Legal Notice - example of description usage'} },
     { name: 'privacy', path: '/privacy', component: Static, props: {page: 'lorem', title: 'Privacy'} },
     { name: 'magazine', path: '/magazine', component: Static, props: {page: 'lorem', title: 'Magazine'} },
     { name: 'sale', path: '/sale', component: Static, props: {page: 'lorem', title: 'Sale'} },

--- a/src/themes/default/pages/Static.vue
+++ b/src/themes/default/pages/Static.vue
@@ -12,16 +12,31 @@
 
 <script>
 import staticpage from '../resource/lorem.md'
+import Meta from 'src/lib/meta'
 
 export default {
+  components: {
+    staticpage
+  },
+  mixins: [Meta],
+  meta () {
+    return {
+      title: this.$props.title
+    }
+  },
   data () {
     return {
       breadcrumbs: 'Homepage / ' + this.$props.title
     }
   },
   props: ['page', 'title'],
-  components: {
-    staticpage
+  watch: {
+    '$route': 'validateRoute'
+  },
+  methods: {
+    validateRoute () {
+      this.setMeta()
+    }
   }
 }
 </script>


### PR DESCRIPTION
HI, I added title / description tags support. In the near future we can extend it about more tags/fields.

You can provide meta tags by:
1) Meta component object: 
```
export default {
  name: 'Home',
  meta: {
    title: 'Home Page',
    description: 'Example of home page description'
  },
}
```

or 

```
meta () {
    return {
      title: this.product.name
    }
  },
```

2) Route meta params - Useful when components do not have any asyncData. ( look here https://github.com/DivanteLtd/vue-storefront/pull/193/files#diff-bcbdb08f1dd4712deb4595fa738072b3R16 ) 

```
{ name: 'legal', path: '/legal', component: Static, props: {page: 'lorem', title: 'Legal Notice'}, meta: {title: 'Legal Notice', description: 'Legal Notice - example of description usage'} },
```

3. Manually for SSR purposes or specific routes 
``` store.dispatch('meta/set', { title: product.name }) ```
Sometimes after specific route change you may have refresh the tags manually by: 
``` this.setMeta() ```
For example in staticPage component when you go to static page from another static page. 
https://github.com/DivanteLtd/vue-storefront/pull/193/files#diff-53623d3d96444676ad00f4011dfaafe2R38
