### PR TITLE
ref. #956 replace all #333 colors to #4F4F4F

### DIFF
--- a/src/themes/default/css/components/_buttons.scss
+++ b/src/themes/default/css/components/_buttons.scss
@@ -43,4 +43,5 @@ button,
 .button {
   outline: none;
   cursor: pointer;
+  margin: 0;
 }


### PR DESCRIPTION
Notice: pay attention that this may disable color change effects on hovering some element, especially those that use primary color variables as now they're the same in both statuses:

  primary: (
    default: map-get($colors, matterhorn),
    hover: map-get($colors, matterhorn)
  ),

matterhorn is #4F4F4F