### PR TITLE
Fix the offline message on the checkout

### DIFF
--- a/src/themes/default/pages/Checkout.vue
+++ b/src/themes/default/pages/Checkout.vue
@@ -108,6 +108,9 @@ export default {
       this.activateSection(section)
     })
   },
+  destroyed () {
+    this.$bus.$off('network.status')
+  },
   computed: {
     isValid () {
       let isValid = true


### PR DESCRIPTION
Added destroyed to Checkout page in order to remove network.status listener. This fixes the issue 'Fix the offline message on the checkout #298'