### PR TITLE
ref. #956 replace all #333 colors to #4F4F4F

### DIFF
--- a/src/themes/catalog/components/core/Notification.vue
+++ b/src/themes/catalog/components/core/Notification.vue
@@ -73,6 +73,6 @@ export default {
 }
 
 .notification.info {
-  background: #333333;
+  background: #4F4F4F;
 }
 </style>

--- a/src/themes/catalog/css/vars/_colors.scss
+++ b/src/themes/catalog/css/vars/_colors.scss
@@ -10,7 +10,7 @@ $c-text-on-dark: white;
 $c-text-on-light: black;
 $c-text-on-accent: white;
 $c-text-on-bg-secondary: #4F4F4F;
-$c-text-heading: #333333;
+$c-text-heading: #4F4F4F;
 
 $c-text-header-link: black;
 

--- a/src/themes/default/css/variables/_colors.scss
+++ b/src/themes/default/css/variables/_colors.scss
@@ -15,6 +15,7 @@ $colors: (
   gray: #828282,
   suva-gray: #8e8e8e,
   matterhorn: #4f4f4f,
+  night-rider: #333,
   burnt-sienna: #eb5757,
   buccaneer: #755,
   forest-green: #308c14,
@@ -27,7 +28,7 @@ $colors: (
 $colors-theme: (
   primary: (
     default: map-get($colors, matterhorn),
-    hover: map-get($colors, matterhorn)
+    hover: map-get($colors, night-rider)
   ),
   secondary: (
     default: map-get($colors, gray),

--- a/src/themes/default/css/variables/_colors.scss
+++ b/src/themes/default/css/variables/_colors.scss
@@ -15,7 +15,6 @@ $colors: (
   gray: #828282,
   suva-gray: #8e8e8e,
   matterhorn: #4f4f4f,
-  night-rider: #333,
   burnt-sienna: #eb5757,
   buccaneer: #755,
   forest-green: #308c14,
@@ -28,14 +27,14 @@ $colors: (
 $colors-theme: (
   primary: (
     default: map-get($colors, matterhorn),
-    hover: map-get($colors, night-rider)
+    hover: map-get($colors, matterhorn)
   ),
   secondary: (
     default: map-get($colors, gray),
     hover: map-get($colors, matterhorn),
   ),
   accent: (
-    default: map-get($colors, night-rider),
+    default: map-get($colors, matterhorn),
     hover: map-get($colors, black),
   ),
   tertiary: map-get($colors, silver),


### PR DESCRIPTION
Notice: pay attention that this may disable color change effects on hovering some element, especially those that use primary color variables as now they're the same in both statuses:

primary: (
default: map-get($colors, matterhorn),
hover: map-get($colors, matterhorn)
),

matterhorn is #4F4F4F


(this is the right PR, I hope! thanks @pkarw for the patience!)