### PR TITLE
Improved templates for ButtonFull and ButtonOutline

### DIFF
--- a/src/themes/default/components/core/AddToCart.vue
+++ b/src/themes/default/components/core/AddToCart.vue
@@ -1,21 +1,17 @@
 <template>
-  <!-- Add to cart button example with addToCart action from cart store -->
-  <button
-    type="button"
-    class="ripple"
-    @click="addToCart(product)"
-    v-focus-clean="{ class: 'no-outline' }"
-  >
+  <button-full @click.native="addToCart(product)">
     {{ $t('Add to cart') }}
-  </button>
+  </button-full>
 </template>
 
 <script>
 import { coreComponent } from 'lib/themes'
 import focusClean from 'theme/components/theme/directives/focusClean'
+import ButtonFull from 'theme/components/theme/ButtonFull.vue'
 
 export default {
   mixins: [coreComponent('core/AddToCart')],
-  directives: { focusClean }
+  directives: { focusClean },
+  components: { ButtonFull }
 }
 </script>

--- a/src/themes/default/components/core/NewsletterPopup.vue
+++ b/src/themes/default/components/core/NewsletterPopup.vue
@@ -23,10 +23,11 @@
         </div>
         <div class="mb35 center-xs">
           <button-full
-            class="block p0 ripple"
-            :text="$t('Subscribe')"
-            @click.native="$v.email.$touch(); subscribe()"
-          />
+            type="submit"
+            @click.native="$v.email.$touch"
+          >
+            {{ $t('Subscribe') }}
+          </button-full>
         </div>
       </form>
     </div>

--- a/src/themes/default/components/core/blocks/Auth/ForgotPass.vue
+++ b/src/themes/default/components/core/blocks/Auth/ForgotPass.vue
@@ -24,7 +24,9 @@
             <p class="m0 c-red h6" v-if="!$v.email.email">Please provide valid e-mail address.</p>
           </div>
           <div class="mb35">
-            <button-full class="btn-full p0 center-xs" :text="$t('Reset password')" @click.native="sendEmail"/>
+            <button-full type="submit">
+              {{ $t('Reset password') }}
+            </button-full>
           </div>
           <div class="center-xs">
             <span>
@@ -44,7 +46,9 @@
             </p>
           </div>
           <div class="mb35">
-            <button-full class="btn-full p0 center-xs" :text="$t('Back to login')" @click.native="switchElem"/>
+            <button-full type="submit">
+              {{ $t('Back to login') }}
+            </button-full>
           </div>
         </form>
       </template>
@@ -133,9 +137,5 @@ export default {
     outline: none;
     border-color: $black;
     transition: 0.3s all;
-  }
-
-  .btn-full {
-    display: block;
   }
 </style>

--- a/src/themes/default/components/core/blocks/Auth/Login.vue
+++ b/src/themes/default/components/core/blocks/Auth/Login.vue
@@ -44,13 +44,10 @@
           </div>
         </div>
         <div class="mb20">
-          <button-full
-            class="w-100 border-box p0 center-xs"
-            :text="$t('Log in to your account')"
-            @click.native="login"
-          />
+          <button-full type="submit">
+            {{ $t('Log in to your account') }}
+          </button-full>
         </div>
-        <input class="hidden" type="submit">
         <div class="center-xs">
           <span>
             or

--- a/src/themes/default/components/core/blocks/Auth/Register.vue
+++ b/src/themes/default/components/core/blocks/Auth/Register.vue
@@ -76,9 +76,10 @@
           </span>
         </div>
         <div class="mb20">
-          <button-full class="w-100 border-box center-xs" :text="$t('Register an account')" @click.native="register"/>
+          <button-full type="submit">
+            {{ $t('Register an account') }}
+          </button-full>
         </div>
-        <input class="hidden" type="submit">
         <div class="center-xs">
           <span>
             {{ $t('or') }}

--- a/src/themes/default/components/core/blocks/Checkout/OrderReview.vue
+++ b/src/themes/default/components/core/blocks/Checkout/OrderReview.vue
@@ -57,10 +57,11 @@
         <div class="row">
           <div class="col-xs-12 bottom-button">
             <button-full
