### PR TITLE
Clean focus on click 

### DIFF
--- a/src/components/core/AddToCart.vue
+++ b/src/components/core/AddToCart.vue
@@ -1,6 +1,6 @@
 <template>
     <!-- Add to cart button example with addToCart action from cart store-->
-    <button class="ripple" v-on:click="addToCart(product)">Add to cart</button>
+    <button v-on:click="addToCart(product)">Add to cart</button>
 </template>
 
 <script>

--- a/src/themes/default/App.vue
+++ b/src/themes/default/App.vue
@@ -82,6 +82,7 @@ export default {
 <style src="./css/border.scss" lang="scss"></style>
 <style src="./css/positioning.scss" lang="scss"></style>
 <style src="./css/visibility.scss" lang="scss"></style>
+<style src="./css/utilities.scss" lang="scss"></style>
 
 <style>
   html,

--- a/src/themes/default/components/core/AddToCart.vue
+++ b/src/themes/default/components/core/AddToCart.vue
@@ -1,8 +1,13 @@
+<template>
+  <!-- Add to cart button example with addToCart action from cart store-->
+  <button  class="ripple" v-on:click="addToCart(product)" v-focus-clean="{class: 'no-outline'}">Add to cart</button>
+</template>
 <script>
 import { coreComponent } from 'lib/themes'
-
+import focusClean from 'theme/components/theme/directives/focusClean'
 export default {
-  mixins: [coreComponent('core/AddToCart')]
+  mixins: [coreComponent('core/AddToCart')],
+  directives: { focusClean }
 }
 </script>
 

--- a/src/themes/default/components/theme/ButtonFull.vue
+++ b/src/themes/default/components/theme/ButtonFull.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="button-full px55 py20 center-xs">
+  <div class="button-full px55 py20 center-xs ripple" tabindex="0" v-focus-clean="{class: 'no-outline'}">
     {{ text }}
   </div>
 </template>

--- a/src/themes/default/components/theme/ButtonOutline.vue
+++ b/src/themes/default/components/theme/ButtonOutline.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="button-outline uppercase px40 py15" :class="{ 
+  <div class="button-outline uppercase px40 py15" tabindex="0" :class="{
     light : color === 'light', 'brdr-white' : color === 'light', 'c-white' : color === 'light',
     dark : color === 'dark', 'brdr-black' : color === 'dark', 'c-black' : color === 'dark'
   }">
@@ -8,8 +8,10 @@
 </template>
 
 <script>
+import focusClean from 'theme/components/theme/directives/focusClean'
 export default {
   name: 'button-outline',
+  directives: { focusClean },
   props: {
     text: {
       type: String,

--- a/src/themes/default/components/theme/directives/focusClean.js
+++ b/src/themes/default/components/theme/directives/focusClean.js
@@ -1,0 +1,32 @@
+import Vue from 'vue'
+
+export default Vue.directive('focus-clean', {
+  inserted: function (el, binding) {
+    let mouseDown = false
+    let css = binding.value && binding.value.class ? binding.value.class : false
+    let timeout = binding.value && binding.value.delay ? binding.value.delay : 1000
+
+    el.addEventListener('mousedown', () => {
+      mouseDown = true
+    })
+
+    el.addEventListener('mouseup', (event) => {
+      mouseDown = false
+
+      css && setTimeout(() => {
+        event.target.blur()
+        event.target.classList.remove(css)
+      }, timeout)
+    })
+
+    el.addEventListener('focus', (event) => {
+      if (mouseDown) {
+        if (css) {
+          event.target.classList.add(css)
+        } else {
+          event.target.blur()
+        }
+      }
+    })
+  }
+})

--- a/src/themes/default/css/utilities.scss
+++ b/src/themes/default/css/utilities.scss
@@ -1,0 +1,3 @@
+.no-outline {
+  outline: 0;
+}

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -31,7 +31,7 @@
                 <span>{{ option.label }} <strong>{{ configuration[option.label.toLowerCase()].label }}</strong></span>
                 <div class="mt20 mb45">
                   <color-button v-for="(c, i) in options.color" :key="i" :id="c.id" :label="c.label" context="product" code="color" class="mr10" :class="{ active: c.id == configuration.color.id }" v-if="option.label == 'Color'" />
-                  <size-button v-for="(s, i) in options.size" :key="i" :id="s.id" :label="s.label" context="product" code="size" class="mr10" :class="{ active: s.id == configuration.size.id }" v-if="option.label == 'Size'" />
+                  <size-button v-for="(s, i) in options.size" :key="i" :id="s.id" :label="s.label" context="product" code="size" class="mr10" :class="{ active: s.id == configuration.size.id }" v-if="option.label == 'Size'" v-focus-clean />
                   <router-link to="/size-guide" v-if="option.label == 'Size'" class="p0 ml30 action size-guide">
                     <i class="pr5 material-icons">accessibility</i>
                       Size guide


### PR DESCRIPTION
1. We should not remove the default focus from the buttons, because then we lose accessibility.
Specially when we don't design our focus state. So for situations like these I prepared special directive to clean focus state only when user click on button by mouse. When user is clicking by tab key - focus is visible. 

Basic usage: 
```html
<button v-focus-clean>Button</button>
```
When user is clicking on button by mouse I execute blur event to lose focus. When user is clicking by tab behavior is like default. 

But what if our animation is working on focus state ? We can't execute blur event, because we need focus. So then we can delete just visually part of focus by: 
```html
<button v-focus-clean="{class: 'no-outline'}">
```
Then when user is clicking by mouse we are applying special class to remove visually part of focus. 

2. Referring to non-native buttons I'm wondering why they are non-native ? Why we can't just use button ? Right now I added tabindex attribute to add focus possibility on div, but from my perspective we should keep just button element to keep all functionalities like submit on enter keypress etc. @filrak what do you think ? 

3. We didn't have directives yet. I added it here src/themes/default/components/theme/directives But it is good place ? @filrak what do you think ? 