### PR TITLE
Breadcrumbs with html entities, product changed to „configured_produc…

### DIFF
--- a/src/themes/default/components/core/Breadcrumbs.vue
+++ b/src/themes/default/components/core/Breadcrumbs.vue
@@ -2,11 +2,11 @@
   <div class="breadcrumbs h5 c-darkgray">
       <span v-for="link in routes" v-bind:key="link.route_link">
         <router-link :to="link.route_link">
-          {{ link.name }}
+          {{ link.name | htmlDecode }}
         </router-link> /
       </span>
       <strong>
-        {{ activeRoute }}
+        {{ activeRoute | htmlDecode }}
       </strong>
   </div>
 </template>

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -102,9 +102,9 @@ export default {
   computed: {
     imgObj () {
       return {
-        src: thumbnail(this.product.image, 570, 569),
-        error: thumbnail(this.product.image, 310, 300),
-        loading: thumbnail(this.product.image, 310, 300)
+        src: thumbnail(this.configured_product.image, 570, 569),
+        error: thumbnail(this.configured_product.image, 310, 300),
+        loading: thumbnail(this.configured_product.image, 310, 300)
       }
     }
   },


### PR DESCRIPTION
…t” for photos