-              :text="$t('Place the order')"
               @click.native="placeOrder"
-              :class="{ 'ripple': true, 'button-disabled' : $v.orderReview.$invalid }"
-            />
+              :class="{ 'button-disabled' : $v.orderReview.$invalid }"
+            >
+              {{ $t('Place the order') }}
+            </button-full>
           </div>
         </div>
       </div>

--- a/src/themes/default/components/core/blocks/Checkout/OrderReview.vue
+++ b/src/themes/default/components/core/blocks/Checkout/OrderReview.vue
@@ -55,7 +55,7 @@
       <div class="hidden-xs col-sm-2 col-md-1"/>
       <div class="col-xs-12 col-sm-9 col-md-11">
         <div class="row">
-          <div class="col-xs-12 bottom-button">
+          <div class="col-xs-12 col-md-8 px20">
             <button-full
               @click.native="placeOrder"
               :class="{ 'button-disabled' : $v.orderReview.$invalid }"

--- a/src/themes/default/components/core/blocks/Checkout/Payment.vue
+++ b/src/themes/default/components/core/blocks/Checkout/Payment.vue
@@ -262,9 +262,10 @@
           <div class="col-xs-12 my30 bottom-button">
             <button-full
               @click.native="sendDataToCheckout"
-              :text="$t('Go review the order')"
-              :class="{ 'ripple': true, 'button-disabled' : $v.payment.$invalid }"
-            />
+              :class="{ 'button-disabled' : $v.payment.$invalid }"
+            >
+              {{ $t('Go review the order') }}
+            </button-full>
           </div>
         </div>
       </div>

--- a/src/themes/default/components/core/blocks/Checkout/Payment.vue
+++ b/src/themes/default/components/core/blocks/Checkout/Payment.vue
@@ -259,7 +259,7 @@
       <div class="hidden-xs col-sm-2 col-md-1"/>
       <div class="col-xs-12 col-sm-9 col-md-11">
         <div class="row">
-          <div class="col-xs-12 my30 bottom-button">
+          <div class="col-xs-12 col-md-8 px20 my30">
             <button-full
               @click.native="sendDataToCheckout"
               :class="{ 'button-disabled' : $v.payment.$invalid }"

--- a/src/themes/default/components/core/blocks/Checkout/PersonalDetails.vue
+++ b/src/themes/default/components/core/blocks/Checkout/PersonalDetails.vue
@@ -151,7 +151,7 @@
       <div class="hidden-xs col-sm-2 col-md-1"/>
       <div class="col-xs-12 col-sm-9 col-md-11">
         <div class="row">
-          <div class="col-xs-12 col-sm-12 col-md-8 col-lg-6 my30 pl20 button-container bottom-button">
+          <div class="col-xs-12 col-md-8 col-lg-6 my30 px20 button-container">
             <button-full
               @click.native="sendDataToCheckout"
               :class="{ 'button-disabled' : (createAccount ? $v.$invalid : $v.personalDetails.$invalid) }"
@@ -159,7 +159,7 @@
               {{ $t('Continue to shipping') }}
             </button-full>
           </div>
-          <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6 pl20 login-prompt bottom-button" v-show="!currentUser">
+          <div class="col-xs-12 col-md-12 col-lg-6 pl20 login-prompt bottom-button" v-show="!currentUser">
             <p class="h4 c-darkgray">
               {{ $t('or') }}
               <a v-if="true" href="#" @click="gotoAccount" class="link no-underline fs16 c-darkgray">

--- a/src/themes/default/components/core/blocks/Checkout/PersonalDetails.vue
+++ b/src/themes/default/components/core/blocks/Checkout/PersonalDetails.vue
@@ -154,9 +154,10 @@
           <div class="col-xs-12 col-sm-12 col-md-8 col-lg-6 my30 pl20 button-container bottom-button">
             <button-full
               @click.native="sendDataToCheckout"
