### PR TITLE
Improve header items layout

### DIFF
--- a/src/themes/catalog/components/core/blocks/Header/Header.vue
+++ b/src/themes/catalog/components/core/blocks/Header/Header.vue
@@ -6,8 +6,8 @@
     </div>
 
     <nav class="menu container">
-      <div class="row middle-xs full-size">
-        <div class="col-xs-6 col-md-3 center-xs start-md middle-xs inline-flex">
+      <div class="row middle-xs between-md pl10 full-size">
+        <div class="col-xs-6 col-md-3 start-xl center-md middle-xs inline-flex">
           <router-link to="/"><logo class="logo inline-flex pr25"/></router-link>
           <i @click="focusSearchBox" class="material-icons b-left-md middle-xs px25 full-size inline-flex">search</i>
         </div>


### PR DESCRIPTION
Improve header items layout for tablet and mobile view. Menu can fit on 320px screen.

Tablet view before and after
![image](https://user-images.githubusercontent.com/11904934/36285859-8d59815c-12ad-11e8-9639-f5f2e62e12a3.png)
![image](https://user-images.githubusercontent.com/11904934/36285886-a033dade-12ad-11e8-9fb8-771f4bce469c.png)

Mobile view 320px before and after
![image](https://user-images.githubusercontent.com/11904934/36285909-b9ac07b6-12ad-11e8-954f-2043da048f06.png)
![image](https://user-images.githubusercontent.com/11904934/36285925-c6a75042-12ad-11e8-90c5-99e216d98096.png)

