### PR TITLE
[#295] Add core modal component

### DIFF
--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -29,7 +29,8 @@ module.exports = {
       theme_pages: path.resolve(__dirname, '../src/themes/default/pages'),
       theme_components: path.resolve(__dirname, '../src/themes/default/components'),
       'theme/components': path.resolve(__dirname, '../src/themes/default/components'),
-      'theme/pages': path.resolve(__dirname, '../src/themes/default/pages')
+      'theme/pages': path.resolve(__dirname, '../src/themes/default/pages'),
+      'theme/css': path.resolve(__dirname, '../src/themes/default/css')
 
     }
   },

--- a/src/components/core/Modal.vue
+++ b/src/components/core/Modal.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="modal"
+    v-if="isVisible"
+    ref="modal"
+    @click.self="close">
+    <slot name="close"><button @click="close"> X </button></slot>
+    <slot/>
+  </div>
+</template>
+
+<script>
+import { mapMutations } from 'vuex'
+export default {
+  name: 'modal',
+  data () {
+    return {
+      isVisible: false
+    }
+  },
+  props: {
+    name: {
+      required: true,
+      type: String
+    },
+    delay: {
+      required: false,
+      type: Number,
+      default: 300
+    }
+  },
+  beforeMount () {
+    this.$bus.$on('modal.toggle', (name, state, params) => {
+      if (name === this.name) {
+        state = typeof state === 'undefined' ? !this.isVisible : state
+        this.toggle(state)
+      }
+    })
+
+    this.$bus.$on('modal.show', (name, state, params) => name === this.name ? this.toggle(true) : false)
+    this.$bus.$on('modal.hide', (name, state, params) => name === this.name ? this.toggle(false) : false)
+  },
+  methods: {
+    ...mapMutations('ui', [
+      'setOverlay'
+    ]),
+    toggle (state) {
+      this.isVisible = state
+      state ? this.setOverlay(state) : setTimeout(() => this.setOverlay(state), this.delay)
+    },
+    close () {
+      this.toggle(false)
+    }
+  }
+}
+</script>

--- a/src/themes/default/App.vue
+++ b/src/themes/default/App.vue
@@ -28,6 +28,7 @@ import SidebarMenu from './components/core/blocks/SidebarMenu/SidebarMenu.vue'
 import SearchPanel from './components/core/blocks/SearchPanel/SearchPanel.vue'
 
 import Overlay from './components/core/Overlay.vue'
+import Modal from './components/core/Modal.vue'
 import Notification from './components/core/Notification.vue'
 import SignUp from './components/core/blocks/Auth/SignUp.vue'
 import NewsletterPopup from './components/core/NewsletterPopup.vue'
@@ -50,6 +51,7 @@ export default {
     SidebarMenu,
     Overlay,
     Notification,
+    Modal,
     SignUp,
     NewsletterPopup
   }

--- a/src/themes/default/components/core/Modal.vue
+++ b/src/themes/default/components/core/Modal.vue
@@ -1,0 +1,88 @@
+<template>
+    <transition name="fade-in-down">
+        <div class="modal modal-wrapper flex center-xs middle-xs"
+            v-if="isVisible"
+            ref="modal-wrapper"
+            @click.self="close">
+            <div class="modal-container" ref="modal" :style="style">
+                <header class="modal-header py25 px65 h1 serif weight-700 bg-lightgray" v-if="$slots.header">
+                    <i slot="close" class="modal-close material-icons p15 c-gray" @click="close">close</i>
+                    <slot name="header"></slot>
+                </header>
+                <div class="modal-content pt30 pb60 px65 bg-white" v-if="$slots.content">
+                    <slot name="content"></slot>
+                </div>
+                <slot/>
+            </div>
+        </div>
+    </transition>
+</template>
+
+<script>
+import { coreComponent } from 'lib/themes'
+
+export default {
+  mixins: [coreComponent('core/Modal')],
+  props: {
+    width: {
+      type: Number,
+      default: 0
+    }
+  },
+  computed: {
+    style () {
+      return this.width ? `width: ${this.width}px` : false
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+@import '~theme/css/global_vars';
+$z-index-modal: map-get($z-index, modal);
+
+.modal-wrapper {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    overflow: auto;
+    z-index: $z-index-modal;
+    text-align: inherit;
+}
+
+.modal-container {
+    width: 945px;
+    max-width: 100%;
+    margin: 15px;
+    z-index: $z-index-modal+1;
+
+    @media (max-width: 600px) {
+      display: flex;
+      flex-direction: column;
+      min-height: 100%;
+      min-width: 100%;
+      margin: 0;
+    }
+}
+  
+.modal-header {
+    position: relative;
+
+    > * {
+        margin: 0;
+    }
+}
+
+.modal-content {
+    flex: 1;
+}
+
+.modal-close {
+    position: absolute;
+    cursor: pointer;
+    right: 0;
+    top: 0;
+}
+</style>

--- a/src/themes/default/css/global_vars.scss
+++ b/src/themes/default/css/global_vars.scss
@@ -13,3 +13,7 @@ $colors: (
 );
 
 //@to-do make it more customizable - change colors to match their usage not color name so other people can customize it when creatign own theme
+
+$z-index: (
+    modal: 10
+)


### PR DESCRIPTION
I added simple global modal component for all purposes. We can develop it later. But right now: 

<img width="1423" alt="zrzut ekranu 2017-12-11 o 22 20 55" src="https://user-images.githubusercontent.com/7935392/33854336-a2b81222-dec1-11e7-9844-4ba02af81e18.png">

Example markup - to get modal design according to figma: 
```html
<modal name="modal-example" class="if-you-need" :width="500">
   <p slot="header">Modal example</p>
   <div slot="content">
      Lorem Ipsum is simply dummy text of the printing and typesetting industry. 
   </div>
</modal>
```

Width value is optional. As default I set 945 according to figma 

If you want to design your own modal just don't use slots:
```html
<modal name="example">
  <div> Lorem Ipsum is simply dummy text of the printing and typesetting industry. </div>
</modal>
```

You can open, hide or toggle by simple events. 
```html
<button @click="$bus.$emit('modal.toggle', 'modal-example')">Example</button>
<button @click="$bus.$emit('modal.show', 'example')">Example</button>
<button @click="$bus.$emit('modal.hide', 'example')">Example</button>
```

PS. this is only first part of #295, I have to add suitable modal + content now 
PS2 if everything goes well, we can rewrite our current modal (auth, subscription) 
PS3 one thing I see to handle: jumping of page when overlay appears -> caused by overflow on #app, we should consider overflow on body only. 