-              :text="$t('Continue to shipping')"
-              :class="{ 'ripple': true, 'button-disabled' : (createAccount ? $v.$invalid : $v.personalDetails.$invalid) }"
-            />
+              :class="{ 'button-disabled' : (createAccount ? $v.$invalid : $v.personalDetails.$invalid) }"
+            >
+              {{ $t('Continue to shipping') }}
+            </button-full>
           </div>
           <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6 pl20 login-prompt bottom-button" v-show="!currentUser">
             <p class="h4 c-darkgray">

--- a/src/themes/default/components/core/blocks/Checkout/Shipping.vue
+++ b/src/themes/default/components/core/blocks/Checkout/Shipping.vue
@@ -197,9 +197,10 @@
           <div class="col-xs-12 my30 bottom-button">
             <button-full
               @click.native="sendDataToCheckout"
-              :text="$t('Continue to payment')"
               :class="{ 'ripple': true, 'button-disabled' : $v.shipping.$invalid}"
-            />
+            >
+              {{ $t('Continue to payment') }}
+            </button-full>
           </div>
         </div>
       </div>

--- a/src/themes/default/components/core/blocks/Checkout/Shipping.vue
+++ b/src/themes/default/components/core/blocks/Checkout/Shipping.vue
@@ -194,7 +194,7 @@
       <div class="hidden-xs col-sm-2 col-md-1"/>
       <div class="col-xs-12 col-sm-9 col-md-11">
         <div class="row">
-          <div class="col-xs-12 my30 bottom-button">
+          <div class="col-xs-12 col-md-8 my30 px20">
             <button-full
               @click.native="sendDataToCheckout"
               :class="{ 'ripple': true, 'button-disabled' : $v.shipping.$invalid}"

--- a/src/themes/default/components/core/blocks/Footer/Newsletter.vue
+++ b/src/themes/default/components/core/blocks/Footer/Newsletter.vue
@@ -9,10 +9,11 @@
         </div>
         <div class="newsletter-button col-md-3 col-xs-12 end-md">
           <button-outline
-            :text="$t('Subscribe')"
             @click.native="$bus.$emit('modal.show', 'modal-newsletter')"
             color="dark"
-          />
+          >
+            {{ $t('Subscribe') }}
+          </button-outline>
         </div>
       </div>
     </div>

--- a/src/themes/default/components/core/blocks/MainSlider/MainSlider.vue
+++ b/src/themes/default/components/core/blocks/MainSlider/MainSlider.vue
@@ -9,7 +9,9 @@
                 <p class="subtitle mb0 serif uppercase h3 align-center">{{ slide.subtitle }}</p>
                 <h1 class="title mt0 mb30 align-center">{{ slide.title }}</h1>
                 <div class="align-center">
-                  <button-outline class="button" :text="slide.button_text" :link="slide.link" color="light" />
+                  <button-outline :link="slide.link" color="light">
+                    {{ slide.button_text }}
+                  </button-outline>
                 </div>
               </div>
             </div>

--- a/src/themes/default/components/core/blocks/Microcart/Microcart.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Microcart.vue
@@ -84,7 +84,6 @@
       </div>
       <div class="col-xs-12 first-xs col-sm-4 end-sm">
         <button-full
-          tag="router-link"
           :link="{ name: 'checkout' }"
           @click.native="closeMicrocart"
         >

--- a/src/themes/default/components/core/blocks/Microcart/Microcart.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Microcart.vue
@@ -82,18 +82,14 @@
           </span>
         </router-link>
       </div>
-      <div class="col-xs-12 first-xs col-sm end-sm">
-        <router-link
-          class="no-underline inline-flex h4 checkout-button bg-darkgray link checkout"
-          :to="{ name: 'checkout' }"
+      <div class="col-xs-12 first-xs col-sm-4 end-sm">
+        <button-full
+          tag="router-link"
+          :link="{ name: 'checkout' }"
+          @click.native="closeMicrocart"
         >
-          <span
-            class="c-white py20 px70"
-            @click="closeMicrocart"
-          >
-            {{ $t('Go to checkout') }}
-          </span>
-        </router-link>
+          {{ $t('Go to checkout') }}
+        </button-full>
       </div>
     </div>
   </div>
