### PR TITLE
fixed header column size at approx sm/tablet device width

### DIFF
--- a/src/themes/default/components/core/blocks/Header/Header.vue
+++ b/src/themes/default/components/core/blocks/Header/Header.vue
@@ -3,7 +3,7 @@
     <header class="brdr-bottom bg-white brdr-c-alto"  :class="{ 'is-visible': navVisible }">
         <div class="container">
             <div class="row between-xs middle-xs px15" v-if="!isCheckout">
-                <div class="col-md-3 col-xs-2 middle-xs">
+                <div class="col-sm-4 col-xs-2 middle-xs">
                     <div>
                         <hamburger-icon class="p15 icon bg-lightgray"/>
                     </div>
@@ -11,7 +11,7 @@
                 <div class="col-xs-2 visible-xs">
                     <search-icon class="p15 icon" />
                 </div>
-                <div class="col-md-6 col-xs-4 center-xs">
+                <div class="col-sm-4 col-xs-4 center-xs">
                     <div>
                         <logo width="36px" height="41px"/>
                     </div>
@@ -19,7 +19,7 @@
                 <div class="col-xs-2 visible-xs">
                     <wishlist-icon class="p15 icon" />
                 </div>
-                <div class="col-md-3 col-xs-2 end-xs">
+                <div class="col-sm-4 col-xs-2 end-xs">
                     <div class="inline-flex">
                         <search-icon class="p15 icon hidden-xs" />
                         <wishlist-icon class="p15 icon hidden-xs" />


### PR DESCRIPTION
Noticed that the right header column became cropped between 800 to 950px approx, updated the column class names to fix it.

### Before
![before](https://user-images.githubusercontent.com/2452991/34818884-13543ef2-f6b4-11e7-9eaf-cb2bc6eb56aa.png)

### After
![after](https://user-images.githubusercontent.com/2452991/34818892-1cb88994-f6b4-11e7-9824-d046e01a59ff.png)
