### PR TITLE
Add 'sale' and 'new' labels, one product box on mobile

### DIFF
--- a/src/themes/default/components/core/ProductListing.vue
+++ b/src/themes/default/components/core/ProductListing.vue
@@ -1,6 +1,11 @@
 <template>
-  <div class="product-listing row m0 start-xs">
-    <div v-for="(product, key) in products" :key="product.id" class="col-xs-6 pb10" :class="'col-md-' + (12/columns)%10">
+  <div class="product-listing row m0 center-xs start-md">
+    <div
+      v-for="(product, key) in products"
+      :key="product.id"
+      class="pb10 col-sm-6"
+      :class="['col-md-' + (12/columns)%10, wide(product.sale)]"
+    >
       <product-tile :product="product" :instant="key < 6 ? true : false" />
     </div>
   </div>
@@ -24,6 +29,11 @@ export default {
   components: {
     ProductTile
   },
-  mixins: [coreComponent('core/ProductListing')]
+  mixins: [coreComponent('core/ProductListing')],
+  methods: {
+    wide (isOnSale) {
+      return isOnSale === '1' ? 'col-xs-12' : 'col-xs-6'
+    }
+  }
 }
 </script>

--- a/src/themes/default/components/core/ProductTile.vue
+++ b/src/themes/default/components/core/ProductTile.vue
@@ -13,8 +13,8 @@
         }"
       >
         <div
-          class="product-image bg-lightgray"
-          :class="[{ sale: isOnSale }, { new: isNew }]"
+          class="product-image relative bg-lightgray"
+          :class="[{ sale: labelsActive && isOnSale }, { new: labelsActive && isNew }]"
         >
           <transition name="fade" appear>
             <img class="mw-100" v-if="instant" :src="thumbnail" :key="thumbnail" v-img-placeholder="placeholder">
@@ -52,6 +52,11 @@ export default {
       type: Boolean,
       required: false,
       default: () => false
+    },
+    labelsActive: {
+      type: Boolean,
+      requred: false,
+      default: true
     }
   },
   mixins: [coreComponent('core/ProductTile')],

--- a/src/themes/default/components/core/ProductTile.vue
+++ b/src/themes/default/components/core/ProductTile.vue
@@ -12,7 +12,10 @@
           }
         }"
       >
-        <div class="product-image bg-lightgray">
+        <div
+          class="product-image bg-lightgray"
+          :class="[{ sale: isOnSale }, { new: isNew }]"
+        >
           <transition name="fade" appear>
             <img class="mw-100" v-if="instant" :src="thumbnail" :key="thumbnail" v-img-placeholder="placeholder">
             <img class="mw-100" v-if="!instant" v-lazy="thumbnailObj" :key="thumbnail">
@@ -82,6 +85,12 @@ export default {
         src: this.thumbnail,
         loading: this.placeholder
       }
+    },
+    isOnSale () {
+      return this.product.sale === '1' ? 'sale' : ''
+    },
+    isNew () {
+      return this.product.new === '1' ? 'new' : ''
     }
   },
   methods: {
@@ -99,15 +108,36 @@ export default {
 @import '~src/themes/default/css/transitions';
 @import '~theme/css/global_vars';
 $lightgray: map-get($colors, lightgray);
+$alto: map-get($colors, alto);
+$white: map-get($colors, white);
 
 .product {
   @media (max-width: 700px) {
     padding: 0;
   }
 }
+
 .price-original {
   text-decoration: line-through;
 }
+
+%label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+  background-color: $alto;
+  transition: 0.3s all $motion-main;
+  text-transform: uppercase;
+  color: $white;
+  font-size: 12px;
+  font-weight: 400;
+}
+
 .product-image {
   width: 100%;
   mix-blend-mode: multiply;
@@ -121,6 +151,11 @@ $lightgray: map-get($colors, lightgray);
       transform: scale(1.1);
       opacity: 1;
     }
+
+    &.sale::after,
+    &.new::after {
+      opacity: 0.8;
+    }
   }
 
   > img {
@@ -130,6 +165,20 @@ $lightgray: map-get($colors, lightgray);
     opacity: 0.8;
     transition: 0.3s all $motion-main;
     mix-blend-mode: multiply;
+  }
+
+  &.sale {
+    &::after {
+      @extend %label;
+      content: 'Sale';
+    }
+  }
+
+  &.new {
+    &::after {
+      @extend %label;
+      content: 'New';
+    }
   }
 }
 </style>

--- a/src/themes/default/components/core/ProductsSlider.vue
+++ b/src/themes/default/components/core/ProductsSlider.vue
@@ -23,6 +23,7 @@
                     class="collection-product"
                     :product="product"
                     :class="{'is-muted': (currentPage == index || index == currentPage + 5)}"
+                    :labels-active="false"
                   />
                 </slide>
               </carousel>


### PR DESCRIPTION
#587 
There is one additional prop in `ProductTile` called `labelsActive` to disable labels if needed (e.g. in homepage slider).
Products on sale are wider on mobile, as in design.

Few screenshots:
Homepage:

![homepage](https://user-images.githubusercontent.com/7126345/36094542-f6b9a8be-0fee-11e8-871a-f8885ced5c6d.png)

Category - mobile:

![category](https://user-images.githubusercontent.com/7126345/36094541-f6a2cbbc-0fee-11e8-8329-996fd7f77a3d.png)

Product:
![product](https://user-images.githubusercontent.com/7126345/36094543-f6d1e1cc-0fee-11e8-9183-2d55c3d46078.png)
