### PR TITLE
Fixed bug with validators not working on Checkout page

### DIFF
--- a/src/store/modules/checkout.js
+++ b/src/store/modules/checkout.js
@@ -5,8 +5,23 @@ const store = {
   namespaced: true,
   state: {
     order: {},
-    personalDetails: {},
-    shippingDetails: {}
+    personalDetails: {
+      firstName: '',
+      lastName: '',
+      emailAddress: ''
+    },
+    shippingDetails: {
+      firstName: '',
+      lastName: '',
+      country: '',
+      streetAddress: '',
+      apartmentNumber: '',
+      city: '',
+      state: '',
+      zipCode: '',
+      phoneNumber: '',
+      shippingMethod: 'flatrate'
+    }
   },
   mutations: {
     /**
@@ -33,35 +48,6 @@ const store = {
     }
   },
   getters: {
-    getPersonalDetails (state) {
-      if (Object.keys(state.personalDetails).length > 0) {
-        return state.personalDetails
-      } else {
-        return {
-          firstName: '',
-          lastName: '',
-          emailAddress: ''
-        }
-      }
-    },
-    getShippingDetails (state) {
-      if (Object.keys(state.shippingDetails).length > 0) {
-        return state.shippingDetails
-      } else {
-        return {
-          firstName: state.personalDetails.firstName,
-          lastName: state.personalDetails.lastName,
-          country: '',
-          streetAddress: '',
-          apartmentNumber: '',
-          city: '',
-          state: '',
-          zipCode: '',
-          phoneNumber: '',
-          shippingMethod: 'flatrate'
-        }
-      }
-    }
   },
   actions: {
     /**

--- a/src/themes/default/components/core/blocks/Checkout/PersonalDetails.vue
+++ b/src/themes/default/components/core/blocks/Checkout/PersonalDetails.vue
@@ -90,12 +90,8 @@ export default {
   },
   data () {
     return {
-      isFilled: false
-    }
-  },
-  computed: {
-    personalDetails () {
-      return this.$store.getters['checkout/getPersonalDetails']
+      isFilled: false,
+      personalDetails: this.$store.state.checkout.personalDetails
     }
   },
   methods: {

--- a/src/themes/default/components/core/blocks/Checkout/Shipping.vue
+++ b/src/themes/default/components/core/blocks/Checkout/Shipping.vue
@@ -172,12 +172,8 @@ export default {
     return {
       isFilled: false,
       shippingMethods: ShippingMethods,
-      countries: Countries
-    }
-  },
-  computed: {
-    shipping () {
-      return this.$store.getters['checkout/getShippingDetails']
+      countries: Countries,
+      shipping: this.$store.state.checkout.shippingDetails
     }
   },
   methods: {

--- a/src/themes/default/pages/Checkout.vue
+++ b/src/themes/default/pages/Checkout.vue
@@ -109,8 +109,6 @@ export default {
     this.$bus.$on('checkout.edit', (section) => {
       this.activateSection(section)
     })
-    // Load personal and shipping details from IndexedDB
-    this.$store.dispatch('checkout/load')
   },
   destroyed () {
     this.$bus.$off('network.status')

--- a/src/themes/default/pages/Home.vue
+++ b/src/themes/default/pages/Home.vue
@@ -61,6 +61,10 @@ import TileLinks from '../components/theme/blocks/TileLinks/TileLinks.vue'
 import Collection from '../components/theme/blocks/Collection/Collection'
 
 export default {
+  created () {
+    // Load personal and shipping details for Checkout page from IndexedDB
+    this.$store.dispatch('checkout/load')
+  },
   computed: {
     categories () {
       return this.$store.state.category.list


### PR DESCRIPTION
After merging with feature/issue_225 branch a bug was introduced. It happens that vuelidate does not work for computed properties, rather with data properties only. On the first entrance Checkout page's input fields were not validating. 
This pull request fixes the bug.