### PR TITLE
Issue: 662. [theme-starter] Change text in Home.vue to one that supports vue-i18n

### DIFF
--- a/src/themes/theme-starter/pages/Home.vue
+++ b/src/themes/theme-starter/pages/Home.vue
@@ -1,14 +1,14 @@
 <template>
   <div id="home">
-    <img src="assets/logo.svg" alt="Vue Storefront Logo">
-    <h1>Welcome to Vue Storefront theme starter!</h1>
-    <p>In case of any problems please take a look at the docs. If you havn't find what you were looking for in docs feel free to ask your question on our Slack</p>
-    <P>Here are some links that can help you with developing your own theme:</p>
+    <img src="assets/logo.svg" :alt="$t('Vue Storefront Logo')">
+    <h1>{{ $t('welcomeMessage') }}</h1>
+    <p>{{ $t("In case of any problems please take a look at the docs. If you havn't find what you were looking for in docs feel free to ask your question on our Slack") }}</p>
+    <P>{{ $t('Here are some links that can help you with developing your own theme') }}:</p>
     <p>
-      <a href="https://github.com/DivanteLtd/vue-storefront/blob/master/doc/Project%20structure.md">Project structure</a> |
-      <a href="https://github.com/DivanteLtd/vue-storefront/blob/master/doc/themes/Working%20with%20themes.md">Working with themes</a> |
-      <a href="https://github.com/DivanteLtd/vue-storefront/blob/master/doc/components/Working%20with%20components.md">Working with components</a> |
-      <a href="https://github.com/DivanteLtd/vue-storefront/blob/master/doc/Working%20with%20data.md">Working with data</a>
+      <a href="https://github.com/DivanteLtd/vue-storefront/blob/master/doc/Project%20structure.md">{{ $t('Project structure') }}</a> |
+      <a href="https://github.com/DivanteLtd/vue-storefront/blob/master/doc/themes/Working%20with%20themes.md">{{ $t('Working with themes') }}</a> |
+      <a href="https://github.com/DivanteLtd/vue-storefront/blob/master/doc/components/Working%20with%20components.md">{{ $t('Working with components') }}</a> |
+      <a href="https://github.com/DivanteLtd/vue-storefront/blob/master/doc/Working%20with%20data.md">{{ $t('Working with data') }}</a>
     </p>
   </div>
 </template>

--- a/src/themes/theme-starter/resource/i18n.json
+++ b/src/themes/theme-starter/resource/i18n.json
@@ -1,5 +1,12 @@
 {
   "en-US": {
-      "customMessage": "You can define or override translation messages here."
-    }
-}  
+    "welcomeMessage": "Welcome to Vue Storefront theme starter!",
+    "In case of any problems please take a look at the docs. If you havn't find what you were looking for in docs feel free to ask your question on our Slack": "In case of any problems please take a look at the docs. If you havn't find what you were looking for in docs feel free to ask your question on our Slack",    
+    "Here are some links that can help you with developing your own theme": "Here are some links that can help you with developing your own theme",
+	"Project structure": "Project structure",
+	"Working with themes": "Working with themes",
+	"Working with components": "Working with components",
+	"Working with data": "Working with data",
+	"Vue Storefront Logo": "Vue Storefront Logo"
+  }
+}


### PR DESCRIPTION
After merge, we can close [#662](https://github.com/DivanteLtd/vue-storefront/issues/662)