### PR TITLE
ref. #957 reset margin from all buttons

### DIFF
--- a/src/themes/default/css/components/_buttons.scss
+++ b/src/themes/default/css/components/_buttons.scss
@@ -43,4 +43,5 @@ button,
 .button {
   outline: none;
   cursor: pointer;
+  margin: 0;
 }


### PR DESCRIPTION
Remove margin from all buttons to prevent default browsers margin such as safari