### PR TITLE
Fix wishlist content padding on mobile

### DIFF
--- a/src/themes/catalog/components/core/blocks/Wishlist/Wishlist.vue
+++ b/src/themes/catalog/components/core/blocks/Wishlist/Wishlist.vue
@@ -5,7 +5,7 @@
         <i class="material-icons p15 pointer" @click="closeWishlist">close</i>
       </div>
     </div>
-    <div class="row" v-if="!items.length">
+    <div class="row pr50-md pl20 pr20 pl0-md" v-if="!items.length">
       <div class="col-md-12">
         <h4>Your wishlist is empty.</h4>
         <div>


### PR DESCRIPTION
Fix wishlist content padding on mobile view when list is empty

View without proper row padding
![image](https://user-images.githubusercontent.com/11904934/36283325-7673111e-12a4-11e8-9224-9f30ee27983d.png)

After adding same classes to row as list with items have
![image](https://user-images.githubusercontent.com/11904934/36283388-ae37ecaa-12a4-11e8-9a8b-b5550e62bbae.png)
