### PR TITLE
[#485] Adjustments on the category page on mobile

### DIFF
--- a/src/themes/default/components/core/Breadcrumbs.vue
+++ b/src/themes/default/components/core/Breadcrumbs.vue
@@ -1,5 +1,5 @@
-<template>  
-  <div class="breadcrumbs h5 c-darkgray">
+<template>
+  <div class="breadcrumbs h5 c-darkgray hidden-xs">
       <span v-for="link in routes" v-bind:key="link.route_link">
         <router-link :to="link.route_link">
           {{ link.name | htmlDecode }}
@@ -20,5 +20,5 @@ export default {
 </script>
 
 <style scoped>
-  
+
 </style>

--- a/src/themes/default/components/core/ProductListing.vue
+++ b/src/themes/default/components/core/ProductListing.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="product-listing row start-xs">
-    <div v-for="(product, key) in products" :key="product.id" :class="'col-md-' + (12/columns)%10">
+  <div class="product-listing row m0 start-xs">
+    <div v-for="(product, key) in products" :key="product.id" class="col-xs-6 pb10" :class="'col-md-' + (12/columns)%10">
       <product-tile :product="product" :instant='key < 6 ? true : false' />
     </div>
   </div>

--- a/src/themes/default/components/core/ProductTile.vue
+++ b/src/themes/default/components/core/ProductTile.vue
@@ -60,10 +60,13 @@ export default {
 .product-image > img {
   max-width: 242px;
   height: 100%;
+  opacity: 0.8;
   transition: 0.3s all $motion-main;
+  mix-blend-mode: multiply;
 }
 .product-image:hover > img {
   transform: scale(1.1);
+  opacity: 1;
   transition: 0.3s all $motion-main;
 }
 .product-image {
@@ -71,5 +74,11 @@ export default {
   height: 300px;
   mix-blend-mode: multiply;
   overflow: hidden;
+  background-color: #F2F2F2;
+  transition: 0.3s all $motion-main;
+
+  &:hover {
+    background-color: #FBFBFB;
+  }
 }
 </style>

--- a/src/themes/default/components/core/ProductTile.vue
+++ b/src/themes/default/components/core/ProductTile.vue
@@ -8,12 +8,11 @@
             <img v-if="!instant" v-lazy="thumbnail" :key="thumbnail"/>
           </transition>
         </div>
-        <p class="mb0">{{ product.name | htmlDecode }}</p>
+        <p class="mb0 c-darkgray">{{ product.name | htmlDecode }}</p>
 
-        <span class="price-special lh30 c-gray" v-if="product.special_price">{{ product.priceInclTax | price }}</span>
-        <span class="price-original lh30 c-gray" v-if="product.special_price">{{ product.originalPriceInclTax | price }}</span>
-
-        <span class="lh30 c-gray" v-if="!product.special_price" >{{ product.priceInclTax | price }}</span>
+        <span class="price-original mr5 lh30 c-gray-secondary" v-if="product.special_price">{{ product.originalPriceInclTax | price }}</span>
+        <span class="price-special lh30 c-darkgray weight-700" v-if="product.special_price">{{ product.priceInclTax | price }}</span>
+        <span class="lh30 c-gray-secondary" v-if="!product.special_price" >{{ product.priceInclTax | price }}</span>
       </router-link>
     </span>
   </div>
@@ -54,13 +53,8 @@ export default {
 <style lang="scss" scoped>
 @import '~src/themes/default/css/transitions';
 
-.price-special {
-  color: red;
-  margin-right: 5px
-}
 .price-original {
   text-decoration: line-through;
-  font-size: smaller
 }
 
 .product-image > img {

--- a/src/themes/default/components/core/ProductTile.vue
+++ b/src/themes/default/components/core/ProductTile.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="product align-center p15">
-    <span @click.capture="preventClicks">
+    <div @click.capture="preventClicks">
       <router-link :to="{ name: product.type_id + '-product', params: { parentSku: product.parentSku ? product.parentSku : product.sku, slug: product.slug, childSku: product.sku }}">
         <div class="product-image bg-lightgray">
           <transition name="fade" appear>
@@ -14,7 +14,7 @@
         <span class="price-special lh30 c-darkgray weight-700" v-if="product.special_price">{{ product.priceInclTax | price }}</span>
         <span class="lh30 c-gray-secondary" v-if="!product.special_price" >{{ product.priceInclTax | price }}</span>
       </router-link>
-    </span>
+    </div>
   </div>
 </template>
 
@@ -53,6 +53,11 @@ export default {
 <style lang="scss" scoped>
 @import '~src/themes/default/css/transitions';
 
+.product {
+  @media (max-width: 700px) {
+    padding: 0;
+  }
+}
 .price-original {
   text-decoration: line-through;
 }

--- a/src/themes/default/components/core/ProductTile.vue
+++ b/src/themes/default/components/core/ProductTile.vue
@@ -2,7 +2,7 @@
   <div class="product align-center p15">
     <span @click.capture="preventClicks">
       <router-link :to="{ name: product.type_id + '-product', params: { parentSku: product.parentSku ? product.parentSku : product.sku, slug: product.slug, childSku: product.sku }}">
-        <div class="product-image">
+        <div class="product-image bg-lightgray">
           <transition name="fade" appear>
             <img v-if="instant" :src="thumbnail" :key="thumbnail"/>
             <img v-if="!instant" v-lazy="thumbnail" :key="thumbnail"/>
@@ -56,10 +56,11 @@ export default {
 .price-original {
   text-decoration: line-through;
 }
-
 .product-image > img {
-  max-width: 242px;
-  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
   opacity: 0.8;
   transition: 0.3s all $motion-main;
   mix-blend-mode: multiply;
@@ -71,10 +72,8 @@ export default {
 }
 .product-image {
   width: 100%;
-  height: 300px;
   mix-blend-mode: multiply;
   overflow: hidden;
-  background-color: #F2F2F2;
   transition: 0.3s all $motion-main;
 
   &:hover {

--- a/src/themes/default/components/theme/blocks/Collection/Collection.vue
+++ b/src/themes/default/components/theme/blocks/Collection/Collection.vue
@@ -22,7 +22,7 @@
             </carousel>
           </no-ssr>
         </div>
-      </div>    
+      </div>
     </div>
   </div>
   </div>

--- a/src/themes/default/components/theme/blocks/Collection/Collection.vue
+++ b/src/themes/default/components/theme/blocks/Collection/Collection.vue
@@ -71,6 +71,13 @@
 .collection-product {
   background-color: #f2f2f2;
 }
+
+  .product {
+    &.collection-product {
+      padding: 15px;
+    }
+  }
+
   .collection-product .product-image {
     //TO-DO: Should be global
     mix-blend-mode: darken;

--- a/src/themes/default/css/padding.scss
+++ b/src/themes/default/css/padding.scss
@@ -10,7 +10,7 @@ $padding-px: 0 5 10 12 15 25 45 50;
 $padding-x-px: 10 15 20 25 40 55 65 70;
 $padding-y-px: 5 10 15 20 25 30 35 50;
 $padding-top-px: 0 5 10 15 20 30 35 40 45 50 55 70;
-$padding-bottom-px: 15 20 45 60 70;
+$padding-bottom-px: 10 15 20 45 60 70;
 $padding-left-px: 0 20 30 40 70;
 $padding-right-px: 5 15 20 30 55 70;
 

--- a/src/themes/default/pages/Category.vue
+++ b/src/themes/default/pages/Category.vue
@@ -119,8 +119,8 @@ export default {
             padding: 0 40px;
             left: 0;
             width: 100vw;
-            height: calc(100vh - 56px);
-            top: 56px;
+            height: 100vh;
+            top: 0;
             box-sizing: border-box;
         }
 

--- a/src/themes/default/pages/Category.vue
+++ b/src/themes/default/pages/Category.vue
@@ -3,9 +3,13 @@
     <header class="bg-lightgray py35 pl20">
         <div class="container">
             <breadcrumbs :routes="breadcrumbs.routes" :active-route="category.name" />
-            <h1 class="mb10"> {{ category.name }} </h1> 
+            <h1 class="category-title mb10"> {{ category.name }} </h1>
         </div>
-        <button class="mobile-filters-button bg-black brdr-none c-white" @click="openFilters">ADD FILTERS</button>
+        <div class="container">
+          <div class="row m0">
+            <button class="col-xs-5 mt25 p15 mobile-filters-button bg-black brdr-none c-white h5" @click="openFilters">Filters</button>
+          </div>
+        </div>
     </header>
     <div class="container pb60">
         <div class="row pt15 pl20 center-md">
@@ -71,8 +75,6 @@ export default {
     }
 
     .mobile-filters-button {
-        margin-top: 25px;
-        padding: 15px;
         display: none;
     }
 
@@ -83,6 +85,11 @@ export default {
     }
 
     @media (max-width: 770px) {
+
+        .category-title {
+            margin: 0;
+            font-size: 36px;
+        }
 
         .products-list {
             width: 100%;

--- a/src/themes/default/pages/Category.vue
+++ b/src/themes/default/pages/Category.vue
@@ -8,13 +8,13 @@
         <div class="container">
           <div class="row m0">
             <button class="col-xs-5 mt25 p15 mobile-filters-button bg-black brdr-none c-white h5 weight-300" @click="openFilters">
-              Filters ({{ filtersCounter }})
+              Filters
             </button>
           </div>
         </div>
     </header>
     <div class="container pb60">
-        <div class="row m0 pt15 px10 center-md">
+        <div class="row m0 pt15 center-md">
             <div class="col-md-3 start-xs category-filters">
                 <sidebar :filters="filters"/>
             </div>
@@ -24,8 +24,8 @@
                 </div>
                 <sidebar class="mobile-filters-body" :filters="filters"/>
             </div>
-            <p class="col-xs-12 hidden-md m0 c-gray-secondary">{{ productsCounter }} items</p>
-            <div class="col-md-9 pt20 products-list">
+            <p class="col-xs-12 hidden-md m0 px20 c-gray-secondary">{{ productsCounter }} items</p>
+            <div class="col-md-9 pt20 products-list px10">
                 <div v-if="isCategoryEmpty">
                     No products found!
                 </div>
@@ -57,9 +57,6 @@ export default {
   computed: {
     productsCounter () {
       return this.$store.state.product.list.items.length
-    },
-    filtersCounter () {
-      return Object.keys(this.$store.state.category.filters).length
     }
   },
   methods: {
@@ -75,6 +72,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
+    .products-list {
+      box-sizing: border-box;
+    }
 
     .category-filters {
         width: 242px;

--- a/src/themes/default/pages/Category.vue
+++ b/src/themes/default/pages/Category.vue
@@ -7,12 +7,14 @@
         </div>
         <div class="container">
           <div class="row m0">
-            <button class="col-xs-5 mt25 p15 mobile-filters-button bg-black brdr-none c-white h5" @click="openFilters">Filters</button>
+            <button class="col-xs-5 mt25 p15 mobile-filters-button bg-black brdr-none c-white h5 weight-300" @click="openFilters">
+              Filters ({{ filtersCounter }})
+            </button>
           </div>
         </div>
     </header>
     <div class="container pb60">
-        <div class="row m0 pt15 center-md">
+        <div class="row m0 pt15 px10 center-md">
             <div class="col-md-3 start-xs category-filters">
                 <sidebar :filters="filters"/>
             </div>
@@ -22,6 +24,7 @@
                 </div>
                 <sidebar class="mobile-filters-body" :filters="filters"/>
             </div>
+            <p class="col-xs-12 hidden-md m0 c-gray-secondary">{{ productsCounter }} items</p>
             <div class="col-md-9 pt20 products-list">
                 <div v-if="isCategoryEmpty">
                     No products found!
@@ -51,6 +54,14 @@ export default {
       mobileFilters: false
     }
   },
+  computed: {
+    productsCounter () {
+      return this.$store.state.product.list.items.length
+    },
+    filtersCounter () {
+      return Object.keys(this.$store.state.category.filters).length
+    }
+  },
   methods: {
     openFilters () {
       this.mobileFilters = true
@@ -75,6 +86,7 @@ export default {
     }
 
     .mobile-filters-button {
+        font-family: 'Roboto', sans-serif;
         display: none;
     }
 

--- a/src/themes/default/pages/Category.vue
+++ b/src/themes/default/pages/Category.vue
@@ -12,7 +12,7 @@
         </div>
     </header>
     <div class="container pb60">
-        <div class="row pt15 pl20 center-md">
+        <div class="row m0 pt15 center-md">
             <div class="col-md-3 start-xs category-filters">
                 <sidebar :filters="filters"/>
             </div>


### PR DESCRIPTION
I did some things from #485:
* Adjustments in sizes and colors of fonts
* Added gray background to products photos with opacity and mouseover effect
* Moved filters above the top bar
* Added products counter
* Added two columns on product list
  
<img width="391" alt="zrzut ekranu 2018-01-08 o 22 46 55" src="https://user-images.githubusercontent.com/7126345/34697129-03558e2c-f4d2-11e7-8cc6-46d9d7a8858c.png">
