### PR TITLE
[#367] Static content option for modal

### DIFF
--- a/src/themes/default/components/core/Modal.vue
+++ b/src/themes/default/components/core/Modal.vue
@@ -11,8 +11,9 @@
                             <i slot="close" class="modal-close material-icons p15 c-gray" @click="close">close</i>
                             <slot name="header"></slot>
                         </header>
-                        <div class="modal-content pt30 pb60 px65" v-if="$slots.content">
+                        <div class="modal-content pt30 pb60 px65" v-if="$slots.content || static">
                             <slot name="content"></slot>
+                            <static-content :file="static" v-if="static"/>
                         </div>
                         <slot/>
                     </div>
@@ -24,10 +25,15 @@
 
 <script>
 import { coreComponent } from 'lib/themes'
+import staticContent from 'theme/components/theme/StaticContent'
 
 export default {
   mixins: [coreComponent('core/Modal')],
+  components: { staticContent },
   props: {
+    static: {
+      type: String
+    },
     width: {
       type: Number,
       default: 0

--- a/src/themes/default/components/theme/StaticContent.vue
+++ b/src/themes/default/components/theme/StaticContent.vue
@@ -1,0 +1,36 @@
+<template>
+  <static :is="staticLoaded"></static>
+</template>
+<script>
+export default {
+  components: {
+    static: null
+  },
+  data () {
+    return {
+      staticLoaded: false
+    }
+  },
+  props: {
+    file: {
+      type: String,
+      required: true
+    }
+  },
+  watch: {
+    file: function (newFile) {
+      this.loadContent(newFile)
+    }
+  },
+  mounted () {
+    this.loadContent()
+  },
+  methods: {
+    loadContent (file = this.file) {
+      this.staticLoaded = false
+      this.$options.components.static = require('../../resource/' + file + '.md')
+      this.staticLoaded = 'static'
+    }
+  }
+}
+</script>

--- a/src/themes/default/pages/Static.vue
+++ b/src/themes/default/pages/Static.vue
@@ -17,7 +17,7 @@
           </nav>
         </div>
         <div class="static-content col-sm-9">
-          <static-page :is="loaded"/>
+          <static-content :file="$props.page"/>
         </div>
       </div>
     </div>
@@ -27,11 +27,12 @@
 <script>
 import Breadcrumbs from '../components/core/Breadcrumbs'
 import Meta from 'src/lib/meta'
+import staticContent from 'theme/components/theme/StaticContent'
 
 export default {
   components: {
     Breadcrumbs,
-    staticPage: null
+    staticContent
   },
   props: ['page', 'title'],
   mixins: [Meta],
@@ -42,7 +43,6 @@ export default {
   },
   data () {
     return {
-      loaded: false,
       navigation: [
         { title: 'About us', link: '/about-us' },
         { title: 'Customer service', link: '/customer-service' },
@@ -60,15 +60,7 @@ export default {
   methods: {
     validateRoute () {
       this.setMeta()
-      this.loadStaticPage()
-    },
-    loadStaticPage () {
-      this.$options.components.staticPage = require('../resource/' + this.$props.page + '.md')
-      this.loaded = 'staticPage'
     }
-  },
-  mounted () {
-    this.loadStaticPage()
   }
 }
 </script>


### PR DESCRIPTION
1. I pulled out the static content functionality to separate component
2. I refactored static page by loading static content component
3. Added static page as prop option to modal. 

For example: 
```html
<modal name="modal-test" static="about"/>
```

or with additional header:
```html
<modal name="modal-test" static="about">
    <p slot="header">About us</p>
</modal>
```

<img width="1427" alt="zrzut ekranu 2017-12-18 o 19 50 17" src="https://user-images.githubusercontent.com/7935392/34122445-bd3c3c02-e42c-11e7-9107-774e50a01908.png">
