### PR TITLE
[#431] Pull out product links as separate components

### DIFF
--- a/src/components/core/ProductLinks.vue
+++ b/src/components/core/ProductLinks.vue
@@ -1,0 +1,28 @@
+<template>
+  <ul>
+    <li v-for="(productLink, index) in products" :key="index">
+      {{ productLink.product.name }}
+
+      <div v-if="productLink.product.special_price && productLink.product.priceInclTax && productLink.product.originalPriceInclTax">
+        <span>{{ productLink.product.priceInclTax | price }}</span>
+        <span>{{ productLink.product.originalPriceInclTax | price }}</span>
+      </div>
+      <div v-if="!productLink.product.special_price && productLink.product.priceInclTax">
+        {{ productLink.product.priceInclTax | price }}
+      </div>
+
+      <input type="number" min="1" v-model.number="productLink.product.qty"/>
+    </li>
+  </ul>
+</template>
+<script>
+  export default {
+    name: 'ProductLinks',
+    props: {
+      products: {
+        type: Array,
+        required: true
+      }
+    }
+  }
+</script>

--- a/src/themes/default/components/core/ProductLinks.vue
+++ b/src/themes/default/components/core/ProductLinks.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="links py10">
+    <div class="between-md" v-for="(productLink, index) in products" :key="index">
+      <div class="py10" v-if="productLink.product">
+        <div class="row middle-xs h4 mb10">
+          <p class="col-xs-7 serif m0">{{ productLink.product.name | htmlDecode }}</p>
+          <div class="col-xs-4 c-gray">
+            <div v-if="productLink.product.special_price && productLink.product.priceInclTax && productLink.product.originalPriceInclTax">
+              <span class="price-special">{{ productLink.product.priceInclTax | price }}</span>&nbsp;
+              <span class="price-original" >{{ productLink.product.originalPriceInclTax | price }}</span>
+            </div>
+            <div v-if="!productLink.product.special_price && productLink.product.priceInclTax">
+              {{ productLink.product.priceInclTax | price }}
+            </div>
+          </div>
+        </div>
+
+        <div v-if="productLink.product" class="py5">
+          <p class="h6 c-gray m0">Quantity</p>
+          <input type="number" class="product-qty h4 weight-300" min="1" autofocus
+                 v-model.number="productLink.product.qty"/>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import { coreComponent } from 'lib/themes'
+export default {
+  name: 'ProductLinks',
+  mixins: [coreComponent('core/ProductLinks')]
+}
+</script>
+<style scoped>
+.product-qty {
+  background: transparent;
+  border: 1px solid #BDBDBD;
+  border-width: 0 0 1px 0;
+  width: 90px;
+  padding: 7px 0;
+}
+</style>

--- a/src/themes/default/css/margin.scss
+++ b/src/themes/default/css/margin.scss
@@ -8,7 +8,7 @@
 $margin-px: 0 5 10;
 $margin-x-px: 10;
 $margin-y-px: 0 5 10 30;
-$margin-top-px: 0 5 10 15 20 25 30 50;
+$margin-top-px: 0 5 10 15 20 25 30 50 55;
 $margin-bottom-px: 0 5 10 15 20 25 30 35 45 55;
 $margin-left-px: 10 15 20 30;
 $margin-right-px: 0 5 10 15;

--- a/src/themes/default/css/text.scss
+++ b/src/themes/default/css/text.scss
@@ -30,6 +30,7 @@ h6, .h6 { font-size: 12px; }
 .align-right { text-align: right; }
 
 .weight-200 { font-weight: 200; }
+.weight-300 { font-weight: 300; }
 .weight-400 { font-weight: 400; }
 .weight-700 { font-weight: 700; }
 

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -15,13 +15,15 @@
           </div>
           <div class="col-md-5">
 
-            <h1 class="mb25 c-black"> {{ product.name | htmlDecode }} </h1>
-            <div class="h3 c-gray mb55" v-if="product.special_price && product.priceInclTax && product.originalPriceInclTax">
-              <span class="price-special">{{ product.priceInclTax | price }}</span>&nbsp;
-              <span class="price-original" >{{ product.originalPriceInclTax | price }}</span>
-            </div>
-            <div class="h3 c-gray mb55" v-if="!product.special_price && product.priceInclTax">
-              {{ product.priceInclTax | price }}
+            <h1 class="mb25 mt0 c-black"> {{ product.name | htmlDecode }} </h1>
+            <div v-if="product.type_id !== 'grouped'">
+              <div class="h3 c-gray" v-if="product.special_price && product.priceInclTax && product.originalPriceInclTax">
+                <span class="price-special">{{ product.priceInclTax | price }}</span>&nbsp;
+                <span class="price-original" >{{ product.originalPriceInclTax | price }}</span>
+              </div>
+              <div class="h3 c-gray" v-if="!product.special_price && product.priceInclTax">
+                {{ product.priceInclTax | price }}
+              </div>
             </div>
 
             <div class="variants" v-if="product.type_id =='configurable' && !loading">
@@ -37,28 +39,10 @@
                 </div>
               </div>
             </div>
-            
-            <div class="links py10" v-if="product.type_id =='grouped' && !loading">
-              <div class="row between-md">
-                <div class="col-md-7 py10 link-header">Product name</div>
-                <div class="col-md-4 py10 link-header">Qty</div>
-              </div>
-              <div class="row between-md" v-for="(productLink, index) in product.product_links" :key="index">
-                <div class="col-md-7 product-name px10 py5" v-if="productLink.product">{{ productLink.product.name | htmlDecode }}
-                  <div class="c-gray" v-if="productLink.product.special_price && productLink.product.priceInclTax && productLink.product.originalPriceInclTax">
-                    <span class="price-special">{{ productLink.product.priceInclTax | price }}</span>&nbsp;
-                    <span class="price-original" >{{ productLink.product.originalPriceInclTax | price }}</span>
-                  </div>
-                  <div class="c-gray" v-if="!productLink.product.special_price && productLink.product.priceInclTax">
-                    {{ productLink.product.priceInclTax | price }}
-                  </div>
 
+            <product-links v-if="product.type_id =='grouped' && !loading" :products="product.product_links"/>
 
-                </div>
-                <div v-if="productLink.product" class="col-md-4 product-qty px10 py5"><input type="number" autofocus v-model.number="productLink.product.qty" @change="updateQuantity(productLink.product)"/></div>
-              </div>
-            </div>            
-            <add-to-cart :product="product" class="h4 bg-black c-white px55 py20 brdr-none" />
+            <add-to-cart :product="product" class="h4 bg-black c-white px55 mt55 py20 brdr-none" />
             <div class="row pt45">
               <div class="col-xs-6 col-md-5">
                 <button class="p0 bg-transparent brdr-none action" @click="addToFavorite">
@@ -107,6 +91,7 @@ import SizeButton from '../components/core/SizeButton.vue'
 import Breadcrumbs from '../components/core/Breadcrumbs.vue'
 import ProductAttribute from '../components/core/ProductAttribute.vue'
 import ProductTile from '../components/core/ProductTile.vue'
+import ProductLinks from '../components/core/ProductLinks.vue'
 
 export default {
   data () {
@@ -120,11 +105,6 @@ export default {
   asyncData ({ store, route }) { // this is for SSR purposes to prefetch data
   },
   methods: {
-    updateQuantity (product) {
-      if (product.qty <= 0) {
-        product.qty = 1
-      }
-    },
     addToFavorite () {
       let self = this
       if (!self.favorite.isFavorite) {
@@ -155,7 +135,8 @@ export default {
     Breadcrumbs,
     ProductAttribute,
     ProductTile,
-    RelatedProducts
+    RelatedProducts,
+    ProductLinks
   },
   mixins: [corePage('Product')]
 }
@@ -165,9 +146,7 @@ export default {
 .link-header {
   font-weight: bold;
 }
-.product-qty input {
-  width: 30px
-}
+
 .product-name {
   font-size: 14px;
 }


### PR DESCRIPTION
- I pulled out product links as separate components to keep product page template more clean and readable. I think we should do this with product variants also. 
- I added styles according to project on figma: 

<img width="1216" alt="zrzut ekranu 2017-12-29 o 16 08 55" src="https://user-images.githubusercontent.com/7935392/34440077-f7666a54-ecb2-11e7-83f1-89e556bd2806.png">
