### PR TITLE
prevented scrolling to top, when overlay is active

### DIFF
--- a/src/components/core/Overlay.vue
+++ b/src/components/core/Overlay.vue
@@ -10,6 +10,12 @@ export default {
     onClick () {
       this.$store.commit('ui/setOverlay', false)
     }
+  },
+  beforeCreate () {
+    document.documentElement.classList.add('no-scroll')
+  },
+  destroyed () {
+    document.documentElement.classList.remove('no-scroll')
   }
 }
 </script>

--- a/src/components/core/blocks/Auth/SignUp.vue
+++ b/src/components/core/blocks/Auth/SignUp.vue
@@ -18,6 +18,9 @@ export default {
     Register,
     ForgotPass
   },
+  mounted () {
+    this.$store.commit('ui/setSignUp', true)
+  },
   methods: {
     closeSignUp () {
       this.$store.commit('ui/setSignUp', false)

--- a/src/themes/default/App.vue
+++ b/src/themes/default/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" :class="{ 'no-scroll': noScroll }">
+  <div id="app">
     <overlay v-if="overlayActive"/>
     <loader />
     <div id="viewport p55">
@@ -42,7 +42,6 @@ import OfflineBadge from './components/core/OfflineBadge.vue'
 export default {
   computed: {
     ...mapState({
-      noScroll: state => state.ui.overlay,
       newsletterOpen: state => state.ui.newsletterPopup,
       signUpOpen: state => state.ui.signUp,
       overlayActive: state => state.ui.overlay
@@ -87,7 +86,6 @@ export default {
 <style>
   html,
   body {
-    height: 100%;
     margin: 0;
     padding: 0;
   }
@@ -123,14 +121,13 @@ export default {
     overflow-x: hidden;
   }
 
-  #app.no-scroll {
-    height: 100%;
-    overflow: hidden;
-  }
-
   #viewport {
     width: 100%;
     position: relative;
     overflow-x: hidden;
+  }
+
+  .no-scroll {
+    overflow: hidden;
   }
 </style>

--- a/src/themes/default/components/core/blocks/Auth/SignUp.vue
+++ b/src/themes/default/components/core/blocks/Auth/SignUp.vue
@@ -30,7 +30,7 @@ export default {
 </script>
 <style lang="scss" scoped>
   .sign-up {
-    position: absolute;
+    position: fixed;
     width: 555px;
     min-height: 555px;
     background-color: white;
@@ -39,12 +39,14 @@ export default {
     transform: translateX(-50%);
     z-index: 3;
     font-size: 18px;
+    overflow: auto;
 
-    @media (max-width: 600px) {
+    @media (max-width: 600px), (orientation: landscape) and (max-width: 820px) {
       top: 0;
       margin: 0;
       width: 100%;
       height: 100%;
+      min-height: unset;
     }
   }
   .close {


### PR DESCRIPTION
It's not enough to set `overflow: hidden;` on `<div id ="app">` - we must set it on body or html to prevent scrolling.