### PR TITLE
#586 - Add promoted offers section to homepage

### DIFF
--- a/src/resource/promoted_offers.json
+++ b/src/resource/promoted_offers.json
@@ -1,0 +1,22 @@
+{
+  "mainBanner": {
+    "title": "Luma Performance",
+    "subtitle": "Collection",
+    "image": "/assets/slide_02.jpg",
+    "link": "c/women-20"
+  },
+  "smallBanners": [
+    {
+      "title": "Erin Renny",
+      "subtitle": "New",
+      "image": "/assets/ig/ig03.png",
+      "link": "c/men-11"
+    },
+    {
+      "title": "Eco-friendly",
+      "subtitle": "Sales",
+      "image": "/assets/ig/ig05.png",
+      "link": "c/gear-3"
+    }
+  ]
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -93,6 +93,7 @@ import tax from './modules/tax'
 import social from './modules/social-tiles'
 import claims from './modules/claims'
 import sync from './modules/sync'
+import promoted from './modules/promoted-offers'
 
 Vue.use(Vuex)
 
@@ -188,7 +189,8 @@ export default new Vuex.Store({
     checkout,
     tax,
     claims,
-    sync
+    sync,
+    promoted
   },
   state,
   mutations,

--- a/src/store/modules/promoted-offers.js
+++ b/src/store/modules/promoted-offers.js
@@ -1,0 +1,19 @@
+import promotedOffers from '../../resource/promoted_offers.json'
+
+// Initial state
+
+const state = {
+  banners: promotedOffers
+}
+
+const getters = {
+  getPromotedOffers: state => {
+    return state.banners
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters
+}

--- a/src/themes/default/components/theme/blocks/PromotedOffers/PromotedOffers.vue
+++ b/src/themes/default/components/theme/blocks/PromotedOffers/PromotedOffers.vue
@@ -32,17 +32,6 @@
             </div>
           </router-link>
         </div>
-        <!-- <div class="offer-container px15 pt15">
-          <router-link to="c/women-20">
-            <div
-              class="offer offer-small p5 flex center-xs middle-xs c-white"
-              v-lazy:background-image="'/assets/ig/ig05.png'"
-            >
-              <p class="subtitle m0 serif h3 uppercase">Sales</p>
-              <h2 class="title m0 h1">Eco Friendly</h2>
-            </div>
-          </router-link>
-        </div> -->
       </div>
     </div>
   </section>

--- a/src/themes/default/components/theme/blocks/PromotedOffers/PromotedOffers.vue
+++ b/src/themes/default/components/theme/blocks/PromotedOffers/PromotedOffers.vue
@@ -1,0 +1,113 @@
+<template>
+  <section class="offers container my30">
+    <div class="row m0">
+      <div class="offer-container col-xs-12 col-sm-6 px15">
+      <router-link :to="banners.mainBanner.link">
+        <div
+          class="offer p5 flex center-xs middle-xs c-white"
+          v-lazy:background-image="banners.mainBanner.image"
+        >
+          <p class="subtitle m0 serif h3 uppercase">
+            {{ banners.mainBanner.subtitle}}
+          </p>
+          <h2 class="title m0 h1">
+            {{ banners.mainBanner.title }}
+          </h2>
+        </div>
+      </router-link>
+      </div>
+
+      <div class="col-xs-12 col-sm-6 p0">
+        <div
+          class="offer-container px15 pb30"
+          v-for="banner in banners.smallBanners"
+        >
+          <router-link :to="banner.link">
+            <div
+              class="offer offer-small p5 flex center-xs middle-xs c-white"
+              v-lazy:background-image="banner.image"
+            >
+              <p class="subtitle m0 serif h3 uppercase">{{ banner.subtitle }}</p>
+              <h2 class="title m0 h1">{{ banner.title }}</h2>
+            </div>
+          </router-link>
+        </div>
+        <!-- <div class="offer-container px15 pt15">
+          <router-link to="c/women-20">
+            <div
+              class="offer offer-small p5 flex center-xs middle-xs c-white"
+              v-lazy:background-image="'/assets/ig/ig05.png'"
+            >
+              <p class="subtitle m0 serif h3 uppercase">Sales</p>
+              <h2 class="title m0 h1">Eco Friendly</h2>
+            </div>
+          </router-link>
+        </div> -->
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+export default {
+  name: 'promoted-offers',
+  computed: {
+    ...mapGetters({
+      banners: 'promoted/getPromotedOffers'
+    })
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+ .offers {
+    @media (max-width: 767px) {
+      padding: 0 15px;
+    }
+  }
+  .offer-container {
+    &:last-child {
+      padding-bottom: 0;
+    }
+
+    @media (max-width: 767px) {
+      padding: 5px 0;
+    }
+  }
+  .offer {
+    height: 750px;
+    flex-direction: column;
+    box-sizing: border-box;
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+    opacity: 0.9;
+    transition: 0.3s all;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    @media (max-width: 767px) {
+      height: 200px;
+    }
+  }
+  .offer-small {
+    height: 360px;
+
+    @media (max-width: 767px) {
+      height: 200px;
+    }
+  }
+  .title {
+    @media (max-width: 767px) {
+      font-size: 36px;
+    }
+  }
+  .subtitle {
+    @media (max-width: 767px) {
+      font-size: 18px;
+    }
+  }
+</style>

--- a/src/themes/default/css/padding.scss
+++ b/src/themes/default/css/padding.scss
@@ -10,7 +10,7 @@ $padding-px: 0 5 10 12 15 25 45 50;
 $padding-x-px: 10 15 20 25 40 55 65 70;
 $padding-y-px: 5 10 15 20 25 30 35 50;
 $padding-top-px: 0 5 10 15 20 30 35 40 45 50 55 70;
-$padding-bottom-px: 10 15 20 40 45 60 70;
+$padding-bottom-px: 10 15 20 30 40 45 60 70;
 $padding-left-px: 0 20 30 35 40 70;
 $padding-right-px: 0 5 15 20 30 55 70;
 

--- a/src/themes/default/pages/Home.vue
+++ b/src/themes/default/pages/Home.vue
@@ -1,8 +1,10 @@
 <template>
   <div id="home">
   <main-slider />
-  
-  <section class="new-collection container pt40 px15">
+
+  <promoted-offers></promoted-offers>
+
+  <section class="new-collection container px15">
     <div>
       <header class="col-md-12">
         <h2 class="align-center c-black">Everything new</h2>
@@ -36,6 +38,7 @@ import MainSlider from '../components/core/blocks/MainSlider/MainSlider.vue'
 // import ProductTile from '../components/core/ProductTile.vue'
 import ProductListing from '../components/core/ProductListing.vue'
 
+import PromotedOffers from '../components/theme/blocks/PromotedOffers/PromotedOffers.vue'
 import TileLinks from '../components/theme/blocks/TileLinks/TileLinks.vue'
 import Collection from '../components/theme/blocks/Collection/Collection'
 import Onboard from '../components/theme/blocks/Home/Onboard.vue'
@@ -88,6 +91,7 @@ export default {
   components: {
     ProductListing,
     MainSlider,
+    PromotedOffers,
     TileLinks,
     Collection,
     Onboard


### PR DESCRIPTION
The content for banners is pulled from `promoted_offers.json` (similar solution to TileLinks).
For now banners link to categories.

Desktop
![zrzut ekranu 2018-01-26 o 14 25 00](https://user-images.githubusercontent.com/7126345/35441692-c633e74c-02a4-11e8-9ada-181abbd2bdf8.png)

Mobile
![zrzut ekranu 2018-01-26 o 14 26 52](https://user-images.githubusercontent.com/7126345/35441753-ffc20c8c-02a4-11e8-82bb-30ca951ae78d.png)

