### PR TITLE
Minor fix (search panel positioning)

### DIFF
--- a/src/themes/default/components/core/blocks/SearchPanel/SearchPanel.vue
+++ b/src/themes/default/components/core/blocks/SearchPanel/SearchPanel.vue
@@ -50,9 +50,9 @@ export default {
 @import "../../../../css/transitions.scss";
 
   .searchpanel {
-      height: calc(100vh - 54px);
+      height: 100vh;
       width: 800px;
-      top: 54px;
+      top: 0;
       right: 0;
       max-width: 100%;
       position: fixed;


### PR DESCRIPTION
I've noticed that the search panel takes the old positioning into consideration. There used to be a 54px margin above the sidebar and microcart.