### PR TITLE
Add hover and focus styles to filter buttons

### DIFF
--- a/src/themes/default/components/core/ColorButton.vue
+++ b/src/themes/default/components/core/ColorButton.vue
@@ -1,6 +1,6 @@
 <template>
     <button
-      class="bg-transparent brdr-1 brdr-circle brdr-c-transparent relative color"
+      class="mr10 mb5 bg-transparent brdr-1 brdr-circle brdr-c-transparent relative color"
       @click="switchFilter(id, label)"
       :class="{ active: active }"
       :aria-label="'Select color ' + label"

--- a/src/themes/default/components/core/ColorButton.vue
+++ b/src/themes/default/components/core/ColorButton.vue
@@ -1,7 +1,15 @@
 <template>
-    <div class="bg-transparent brdr-1 brdr-circle color" :class="{ active: active }">
-        <div class="brdr-circle brdr-1" :style="colorFrom(label)" @click="switchFilter(id, label)"></div>
-    </div>
+    <button
+      class="bg-transparent brdr-1 brdr-circle brdr-c-transparent relative color"
+      @click="switchFilter(id, label)"
+      :class="{ active: active }"
+      :aria-label="'Select color ' + label"
+    >
+        <div
+          class="brdr-circle brdr-1 brdr-c-alto absolute color-inside"
+          :style="colorFrom(label)"
+        ></div>
+    </button>
 </template>
 
 <script>
@@ -48,30 +56,33 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+  @import '~theme/css/global_vars';
+  $lightgray-secondary: map-get($colors, lightgray-secondary);
+  $emperor: map-get($colors, emperor);
 
-    .color {
-        width: 40px;
-        height: 40px;
-        border-color: rgba(113,113,113,0);
-        position: relative;
-        display: inline-flex;
-        cursor: pointer;
+  .color {
+    width: 40px;
+    height: 40px;
+    display: inline-flex;
+    cursor: pointer;
+
+    &:hover,
+    &:focus {
+      border-color: $lightgray-secondary;
     }
 
-    .color.active {
-        border-color: #4f4f4f;
+    &.active {
+      border-color: $emperor;
     }
+  }
 
-    .color > div {
-        width: 34px;
-        height: 34px;
-        display: block;
-        position: absolute;
-        border-color: #E0E0E0;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%,-50%)
-    }
-
+  .color-inside {
+    width: 34px;
+    height: 34px;
+    display: block;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%,-50%)
+  }
 </style>

--- a/src/themes/default/components/core/PriceButton.vue
+++ b/src/themes/default/components/core/PriceButton.vue
@@ -1,8 +1,12 @@
 <template>
     <span @click="switchFilter(id, from, to)">
-        <button class="brdr-c-gray brdr-1 bg-transparent mr10" :class="{ active: active }">
-            <div class="bg-transparent"></div>
-        </button> 
+        <button
+          class="relative brdr-c-gray brdr-1 bg-transparent mr10 price-button"
+          :class="{ active: active }"
+          :aria-label="'Price ' + content"
+        >
+          <div class="bg-transparent absolute square"></div>
+        </button>
         <span>{{ content }}</span>
     </span>
 </template>
@@ -42,27 +46,36 @@ export default { // TODO: move logic to parent component
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+  @import '~theme/css/global_vars';
+  $lightgray-secondary: map-get($colors, lightgray-secondary);
+  $darkgray: map-get($colors, darkgray);
 
-    button {
-        width: 20px;
-        height: 20px;
-        position: relative;
-        cursor: pointer;
+  .price-button {
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+
+    &:hover,
+    &:focus {
+      .square {
+        background-color: $lightgray-secondary;
+      }
     }
 
-    button > div {
-        width: 80%;
-        height: 80%;
-        display: block;
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%,-50%);
+    &.active {
+      .square {
+        background-color: $darkgray;
+      }
     }
+  }
 
-    button.active > div {
-        background-color: black;
-    }
-
+  .square {
+    width: 80%;
+    height: 80%;
+    display: block;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%,-50%);
+  }
 </style>

--- a/src/themes/default/components/core/SizeButton.vue
+++ b/src/themes/default/components/core/SizeButton.vue
@@ -1,7 +1,15 @@
 <template>
-    <button class="p0 bg-white c-gray brdr-1 brdr-gray" :class="{ active: active }" @click="switchFilter(id, label)">
-        {{ label }}
-    </button>
+  <button
+    class="
+      p0 bg-white brdr-1 brdr-c-lightgray-secondary
+      brdr-square h5 c-lightgray-secondary size-button
+    "
+    :class="{ active: active }"
+    @click="switchFilter(id, label)"
+    :aria-label="'Select size ' + label"
+  >
+    {{ label }}
+  </button>
 </template>
 
 <script>
@@ -39,26 +47,35 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+  @import '~theme/css/global_vars';
+  $gray-secondary: map-get($colors, gray-secondary);
+  $alto: map-get($colors, alto);
 
-    button {
-      width: 40px;
-      height: 40px;
-      cursor: pointer;
-      border-radius: 0;
-      border-color: #BDBDBD;
-      font-size: 14px;
-      color: #BDBDBD;
-    }
-    button.active {
-      border-color: #828282;
+  .size-button {
+    width: 40px;
+    height: 40px;
+
+    &:hover,
+    &:focus {
       border-width: 2px;
-      color: #828282;
-    }
-    button:disabled {
-      border-color: #E0E0E0;
-      color: #E0E0E0;
-      cursor: not-allowed;
     }
 
+    &.active {
+      border-color: $gray-secondary;
+      border-width: 2px;
+      color: $gray-secondary;
+    }
+
+    &:disabled {
+      border-color: $alto;
+      color: $alto;
+      cursor: not-allowed;
+
+      &:hover,
+      &:after {
+        border-width: 1px;
+      }
+    }
+  }
 </style>

--- a/src/themes/default/components/core/blocks/Category/Sidebar.vue
+++ b/src/themes/default/components/core/blocks/Category/Sidebar.vue
@@ -1,9 +1,9 @@
-<template> 
+<template>
     <div class="sidebar">
         <h4>Filter</h4>
         <div v-if="filters.color.length">
-            <h5>Color</h5> 
-            <color-button context="category" :attribute_code="color" code="color" class="color-select mr10" v-for="(color, index) in filters.color" :key="index" :id="color.id" :label="color.label" />
+            <h5>Color</h5>
+            <color-button context="category" :attribute_code="color" code="color" v-for="(color, index) in filters.color" :key="index" :id="color.id" :label="color.label" />
         </div>
         <div v-if="filters.size.length">
             <h5>Size</h5>

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -59,7 +59,6 @@
                       :label="c.label"
                       context="product"
                       code="color"
-                      class="mr10"
                       :class="{ active: c.id == configuration.color.id }"
                     />
                   </div>


### PR DESCRIPTION
- Added hover, focus and aria-label to filter buttons for support keyboard navigation and accessibility
- Some code refactoring
![zrzut ekranu 2018-01-29 o 12 55 22](https://user-images.githubusercontent.com/7126345/35509251-c616ca58-04f3-11e8-9eda-f75e21d095d6.png)
![zrzut ekranu 2018-01-29 o 12 55 12](https://user-images.githubusercontent.com/7126345/35509250-c5aa8802-04f3-11e8-8d8e-6529b35a0f8d.png)
![zrzut ekranu 2018-01-29 o 12 55 33](https://user-images.githubusercontent.com/7126345/35509253-c66caff4-04f3-11e8-9fb4-a752b53568d7.png)