@@ -102,10 +98,12 @@
 <script>
 import { coreComponent } from 'lib/themes'
 import Product from './Product'
+import ButtonFull from 'theme/components/theme/ButtonFull.vue'
 
 export default {
   components: {
-    Product
+    Product,
+    ButtonFull
   },
   mixins: [coreComponent('core/blocks/Microcart/Microcart')]
 }

--- a/src/themes/default/components/core/blocks/MyAccount/MyNewsletter.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyNewsletter.vue
@@ -99,7 +99,9 @@
       </div>
       <div class="hidden-xs hidden-sm col-md-6"/>
       <div class="col-xs-12 col-sm-6 mt10 bottom-button" v-show="isActive">
-        <button-full :text="$t('Update my preferences')" @click.native="updateNewsletter" />
+        <button-full @click.native="updateNewsletter">
+          {{ $t('Update my preferences') }}
+        </button-full>
       </div>
       <div class="col-xs-12 col-sm-6 mt25 bottom-button" v-show="isActive">
         <a href="#" @click="exitSection" class="link no-underline fs16 c-darkgray">

--- a/src/themes/default/components/core/blocks/MyAccount/MyProfile.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyProfile.vue
@@ -176,10 +176,11 @@
 
       <div class="col-xs-12 col-sm-6 bottom-button">
         <button-full
-          :text="$t('Update my profile')"
           @click.native="updateProfile"
           :class="{ 'button-disabled': checkValidation() }"
-        />
+        >
+          {{ $t('Update my profile') }}
+        </button-full>
       </div>
       <div class="col-xs-12 col-sm-6 pt15 bottom-button">
         <a href="#" @click="exitSection" class="link no-underline fs16 c-darkgray">

--- a/src/themes/default/components/core/blocks/MyAccount/MyShippingDetails.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyShippingDetails.vue
@@ -77,10 +77,11 @@
       <div class="hidden-xs col-sm-6 mb25"/>
       <div class="col-xs-12 col-sm-6 bottom-button">
         <button-full
-          :text="$t('Update my shipping details')"
           @click.native="updateDetails"
           :class="{ 'button-disabled': $v.$invalid }"
-        />
+        >
+          {{ $t('Update my shipping details') }}
+        </button-full>
       </div>
       <div class="col-xs-12 col-sm-6 pt15 bottom-button">
         <a href="#" @click="exitSection" class="link no-underline fs16 c-darkgray">

--- a/src/themes/default/components/theme/ButtonFull.vue
+++ b/src/themes/default/components/theme/ButtonFull.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="button-full block brdr-none w-100 px55 py20 bg-black ripple weight-400 h4 c-white"
+    class="button-full block brdr-none w-100 px10 py20 bg-darkgray ripple weight-400 h4 c-white"
     :type="type"
     v-focus-clean="{class: 'no-outline'}"
   >
