### PR TITLE
[WIP] Droppoint shipping extension

### DIFF
--- a/core/components/blocks/Checkout/Shipping.vue
+++ b/core/components/blocks/Checkout/Shipping.vue
@@ -24,7 +24,7 @@ export default {
         this.$store.dispatch('checkout/updatePropValue', ['lastName', receivedData.lastName])
       }
     })
-    this.$bus.$on('checkout.setShipping', (receivedData) => {
+    this.$bus.$on('checkout-after-shippingset', (receivedData) => {
       this.shipping = receivedData
       this.isFilled = true
     })

--- a/core/components/blocks/Checkout/Shipping.vue
+++ b/core/components/blocks/Checkout/Shipping.vue
@@ -24,6 +24,10 @@ export default {
         this.$store.dispatch('checkout/updatePropValue', ['lastName', receivedData.lastName])
       }
     })
+    this.$bus.$on('checkout.setShipping', (receivedData) => {
+      this.shipping = receivedData
+      this.isFilled = true
+    })
   },
   data () {
     return {

--- a/core/pages/Checkout.vue
+++ b/core/pages/Checkout.vue
@@ -231,7 +231,8 @@ export default {
           },
           shipping_method_code: this.shipping.shippingMethod,
           shipping_carrier_code: this.shipping.shippingMethod,
-          payment_method_code: this.payment.paymentMethod
+          payment_method_code: this.payment.paymentMethod,
+          shippingExtraFields: this.shipping.extraFields
         }
       }
       return this.order

--- a/doc/extensions/droppoint-shipping.md
+++ b/doc/extensions/droppoint-shipping.md
@@ -1,0 +1,94 @@
+# Droppoint shipping 
+ [droppoint-shipping]
+ 
+ Allows the customer to select a shipping droppoint instead of specifying delivery address. When a droppoint is selected, the address for the droppoint will used as shipping address. Extra fields can be added, in order to get the name of the person picking up the delivery for example.
+ 
+ Add the extension to enabled extensions in local.json. And add a shipping method with the property "droppoint" set to true in shipping methods.
+ 
+ resource/shipping_methods.json:
+ ```json
+  {
+    "name": "GLS Pakkeshop",
+    "code": "glsparcelshop",
+    "cost": 10,
+    "costInclTax": 10,
+    "default": false,
+    "offline": true,
+    "droppoint": true
+  }
+```
+
+Reference shipping method code in local config, when specifying the endpoint.
+
+config/local.json:
+```json
+  "droppointShipping": {
+    "glsparcelshop": {
+      "endpoint": "http://localhost:8090/api/ext/gls-parcelshop"
+    }
+```
+
+In the themes Shipping.vue component, hide the regular shipping form, when a shipping method has "droppoint" set to true.
+
+```html
+
+            <h4>Shipping method</h4>
+          </div>
+          <div v-for="(method, index) in shippingMethods" :key="index" class="col-md-6 mb15">
+            <label class="radioStyled"> {{ method.name }} | {{ method.cost | price }}
+              <input
+                type="radio"
+                :value="method.code"
+                name="shipping-method"
+                v-model="shipping.shippingMethod"
+                @change="$v.shipping.shippingMethod.$touch(); shipping.droppoint = method.droppoint; shipping.endpoint = method.endpoint"
+              >
+              <span class="checkmark"/>
+            </label>
+          </div>
+     <div v-if="shipping.droppoint">  <!-- Added "droppoint" property in resource/shipping_methods.json -->
+            <droppoint-map :shipping-method="shipping.shippingMethod" :endpoint="shipping.endpoint" />
+          </div>
+          <div v-else>
+            <div class="col-xs-12 col-sm-6 mb25">
+              <input
+...
+
+<script>
+import { coreComponent } from 'lib/themes'
+import ButtonFull from 'theme/components/theme/ButtonFull.vue'
+import Tooltip from 'theme/components/core/Tooltip.vue'
+import { required, minLength } from 'vuelidate/lib/validators'
+import DroppointMap from 'src/extensions/droppoint-shipping/components/DroppointMap.vue'
+
+```
+The endpoint must return json in the following structure:
+
+```javascript
+{
+  extraFields: {
+    pickup_name: {
+      title: "Name of person who will pick up the package",
+    }
+  },
+  droppoints: [
+    {
+      id: droppoint.Number,
+      name: droppoint.CompanyName,
+      streetname: droppoint.Streetname,
+      streetname2: droppoint.Streetname2,
+      zipcode: droppoint.ZipCode,
+      country: droppoint.CountryCodeISO3166A2,
+      city: droppoint.CityName,
+      icon: {url: 'assets/gls.png'},
+      position: {
+        lat: parseFloat(droppoint.Latitude),
+        lng: parseFloat(droppoint.Longitude)
+      }
+    }
+  ]
+}
+```
+
+Extra fields are passed along to the API where they can be transformed into an attribute the backend system can understand.
+For Magento2 for example this would be extensionAttributes.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "vue-no-ssr": "^0.2.0",
     "vue-router": "^3.0.1",
     "vue-server-renderer": "^2.5.2",
