### PR TITLE
Adding Google Analytics feature #494

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "vuelidate": "^0.6.1",
     "vuex": "^3.0.0",
     "vuex-router-sync": "^5.0.0",
-    "webpack-plugin-critical": "^1.0.0"
+    "webpack-plugin-critical": "^1.0.0",
+    "vue-analytics": "^5.8.0"
   },
   "devDependencies": {
     "babel-core": "^6.13.2",

--- a/src/app.js
+++ b/src/app.js
@@ -19,6 +19,11 @@ Vue.use(VueLazyload, {
   attempt: 2
 })
 
+Vue.use(VueAnalytics, {
+  id: config.googleanalytics.id,
+  router
+})
+
 export function createApp () {
   sync(store, router)
   const app = new Vue({

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import VueAnalytics from 'vue-analytics'
 import App from './themes/default/App.vue'
 import store from './store'
 import router from './router'

--- a/src/config.example.json
+++ b/src/config.example.json
@@ -25,6 +25,9 @@
       "defaultCountry": "PL",
       "defaultRegion": "",
       "calculateServerSide": false
+    },
+    "googleanalytics": {
+      "id": "UA-NNNNNNNNN-N"
     },  
     "i18n": {
       "defaultCountry": "US",


### PR DESCRIPTION
1) Added https://github.com/MatteoGabriele/vue-analytics in packages.json
2) Defined Google Analytics UA ID to src/config.example.json
3) Initiated Vue-analytics in src/app.js with route option