### PR TITLE
Fix i18n import in catalog theme (newsletter component)

### DIFF
--- a/src/themes/catalog/components/theme/NewsletterSubscribeForm.vue
+++ b/src/themes/catalog/components/theme/NewsletterSubscribeForm.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-import i18n from './lib/i18n'
+import i18n from 'lib/i18n'
 
 export default {
   data () {


### PR DESCRIPTION
When catalog theme is set, webpack commands crashes with output:
`Module not found: Error: Can't resolve './lib/i18n' `
This change fix this problem