### PR TITLE
Removing event listeners after destroying the Checkout page component…

### DIFF
--- a/src/themes/default/pages/Checkout.vue
+++ b/src/themes/default/pages/Checkout.vue
@@ -110,6 +110,12 @@ export default {
   },
   destroyed () {
     this.$bus.$off('network.status')
+    this.$bus.$off('checkout.personalDetails')
+    this.$bus.$off('checkout.shipping')
+    this.$bus.$off('checkout.payment')
+    this.$bus.$off('checkout.cartSummary')
+    this.$bus.$off('checkout.placeOrder')
+    this.$bus.$off('checkout.edit')
   },
   computed: {
     isValid () {


### PR DESCRIPTION
…. It prevents from same messages appearing several times after going offline.