+    "vue2-google-maps": "^0.8.4",
+    "vue2-slugify": "0.0.1",
     "vuelidate": "^0.6.1",
     "vuex": "^3.0.0",
     "vuex-router-sync": "^5.0.0"

--- a/src/extensions/droppoint-shipping/components/DroppointMap.vue
+++ b/src/extensions/droppoint-shipping/components/DroppointMap.vue
@@ -1,0 +1,182 @@
+<template>
+  <div class="droppoint-map">
+    <input type="text" v-model="searchZipcode" :placeholder="$t('Zipcode')">
+    <button @click="getDroppoints">{{ $t('Update') }}</button>
+
+    <span v-if="loading">loading</span>
+    <gmap-map class="map-container" :center="center" :zoom="12" :options="{streetViewControl:false, fullscreenControl: false}">
+      <gmap-marker
+        :key="index"
+        v-for="(m, index) in droppoints"
+        :position="m.position"
+        :animation="selected.id === m.id? 1:0"
+        :clickable="true"
+        @click="selectDroppoint(m)" />
+    </gmap-map>
+
+    <input type="text" v-model="shipping.phoneNumber" :placeholder="$t('Phone Number')"
+           @change="$v.shipping.phoneNumber.$touch(); setShipping"
+    >
+    <span
+      class="validation-error"
+      v-if="$v.shipping.phoneNumber.$error && !$v.shipping.phoneNumber.required"
+    >
+      Field is required
+    </span>
+
+    <span :key="index" v-for="(field, index) in extraFields">
+      {{ field.title }}
+      <input type="text" v-model="shipping.extraFields[index]" @change="setShipping">
+    </span>
+
+    <span :key="index" v-for="(m, index) in droppoints" @click="selectDroppoint(m)" >
+      <label class="radioStyled">
+        <p>{{ m.name }}</p>
+        <p>{{ m.streetname }}</p>
+        <p>{{ m.zipcode }} {{ m.city }}</p>
+        <input type="radio" v-model="selected" :value="m" >
+        <span class="checkmark"/>
+      </label>
+    </span>
+  </div>
+</template>
+
+<script>
+import Vue from 'vue'
+import { required, minLength } from 'vuelidate/lib/validators'
+
+// GoogleMaps cannot be included while in SSR
+if (process.browser) {
+  const VueGoogleMaps = require('vue2-google-maps')
+  Vue.use(VueGoogleMaps, {
+    load: {
+      key: 'AIzaSyBQwWyTufRQqwJajpxqcCPfdgH27qKWNzc',
+      libraries: 'places'
+    }
+  })
+}
+
+export default {
+  name: 'DroppointMap',
+  data () {
+    return {
+      center: {lat: 55.488351, lng: 9.479296},
+      droppoints: [],
+      error: '',
+      extraFields: {},
+      loading: false,
+      phoneNumber: null,
+      searchZipcode: null,
+      selected: {id: null},
+      shipping: this.$store.state.checkout.shippingDetails
+    }
+  },
+  props: {
+    'shipping-method': {
+      type: String,
+      required: true
+    },
+    zipcode: {
+      type: Number,
+      default: null,
+      required: false
+    }
+  },
+  validations: {
+    shipping: {
+      phoneNumber: {
+        required,
+        minLength: minLength(7)
+      }
+    }
+  },
+  methods: {
+    selectDroppoint (m) {
+      let phoneNumber = this.shipping.phoneNumber
+      let extraFields = this.shipping.extraFields
+      this.selected = m
+
+      let nameArr = m.name.split(' ')
+      let first = nameArr.shift()
+      let last = nameArr.join(' ')
+
+      if (last.length === 0) {
+        last = ' - ' + first
+      }
+
+      this.shipping = {
+        firstName: first,
+        lastName: last,
+        streetAddress: m.streetname,
+        apartmentNumber: m.streetname2,
+        zipCode: m.zipcode,
+        city: m.city,
+        droppoint: m,
+        country: m.country,
+        phoneNumber: phoneNumber,
+        shippingMethod: this.shippingMethod,
+        extraFields: extraFields
+      }
+
+      this.shipping.extraFields.droppoint = JSON.stringify(m)
+
+      this.$v.$touch()
+      this.setShipping()
+    },
+    setShipping () {
+      this.$bus.$emit('checkout.setShipping', this.shipping)
+    },
+    setDroppoints (droppoints = []) {
+      this.droppoints = droppoints
+      this.center = droppoints[0].position
+    },
+    getDroppoints () {
+      this.loading = true
+
+      if (this.searchZipcode) {
+        this.$store.dispatch('droppoint-shipping/fetch', {
+          url: this.$config.glsparcelshop.endpoint + '/zipcode/' + this.searchZipcode,
+          payload: {
+            method: 'GET',
+            headers: {'Content-Type': 'application/json'},
+            mode: 'cors'
+          },
+          callback_event: 'droppoint-map-update'
+        }, {root: true}).then(task => {
+        })
+      }
+    }
+  },
+  mounted () {
+    if (this.shipping) {
+      this.searchZipcode = this.shipping.zipCode
+      this.getDroppoints()
+
+      if (
+        (typeof this.shipping.droppoint === 'object') &&
+        (this.shipping.droppoint.id !== null)
+      ) {
+        this.selectDroppoint(this.shipping.droppoint)
+      } else {
+        this.shipping.streetAddress = ''
+      }
+    }
+    this.$bus.$on('droppoint-map-update', (event) => {
+      this.loading = false
+      if (event.result.droppoints) {
+        this.setDroppoints(event.result.droppoints)
+        this.extraFields = event.result.extraFields
+      } else {
+        this.error = event.result.error
+      }
+    })
+  }
+}
+</script>
+
+<style>
+  .map-container {
+    width: 600px;
+    height: 400px;
+  }
+</style>