@@ -25,12 +25,12 @@ export default {
 
 <style lang="scss" scoped>
 @import '~theme/css/base/global_vars';
-$darkgray: map-get($colors, darkgray);
+$emperor: map-get($colors, emperor);
 
 .button-full {
   &:hover,
   &:focus {
-    background-color: $darkgray;
+    background-color: $emperor;
   }
 }
 </style>

--- a/src/themes/default/components/theme/ButtonFull.vue
+++ b/src/themes/default/components/theme/ButtonFull.vue
@@ -1,23 +1,36 @@
 <template>
-  <button
-    class="button-full block brdr-none w-100 px10 py20 bg-darkgray ripple weight-400 h4 c-white"
-    :type="type"
-    v-focus-clean="{class: 'no-outline'}"
+  <component
+    :is="tag"
+    :type="tag === 'button' ? type : false"
+    :to="link"
+    class="no-outline button-full block brdr-none w-100 px10 py20 bg-darkgray ripple weight-400 h4 c-white"
+    :class="{ 'no-underline pointer align-center border-box': tag != 'button' }"
+    v-focus-clean="{ class: 'no-outline' }"
   >
     <slot>
       Button
     </slot>
-  </button>
+  </component>
 </template>
 
 <script>
 export default {
   name: 'ButtonFull',
   props: {
+    tag: {
+      type: String,
+      required: false,
+      default: 'button'
+    },
     type: {
       type: String,
       required: false,
       default: 'button'
+    },
+    link: {
+      type: Object,
+      required: false,
+      default: null
     }
   }
 }

--- a/src/themes/default/components/theme/ButtonFull.vue
+++ b/src/themes/default/components/theme/ButtonFull.vue
@@ -1,10 +1,10 @@
 <template>
   <component
-    :is="tag"
-    :type="tag === 'button' ? type : false"
+    :is="link ? 'router-link' : 'button'"
+    :type="!link ? type : false"
     :to="link"
     class="no-outline button-full block brdr-none w-100 px10 py20 bg-darkgray ripple weight-400 h4 c-white"
-    :class="{ 'no-underline pointer align-center border-box': tag != 'button' }"
+    :class="{ 'no-underline pointer align-center border-box': link }"
     v-focus-clean="{ class: 'no-outline' }"
   >
     <slot>
@@ -17,11 +17,6 @@
 export default {
   name: 'ButtonFull',
   props: {
-    tag: {
-      type: String,
-      required: false,
-      default: 'button'
-    },
     type: {
       type: String,
       required: false,

--- a/src/themes/default/components/theme/ButtonFull.vue
+++ b/src/themes/default/components/theme/ButtonFull.vue
@@ -1,20 +1,23 @@
 <template>
-  <div
-    class="button-full inline-flex px55 py20 center-xs ripple pointer weight-400 h4 bg-black c-white"
-    tabindex="0"
+  <button
+    class="button-full block brdr-none w-100 px55 py20 ripple weight-400 h4 bg-black c-white"
+    :type="type"
     v-focus-clean="{class: 'no-outline'}"
   >
-    {{ text }}
-  </div>
+    <slot>
+      Button
+    </slot>
+  </button>
 </template>
 
 <script>
 export default {
   name: 'ButtonFull',
   props: {
-    text: {
+    type: {
       type: String,
-      required: true
+      required: false,
+      default: 'button'
     }
   }
 }
@@ -24,7 +27,10 @@ export default {
 @import '~theme/css/base/global_vars';
 $darkgray: map-get($colors, darkgray);
 
-.button-full:hover {
-  background: $darkgray;
+.button-full {
+  &:hover,
+  &:focus {
+    background-color: $darkgray;
+  }
 }
 </style>

--- a/src/themes/default/components/theme/ButtonFull.vue
+++ b/src/themes/default/components/theme/ButtonFull.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="button-full block brdr-none w-100 px55 py20 ripple weight-400 h4 bg-black c-white"
+    class="button-full block brdr-none w-100 px55 py20 bg-black ripple weight-400 h4 c-white"
     :type="type"
     v-focus-clean="{class: 'no-outline'}"
   >

--- a/src/themes/default/components/theme/ButtonOutline.vue
+++ b/src/themes/default/components/theme/ButtonOutline.vue
@@ -1,26 +1,25 @@
 <template>
-  <div
-    class="button-outline inline-flex uppercase brdr-2 pointer weight-400 h4"
-    tabindex="0"
+  <router-link
+    v-if="link"
+    :to="link"
+    class="button-outline inline-flex uppercase weight-400 h4 px40 py15 no-underline"
     :class="{
       light : color === 'light', 'brdr-white' : color === 'light', 'c-white' : color === 'light',
       dark : color === 'dark', 'brdr-darkgray' : color === 'dark', 'c-gray-secondary' : color === 'dark'
     }"
   >
-    <router-link
-      v-if="link"
-      :to="link"
-      class="px40 py15 no-underline"
-    >
-      {{ text }}
-    </router-link>
-    <span
-      v-else
-      class="px40 py15"
-    >
-      {{ text }}
-    </span>
-  </div>
+    <slot>Button</slot>
+  </router-link>
+  <button
+    v-else
+    class="button-outline px40 py15 bg-transparent uppercase h4"
+    :class="{
+      light : color === 'light', 'brdr-white' : color === 'light', 'c-white' : color === 'light',
+      dark : color === 'dark', 'brdr-darkgray' : color === 'dark', 'c-gray-secondary' : color === 'dark'
+    }"
+  >
+    <slot>Button</slot>
+  </button>
 </template>
 
 <script>
@@ -29,10 +28,6 @@ export default {
   name: 'ButtonOutline',
   directives: { focusClean },
   props: {
-    text: {
-      type: String,
-      required: true
-    },
     color: {
       type: String,
       required: true
@@ -58,15 +53,19 @@ export default {
   .dark {
     font-weight: 200;
     border: 1px solid $gray-secondary;
+    &:hover,
+    &:focus {
+      color: $white;
+      background: $black;
+      border-color: $black;
+    }
   }
-  .light:hover {
-    color: $black;
-    background: $white;
-    border-color: $white;
-  }
-  .dark:hover {
-    color: $white;
-    background: $black;
-    border-color: $black;
+  .light {
+    &:hover,
+    &:focus {
+      color: $black;
+      background: $white;
+      border-color: $white;
+    }
   }
 </style>

--- a/src/themes/default/components/theme/ButtonOutline.vue
+++ b/src/themes/default/components/theme/ButtonOutline.vue
@@ -1,25 +1,17 @@
 <template>
-  <router-link
-    v-if="link"
+  <component
+    :is="link ? 'router-link' : 'button'"
     :to="link"
-    class="button-outline inline-flex uppercase weight-400 h4 px40 py15 no-underline"
+    class="button-outline no-outline px40 py15 bg-transparent uppercase h4 no-underline"
     :class="{
       light : color === 'light', 'brdr-white' : color === 'light', 'c-white' : color === 'light',
-      dark : color === 'dark', 'brdr-darkgray' : color === 'dark', 'c-gray-secondary' : color === 'dark'
+      dark : color === 'dark', 'brdr-darkgray' : color === 'dark', 'c-gray-secondary' : color === 'dark',
     }"
   >
-    <slot>Button</slot>
-  </router-link>
-  <button
-    v-else
-    class="button-outline px40 py15 bg-transparent uppercase h4"
-    :class="{
-      light : color === 'light', 'brdr-white' : color === 'light', 'c-white' : color === 'light',
-      dark : color === 'dark', 'brdr-darkgray' : color === 'dark', 'c-gray-secondary' : color === 'dark'
-    }"
-  >
-    <slot>Button</slot>
-  </button>
+    <slot>
+      Button
+    </slot>
+  </component>
 </template>
 
 <script>

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -98,7 +98,7 @@
             <div class="row m0">
               <add-to-cart
                 :product="product"
-                class="col-xs-12 col-sm-4 col-md-6 h4 bg-darkgray c-white py20 brdr-none"
+                class="col-xs-12 col-sm-4 col-md-6"
               />
             </div>
             <div class="row pt45 add-to-buttons">


### PR DESCRIPTION
#670
- Changes in ButtonFull and ButtonOutline templates for better semantics and accessibility
- Button size adjustments in Checkout
- Replaced custom 'addToCart' and 'goToCheckout' buttons with ButtonFull
- Buttons can be used with a `button` or `router-link` tag, e.g.:

Link to checkout in microcart:
```
<button-full
    :link="{ name: 'checkout' }"
    @click.native="closeMicrocart"
>
    {{ $t('Go to checkout') }}
</button-full>
```
<img width="238" alt="zrzut ekranu 2018-02-18 o 01 18 34" src="https://user-images.githubusercontent.com/7126345/36346917-ae7d1414-1449-11e8-8ee8-728f71c0ac64.png">

Login button with `type="submit"`
```
<button-full type="submit">
    {{ $t('Log in to your account') }}
</button-full>
```
<img width="318" alt="zrzut ekranu 2018-02-18 o 01 23 15" src="https://user-images.githubusercontent.com/7126345/36346948-56fea97c-144a-11e8-930c-d3de32a89d40.png">
