### PR TITLE
[#161] Add router-link to logo / fix underline

### DIFF
--- a/src/themes/default/components/core/Logo.vue
+++ b/src/themes/default/components/core/Logo.vue
@@ -1,5 +1,5 @@
 <template>
-  <a href="/" title="Home Page">
+  <router-link to="/" title="Home Page" class="no-underline">
     <div class="logo">
       <svg :width="width" :height="height" viewBox="0 0 40 47" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <g id="Canvas" transform="translate(306 321)">
@@ -83,7 +83,7 @@
       </svg>
 
     </div>
-  </a>
+  </router-link>
 </template>
 
 <script>


### PR DESCRIPTION
I think logo link should be router-link to prevent page reloading. 
I added no-underline class also to hide unneeded underline. You can see it on screenshot below: 
<img width="223" alt="zrzut ekranu 2017-10-29 o 13 48 30" src="https://user-images.githubusercontent.com/7935392/32143861-8aa30e40-bcb0-11e7-84bb-979abdd404be.png">