--- a/src/extensions/droppoint-shipping/index.js
+++ b/src/extensions/droppoint-shipping/index.js
@@ -1,0 +1,12 @@
+import extensionStore from './store'
+import extensionRoutes from './router'
+
+const EXTENSION_KEY = 'droppoint-shipping'
+
+export default function (app, router, store, config) {
+  console.log('Droppoint shipping extension registered')
+  router.addRoutes(extensionRoutes) // add custom routes
+  store.registerModule(EXTENSION_KEY, extensionStore) // add custom store
+
+  return {EXTENSION_KEY, extensionRoutes, extensionStore}
+}

--- a/src/extensions/droppoint-shipping/router.js
+++ b/src/extensions/droppoint-shipping/router.js
@@ -1,0 +1,2 @@
+export default [
+]

--- a/src/extensions/droppoint-shipping/store.js
+++ b/src/extensions/droppoint-shipping/store.js
@@ -1,0 +1,28 @@
+import { execute as taskExecute } from 'src/api/task'
+import * as entities from 'lib/entities'
+
+const state = {
+}
+
+const getters = {
+}
+
+// actions
+const actions = {
+  fetch ({ commit }, request) {
+    const taskId = entities.uniqueEntityId(request)
+    request.task_id = taskId.toString()
+    return taskExecute(request)
+  }
+}
+
+const mutations = {
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+}


### PR DESCRIPTION
So first iteration of a droppoint shipping extension.

I'm unsure as to how this should be implemented in each usecase. The extension has a component that is include-able in the shipping component. Like so:

Shipping.vue:
```html
            <h4>Shipping method</h4>
          </div>
          <div v-for="(method, index) in shippingMethods" :key="index" class="col-md-6 mb15">
            <label class="radioStyled"> {{ method.name }} | {{ method.cost | price }}
              <input
                type="radio"
                :value="method.code"
                name="shipping-method"
                v-model="shipping.shippingMethod"
                @change="$v.shipping.shippingMethod.$touch(); shipping.droppoint = method.droppoint; shipping.endpoint = method.endpoint"
              >
              <span class="checkmark"/>
            </label>
          </div>
     <div v-if="shipping.droppoint">  <!-- Added "droppoint" property in resource/shipping_methods.json -->
            <droppoint-map :shipping-method="shipping.shippingMethod" :endpoint="shipping.endpoint" />
          </div>
          <div v-else>
            <div class="col-xs-12 col-sm-6 mb25">
              <input
...

<script>
import { coreComponent } from 'lib/themes'
import ButtonFull from 'theme/components/theme/ButtonFull.vue'
import Tooltip from 'theme/components/core/Tooltip.vue'
import { required, minLength } from 'vuelidate/lib/validators'
import DroppointMap from 'src/extensions/droppoint-shipping/components/DroppointMap.vue'


```

Missing, just from the top of my head, the list is not extensive:
- [ ] Currently the droppoint api endpoint is not properly configurable 
- [ ] Set marker icons in api

Idea is that an extension responsible for returning droppoint data is implementet in the vue-storefront-api, at the moment is is possible to search for a postalcode in which the droppoint is located.
Extra fields necessary for individual shipping methods can be defined here. A droppoint can require the name of the person who is coming to pickup the package or something like that.
```javascript
extraFields = {
            pickup_name: {
                title: "Name of person who will pick up the package",
                required: true
            }
        }
```

Currently these fields are sent to the api (i made some small changes here) and in the api (o2m) sent as extensionAttributes to the M2 endpoint.

I will comment the diff with the changes i made in core, in order to pull this off.

I will make a pull-request for the changes to vue-storefront-api, shortly.