### PR TITLE
Minor fix - missing sidebar scroll on smaller devices

### DIFF
--- a/src/themes/default/components/core/blocks/SidebarMenu/SidebarMenu.vue
+++ b/src/themes/default/components/core/blocks/SidebarMenu/SidebarMenu.vue
@@ -59,6 +59,7 @@ ul {
     top: 0;
     left: 0;
     overflow: hidden;
+    overflow-y: auto;
     position: fixed;
     transform: translateX(-100%);
     z-index: 3;


### PR DESCRIPTION
I added missing `overflow-y: auto` because on smaller devices the entire sidebar wasn't visible, now it's scrollable.