### PR TITLE
[#186] Use the same product image on category/product

### DIFF
--- a/src/components/core/ProductTile.vue
+++ b/src/components/core/ProductTile.vue
@@ -14,7 +14,7 @@ export default {
   props: ['product'],
   computed: {
     thumbnail () {
-      return thumbnail(this.product.image, 570, 569)
+      return thumbnail(this.product.image, 310, 300)
     }
   }
 }

--- a/src/components/core/ProductTile.vue
+++ b/src/components/core/ProductTile.vue
@@ -14,7 +14,7 @@ export default {
   props: ['product'],
   computed: {
     thumbnail () {
-      return thumbnail(this.product.image, 310, 300)
+      return thumbnail(this.product.image, 570, 569)
     }
   }
 }

--- a/src/themes/default/components/core/ProductTile.vue
+++ b/src/themes/default/components/core/ProductTile.vue
@@ -22,6 +22,7 @@ export default {
 @import '~src/themes/default/css/transitions';
 
 .product-image > img {
+  height: 100%;
   mix-blend-mode: multiply;
   transition: 0.5s all $motion-main;
 }

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -9,7 +9,7 @@
         </div>
         <div class="row py35">
           <div class="col-md-7 center-md middle-md">
-            <img class="product-image" v-bind:src="thumbnail" />
+            <img class="product-image" v-bind:src="thumbnail" ref="image"/>
           </div>
           <div class="col-md-5">
 
@@ -62,6 +62,9 @@ import { thumbnail } from 'src/lib/filters'
 export default {
   computed: {
     thumbnail () {
+      return thumbnail(this.product.image, 310, 300)
+    },
+    image () {
       return thumbnail(this.product.image, 570, 569)
     }
   },
@@ -71,7 +74,15 @@ export default {
     SizeButton,
     Breadcrumbs
   },
-  mixins: [corePage('Product')]
+  mixins: [corePage('Product')],
+  methods: {
+    setProductImage () {
+      this.$refs.image.src = this.image
+    }
+  },
+  mounted () {
+    this.setProductImage()
+  }
 }
 </script>
 
@@ -79,5 +90,6 @@ export default {
 .product-image {
   display: inline-flex;
   mix-blend-mode: multiply;
+  width: 460px;
 }
 </style>


### PR DESCRIPTION
Quick fix for categories - using the same image size what product page. 
To achieve prefetching we have to prepare meta tags to handle it.