### PR TITLE
Update 'Installing on Linux and MacOS.md'

### DIFF
--- a/doc/Installing on Linux and MacOS.md
+++ b/doc/Installing on Linux and MacOS.md
@@ -11,7 +11,7 @@ Let's go:
 If you're MacOS or Linux user now you're able to install with pretty nice CLI installer :)
 
 ### Requirements
-1. Docker
+1. Docker (with 'docker-compose' installed)
 2. Node.js [Active LTS](https://github.com/nodejs/Release) (>=8.0.0)
 3. [Yarn](https://yarnpkg.com/en/docs/install) (>=1.0.0)
 


### PR DESCRIPTION
When installing vue-storefront-api I noticed that docker is not enough. You also need 'docker-compose'.