### PR TITLE
[#409] Set focus to 1st input

### DIFF
--- a/src/components/core/Loader.vue
+++ b/src/components/core/Loader.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div class="loader-container" v-if="isVisible">
+  <div class="loader-container">
 
       <div class="loader-inner-container">
 
@@ -21,18 +21,13 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-
 export default {
   name: 'loader',
-  data: function () {
+  data () {
     return {
       message: null
     }
   },
-  computed: mapState({
-    isVisible: state => state.ui.loader
-  }),
   methods: {
     show (message = null) {
       this.message = message
@@ -42,7 +37,7 @@ export default {
       this.$store.commit('ui/setLoader', false)
     }
   },
-  mounted: function () {
+  mounted () {
     this.$bus.$on('notification-progress-start', (message) => {
       this.show(message)
     })

--- a/src/components/core/NewsletterPopup.vue
+++ b/src/components/core/NewsletterPopup.vue
@@ -4,15 +4,8 @@
   </div>
 </template>
 <script>
-import { mapState } from 'vuex'
-
 export default {
   name: 'newsletter-popup',
-  computed: {
-    ...mapState({
-      isOpen: state => state.ui.newsletterPopup
-    })
-  },
   methods: {
     closeNewsletter () {
       this.$store.commit('ui/setNewsletterPopup', false)

--- a/src/components/core/Overlay.vue
+++ b/src/components/core/Overlay.vue
@@ -1,16 +1,11 @@
 <template>
-  <div class="overlay" @click="onClick" v-if="isVisible">
+  <div class="overlay" @click="onClick">
   </div>
 </template>
 
 <script>
-import { mapState } from 'vuex'
-
 export default {
   name: 'overlay',
-  computed: mapState({
-    isVisible: state => state.ui.overlay
-  }),
   methods: {
     onClick () {
       this.$store.commit('ui/setOverlay', false)

--- a/src/components/core/blocks/Auth/SignUp.vue
+++ b/src/components/core/blocks/Auth/SignUp.vue
@@ -11,19 +11,12 @@ import Login from './Login.vue'
 import Register from './Register.vue'
 import ForgotPass from './ForgotPass.vue'
 
-import { mapState } from 'vuex'
-
 export default {
   name: 'sign-up',
   components: {
     Login,
     Register,
     ForgotPass
-  },
-  computed: {
-    ...mapState({
-      isOpen: state => state.ui.signUp
-    })
   },
   methods: {
     closeSignUp () {

--- a/src/themes/default/App.vue
+++ b/src/themes/default/App.vue
@@ -11,8 +11,8 @@
       <router-view></router-view>
       <main-footer />
       <notification />
-      <sign-up />
-      <newsletter-popup />
+      <sign-up v-if="signUpOpen" />
+      <newsletter-popup v-if="newsletterOpen"/>
       <CookieNotification />
     </div>
   </div>
@@ -40,7 +40,9 @@ import CookieNotification from './components/core/CookieNotification.vue'
 export default {
   computed: {
     ...mapState({
-      noScroll: state => state.ui.overlay
+      noScroll: state => state.ui.overlay,
+      newsletterOpen: state => state.ui.newsletterPopup,
+      signUpOpen: state => state.ui.signUp
     })
   },
   mounted () {

--- a/src/themes/default/App.vue
+++ b/src/themes/default/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app" :class="{ 'no-scroll': noScroll }">
-    <overlay />
-    <loader />
+    <overlay v-if="overlayActive"/>
+    <loader v-if="loaderActive"/>
     <div id="viewport p55">
       <microcart />
       <search-panel />
@@ -42,7 +42,9 @@ export default {
     ...mapState({
       noScroll: state => state.ui.overlay,
       newsletterOpen: state => state.ui.newsletterPopup,
-      signUpOpen: state => state.ui.signUp
+      signUpOpen: state => state.ui.signUp,
+      loaderActive: state => state.ui.loader,
+      overlayActive: state => state.ui.overlay
     })
   },
   mounted () {

--- a/src/themes/default/components/core/NewsletterPopup.vue
+++ b/src/themes/default/components/core/NewsletterPopup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="newsletter mb20 bg-white" v-if="isOpen">
+  <div class="newsletter mb20 bg-white">
     <i class="material-icons close p15 c-gray" @click="closeNewsletter">close</i>
     <div class="py35 px55 bg-lightgray">
       <h1 class="my0">Newsletter</h1>
@@ -8,7 +8,7 @@
       <form @submit.prevent="subscribe" novalidate>
         <div class="mb35">
           <p class="h4">Sign up to our newsletter and receive a coupon for 10% off!</p>
-          <input class="brdr-none py10 h4 weight-200" type="email" name="email" v-model="email" placeholder="E-mail address *">
+          <input class="brdr-none py10 h4 weight-200" ref="email" type="email" name="email" v-model="email" placeholder="E-mail address *">
           <p class="m0 c-red h6" v-if="!$v.email.required">Field is required.</p>
           <p class="m0 c-red h6" v-if="!$v.email.email">Please provide valid e-mail address.</p>
         </div>
@@ -57,6 +57,9 @@ export default {
       })
       this.$store.commit('ui/setNewsletterPopup', false)
     }
+  },
+  mounted () {
+    this.$refs.email.focus()
   },
   components: {
     ButtonFull

--- a/src/themes/default/components/core/blocks/Auth/ForgotPass.vue
+++ b/src/themes/default/components/core/blocks/Auth/ForgotPass.vue
@@ -8,7 +8,7 @@
         <form @submit.prevent="sendEmail" novalidate>
           <div class="mb35">
             <p class="mb45">Enter your email to receive instructions on how to reset your password.</p>
-            <input class="brdr-none py10 h4 weight-200" type="email" name="email" v-model="email" placeholder="E-mail address *">
+            <input ref="email" class="brdr-none py10 h4 weight-200" type="email" name="email" v-model="email" placeholder="E-mail address *">
             <p class="m0 c-red h6" v-if="!$v.email.required">Field is required.</p>
             <p class="m0 c-red h6" v-if="!$v.email.email">Please provide valid e-mail address.</p>
           </div>
@@ -86,6 +86,9 @@ export default {
     switchElem () {
       this.$store.commit('ui/setAuthElem', 'login')
     }
+  },
+  mounted () {
+    this.$refs.email.focus()
   },
   mixins: [coreComponent('core/blocks/Auth/ForgotPass')],
   components: {

--- a/src/themes/default/components/core/blocks/Auth/Login.vue
+++ b/src/themes/default/components/core/blocks/Auth/Login.vue
@@ -6,7 +6,7 @@
     <div class="py35 px65 bg-white c-gray">
       <form @submit.prevent="login" novalidate>
         <div class="mb35">
-          <input type="email" name="email" v-model="email" placeholder="E-mail address *">
+          <input type="email" name="email" ref="email" v-model="email" placeholder="E-mail address *">
           <span class="validation-error" v-if="!$v.email.required">Field is required.</span>
           <span class="validation-error" v-if="!$v.email.email">Please provide valid e-mail address.</span>
         </div>
@@ -119,6 +119,9 @@ export default {
         this.$bus.$emit('notification-progress-stop')
       })
     }
+  },
+  mounted () {
+    this.$refs.email.focus()
   },
   components: {
     ButtonFull

--- a/src/themes/default/components/core/blocks/Auth/Register.vue
+++ b/src/themes/default/components/core/blocks/Auth/Register.vue
@@ -6,7 +6,7 @@
     <div class="py35 px65 bg-white c-gray">
       <form @submit.prevent="register" novalidate>
         <div class="mb35">
-          <input type="email" name="email" v-model="email" placeholder="E-mail address *">
+          <input type="email" name="email" ref="email" v-model="email" placeholder="E-mail address *">
           <span class="validation-error" v-if="!$v.email.required">Field is required.</span>
           <span class="validation-error" v-if="!$v.email.email">Please provide valid e-mail address.</span>
         </div>
@@ -137,6 +137,9 @@ export default {
         console.error(err)
       })
     }
+  },
+  mounted () {
+    this.$refs.email.focus()
   },
   components: {
     ButtonFull

--- a/src/themes/default/components/core/blocks/Auth/SignUp.vue
+++ b/src/themes/default/components/core/blocks/Auth/SignUp.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sign-up mb20" v-if="isOpen">
+  <div class="sign-up mb20">
     <i class="material-icons p15 close c-gray" @click="closeSignUp">close</i>
     <login v-if="activeElem === 'login'" />
     <register v-if="activeElem === 'register'" />


### PR DESCRIPTION
#409
- First input is now focused in Login, Register, ForgotPass, and Newsletter popups
- Loader and Overlay don't load immediately in App.vue now, only when called.