### PR TITLE
#99 product gallery

### DIFF
--- a/core/components/ProductGallery.vue
+++ b/core/components/ProductGallery.vue
@@ -1,0 +1,53 @@
+<template>
+  <!-- Move in default theme -->
+  <div class="row">
+    <div class="col-xs-2">
+      <div
+        v-for="(images, key) in gallery"
+        :key="key">
+        <transition name="fade" appear>
+          <img v-lazy="images.path" class="mw-100" ref="images.path" @click="navigate(key)">
+        </transition>
+      </div>
+    </div>
+    <div class="col-xs-10">
+      <carousel
+        pagination-active-color="#828282"
+        pagination-color="#fff"
+        :per-page="1"
+        mouse-drag="false"
+        ref="carousel">
+        <slide
+          v-for="(images, key) in gallery"
+          :key="key">
+          <transition name="fade" appear>
+            <!-- SSR support needed here -->
+            <img class="product-image inline-flex mw-100" v-lazy="images.path" ref="images.path">
+          </transition>
+        </slide>
+      </carousel>
+    </div>
+  </div>
+</template>
+
+<script>
+import { Carousel, Slide } from 'vue-carousel'
+export default {
+  name: 'ProductGallery',
+  props: {
+    gallery: {
+      type: Array,
+      required: true
+    }
+  },
+  components: {
+    Slide,
+    Carousel
+  },
+  methods: {
+    navigate (index) {
+      this.$refs.carousel.goToPage(index)
+    }
+  }
+}
+</script>

--- a/core/components/ProductGallery.vue
+++ b/core/components/ProductGallery.vue
@@ -1,32 +1,7 @@
 <template>
-  <!-- Move in default theme -->
-  <div class="row">
-    <div class="col-xs-2">
-      <div
-        v-for="(images, key) in gallery"
-        :key="key">
-        <transition name="fade" appear>
-          <img v-lazy="images.path" class="mw-100" ref="images.path" @click="navigate(key)">
-        </transition>
-      </div>
-    </div>
-    <div class="col-xs-10">
-      <carousel
-        pagination-active-color="#828282"
-        pagination-color="#fff"
-        :per-page="1"
-        mouse-drag="false"
-        ref="carousel">
-        <slide
-          v-for="(images, key) in gallery"
-          :key="key">
-          <transition name="fade" appear>
-            <!-- SSR support needed here -->
-            <img class="product-image inline-flex mw-100" v-lazy="images.path" ref="images.path">
-          </transition>
-        </slide>
-      </carousel>
-    </div>
+  <div class="media-gallery">
+    <!-- SSR support needed here -->
+    Core Media Gallery
   </div>
 </template>
 
@@ -40,6 +15,11 @@ export default {
       required: true
     }
   },
+  data () {
+    return {
+      isZoomOpen: false
+    }
+  },
   components: {
     Slide,
     Carousel
@@ -47,6 +27,9 @@ export default {
   methods: {
     navigate (index) {
       this.$refs.carousel.goToPage(index)
+    },
+    toggleZoom () {
+      this.isZoomOpen ? this.isZoomOpen = false : this.isZoomOpen = true
     }
   }
 }

--- a/core/components/ProductGallery.vue
+++ b/core/components/ProductGallery.vue
@@ -30,7 +30,14 @@ export default {
     },
     toggleZoom () {
       this.isZoomOpen ? this.isZoomOpen = false : this.isZoomOpen = true
+    },
+    selectVariant (option) {
+      let index = this.gallery.findIndex(obj => parseInt(obj.variant) === option.id)
+      this.navigate(index)
     }
+  },
+  created () {
+    this.$bus.$on('filter-changed-product', this.selectVariant.bind(this))
   }
 }
 </script>

--- a/core/pages/Product.vue
+++ b/core/pages/Product.vue
@@ -233,15 +233,15 @@ export default {
     gallery () {
       return [
         {
-          'path': this.getThumbnail(this.product.image, 570, 569),
+          'path': this.getThumbnail(this.product.image, 600, 744),
           'type': 'main'
         },
         {
-          'path': this.getThumbnail(this.product.small_image, 570, 569),
+          'path': this.getThumbnail(this.product.small_image, 600, 744),
           'type': 'small'
         },
         {
-          'path': this.getThumbnail(this.product.thumbnail, 570, 569),
+          'path': this.getThumbnail(this.product.thumbnail, 600, 744),
           'type': 'thumbnail'
         }
       ]

--- a/core/pages/Product.vue
+++ b/core/pages/Product.vue
@@ -7,6 +7,7 @@
 <script>
 import Breadcrumbs from 'core/components/Breadcrumbs.vue'
 import AddToCart from 'core/components/AddToCart.vue'
+import ProductGallery from 'core/components/ProductGallery.vue'
 import EventBus from 'core/plugins/event-bus'
 import Composite from 'core/mixins/composite'
 import { mapGetters } from 'vuex'
@@ -228,12 +229,22 @@ export default {
     productId () {
       return this.product ? this.product.id : ''
     },
-    image () {
-      return {
-        src: this.getThumbnail(this.product.image, 570, 569),
-        error: this.getThumbnail(this.product.image, 310, 300),
-        loading: this.getThumbnail(this.product.image, 310, 300)
-      }
+    // TODO: This work should be done by vue-storefront-api and should expose the whole gallery
+    gallery () {
+      return [
+        {
+          'path': this.getThumbnail(this.product.image, 570, 569),
+          'type': 'main'
+        },
+        {
+          'path': this.getThumbnail(this.product.small_image, 570, 569),
+          'type': 'small'
+        },
+        {
+          'path': this.getThumbnail(this.product.thumbnail, 570, 569),
+          'type': 'thumbnail'
+        }
+      ]
     },
     customAttributes () {
       let inst = this
@@ -256,7 +267,8 @@ export default {
   },
   components: {
     Breadcrumbs,
-    AddToCart
+    AddToCart,
+    ProductGallery
   }
 }
 </script>

--- a/core/pages/Product.vue
+++ b/core/pages/Product.vue
@@ -247,7 +247,8 @@ export default {
             if (confChild.image) {
               images.push({
                 'path': this.getThumbnail(confChild.image, 600, 744),
-                'type': 'main'
+                'type': 'main',
+                'variant': confChild.color
               })
             } // TODO: add support for the whole gallery
           }

--- a/src/themes/default/components/core/ProductGallery.vue
+++ b/src/themes/default/components/core/ProductGallery.vue
@@ -83,7 +83,10 @@ img {
     opacity: 1;
   }
 }
+
 .thumbnails {
+  max-height: 750px;
+  overflow-y: scroll;
   div {
     margin: 0 20px 30px 0;
   }

--- a/src/themes/default/components/core/ProductGallery.vue
+++ b/src/themes/default/components/core/ProductGallery.vue
@@ -1,11 +1,12 @@
 <template>
-  <div class="media-gallery" :class="{ open: isZoomOpen }">
-    <div class="inner" :class="{ container: isZoomOpen }">
+  <div class="media-gallery relative" :class="{ 'open fixed bg-cl-primary': isZoomOpen }">
+    <div :class="{ 'container product-zoom py30': isZoomOpen }">
       <div :class="{ row: isZoomOpen }">
-        <i v-if="isZoomOpen" class="material-icons modal-close p15 cl-bg-tertiary" @click="toggleZoom">close</i>
-        <div class="col-xs-2 thumbnails"
+        <i v-if="isZoomOpen" class="material-icons modal-close p15 cl-bg-tertiary pointer" @click="toggleZoom">close</i>
+        <div class="col-md-2 thumbnails p0"
              v-if="isZoomOpen">
           <div
+            class="bg-cl-secondary"
             v-for="(images, key) in gallery"
             :key="key">
             <transition name="fade" appear>
@@ -13,27 +14,29 @@
             </transition>
           </div>
         </div>
-        <div :class="{ 'col-xs-10' : isZoomOpen}">
+        <div :class="{ 'col-md-10' : isZoomOpen}">
           <carousel
             :per-page="1"
             mouse-drag="false"
             navigation-enabled="true"
-            navigation-next-label="<i class='material-icons'>keyboard_arrow_right</i>"
-            navigation-prev-label="<i class='material-icons'>keyboard_arrow_left</i>"
+            pagination-active-color="transparent"
+            pagination-color="#828282"
+            navigation-next-label="<i class='material-icons p15 cl-bg-tertiary pointer'>keyboard_arrow_right</i>"
+            navigation-prev-label="<i class='material-icons p15 cl-bg-tertiary pointer'>keyboard_arrow_left</i>"
             ref="carousel">
             <slide
               v-for="(images, key) in gallery"
               :key="key">
-              <transition name="fade" appear>
+              <div class="bg-cl-secondary">
                 <img
-                  class="product-image inline-flex pointer"
+                  class="product-image inline-flex pointer mw-100"
                   v-lazy="images.path"
                   ref="images.path"
                   @dblclick="toggleZoom">
-              </transition>
+              </div>
             </slide>
           </carousel>
-          <i v-if="isZoomOpen==false" class="zoom-in material-icons p15 cl-bg-tertiary" @click="toggleZoom">zoom_in</i>
+          <i v-if="isZoomOpen==false" class="zoom-in material-icons p15 cl-bg-tertiary pointer" @click="toggleZoom">zoom_in</i>
         </div>
       </div>
     </div>
@@ -50,25 +53,36 @@ export default {
 
 <style lang="scss" scoped>
 .media-gallery {
-  text-align: left;
-  position: relative;
+  text-align: center;
   &.open {
-    position: fixed;
-    text-align: center;
-    background-color: white;
     z-index: 3;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
   }
-  .zoom-in {
-    position: absolute;
-    bottom: 0;
-    right: 0;
+}
+.product-zoom {
+  max-width: 750px;
+}
+.zoom-in {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+img {
+  opacity: 0.9;
+  mix-blend-mode: multiply;
+  &:hover {
+    opacity: 1;
   }
-  .thumbnails {
-    padding-right: 30px;
+}
+.thumbnails {
+  div {
+    margin: 0 20px 30px 0;
+  }
+  @media (max-width: 767px) {
+    display: none;
   }
 }
 </style>
@@ -80,13 +94,25 @@ export default {
   }
   .VueCarousel-navigation-button {
     margin: 0;
-    opacity: 0;
     transform: translateY(-50%) !important;
   }
+  .VueCarousel-navigation {
+    opacity: 0;
+  }
+
+  .VueCarousel-dot--active .VueCarousel-dot-inner {
+    border: 2px solid #828282;
+    margin-top: -2px;
+  }
   &:hover {
-    .VueCarousel-navigation-button {
+    .VueCarousel-navigation {
       opacity: .9;
+    }
+    .VueCarousel-navigation-button {
       transition: opacity 3s;
+      &:after {
+        background-color: transparent;
+      }
     }
   }
 }

--- a/src/themes/default/components/core/ProductGallery.vue
+++ b/src/themes/default/components/core/ProductGallery.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="media-gallery relative" :class="{ 'open fixed bg-cl-primary': isZoomOpen }">
-    <div :class="{ 'container product-zoom py30': isZoomOpen }">
+    <div :class="{ 'container product-zoom py40': isZoomOpen }">
       <div :class="{ row: isZoomOpen }">
         <i v-if="isZoomOpen" class="material-icons modal-close p15 cl-bg-tertiary pointer" @click="toggleZoom">close</i>
         <div class="col-md-2 thumbnails p0"
@@ -15,27 +15,29 @@
           </div>
         </div>
         <div :class="{ 'col-md-10' : isZoomOpen}">
-          <carousel
-            :per-page="1"
-            mouse-drag="false"
-            navigation-enabled="true"
-            pagination-active-color="transparent"
-            pagination-color="#828282"
-            navigation-next-label="<i class='material-icons p15 cl-bg-tertiary pointer'>keyboard_arrow_right</i>"
-            navigation-prev-label="<i class='material-icons p15 cl-bg-tertiary pointer'>keyboard_arrow_left</i>"
-            ref="carousel">
-            <slide
-              v-for="(images, key) in gallery"
-              :key="key">
-              <div class="bg-cl-secondary">
-                <img
-                  class="product-image inline-flex pointer mw-100"
-                  v-lazy="images.path"
-                  ref="images.path"
-                  @dblclick="toggleZoom">
-              </div>
-            </slide>
-          </carousel>
+          <no-ssr>
+            <carousel
+              :per-page="1"
+              mouse-drag="false"
+              navigation-enabled="true"
+              pagination-active-color="transparent"
+              pagination-color="#828282"
+              navigation-next-label="<i class='material-icons p15 cl-bg-tertiary pointer'>keyboard_arrow_right</i>"
+              navigation-prev-label="<i class='material-icons p15 cl-bg-tertiary pointer'>keyboard_arrow_left</i>"
+              ref="carousel">
+              <slide
+                v-for="(images, key) in gallery"
+                :key="key">
+                <div class="bg-cl-secondary">
+                  <img
+                    class="product-image inline-flex pointer mw-100"
+                    v-lazy="images.path"
+                    ref="images.path"
+                    @dblclick="toggleZoom">
+                </div>
+              </slide>
+            </carousel>
+          </no-ssr>
           <i v-if="isZoomOpen==false" class="zoom-in material-icons p15 cl-bg-tertiary pointer" @click="toggleZoom">zoom_in</i>
         </div>
       </div>

--- a/src/themes/default/components/core/ProductGallery.vue
+++ b/src/themes/default/components/core/ProductGallery.vue
@@ -1,0 +1,7 @@
+<script>
+import { coreComponent } from 'core/lib/themes'
+
+export default {
+  mixins: [coreComponent('ProductGallery')]
+}
+</script>

--- a/src/themes/default/components/core/ProductGallery.vue
+++ b/src/themes/default/components/core/ProductGallery.vue
@@ -1,3 +1,45 @@
+<template>
+  <div class="media-gallery" :class="{ open: isZoomOpen }">
+    <div class="inner" :class="{ container: isZoomOpen }">
+      <div :class="{ row: isZoomOpen }">
+        <i v-if="isZoomOpen" class="material-icons modal-close p15 cl-bg-tertiary" @click="toggleZoom">close</i>
+        <div class="col-xs-2 thumbnails"
+             v-if="isZoomOpen">
+          <div
+            v-for="(images, key) in gallery"
+            :key="key">
+            <transition name="fade" appear>
+              <img v-lazy="images.path" class="mw-100 pointer" ref="images.path" @click="navigate(key)">
+            </transition>
+          </div>
+        </div>
+        <div :class="{ 'col-xs-10' : isZoomOpen}">
+          <carousel
+            :per-page="1"
+            mouse-drag="false"
+            navigation-enabled="true"
+            navigation-next-label="<i class='material-icons'>keyboard_arrow_right</i>"
+            navigation-prev-label="<i class='material-icons'>keyboard_arrow_left</i>"
+            ref="carousel">
+            <slide
+              v-for="(images, key) in gallery"
+              :key="key">
+              <transition name="fade" appear>
+                <img
+                  class="product-image inline-flex pointer"
+                  v-lazy="images.path"
+                  ref="images.path"
+                  @dblclick="toggleZoom">
+              </transition>
+            </slide>
+          </carousel>
+          <i v-if="isZoomOpen==false" class="zoom-in material-icons p15 cl-bg-tertiary" @click="toggleZoom">zoom_in</i>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
 <script>
 import { coreComponent } from 'core/lib/themes'
 
@@ -5,3 +47,47 @@ export default {
   mixins: [coreComponent('ProductGallery')]
 }
 </script>
+
+<style lang="scss" scoped>
+.media-gallery {
+  text-align: left;
+  position: relative;
+  &.open {
+    position: fixed;
+    text-align: center;
+    background-color: white;
+    z-index: 3;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+  .zoom-in {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+  }
+  .thumbnails {
+    padding-right: 30px;
+  }
+}
+</style>
+<style lang="scss">
+.media-gallery {
+  .VueCarousel-pagination {
+    position: absolute;
+    bottom: 0;
+  }
+  .VueCarousel-navigation-button {
+    margin: 0;
+    opacity: 0;
+    transform: translateY(-50%) !important;
+  }
+  &:hover {
+    .VueCarousel-navigation-button {
+      opacity: .9;
+      transition: opacity 3s;
+    }
+  }
+}
+</style>

--- a/src/themes/default/css/components/_buttons.scss
+++ b/src/themes/default/css/components/_buttons.scss
@@ -43,4 +43,5 @@ button,
 .button {
   outline: none;
   cursor: pointer;
+  margin: 0;
 }

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -1,13 +1,13 @@
 <template>
   <div id="product">
-    <section class="bg-cl-secondary py30 px20 product-top-section">
+    <section class="bg-cl-secondary px20 product-top-section">
       <div class="container">
-        <breadcrumbs :routes="breadcrumbs.routes" :active-route="breadcrumbs.name"/>
-        <section class="row py35 m0 data-wrapper">
+        <section class="row m0 data-wrapper">
           <div class="col-xs-12 col-md-7 center-xs middle-xs image">
             <product-gallery :gallery="gallery" />
           </div>
           <div class="col-md-5 col-xs-12 px15 data">
+            <breadcrumbs class="py30" :routes="breadcrumbs.routes" :active-route="breadcrumbs.name"/>
             <div class="uppercase cl-secondary">
               sku: {{ product.sku }}
             </div>

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -256,7 +256,6 @@ $bg-secondary: color(secondary, $colors-background);
   @media (max-width: 1023px) {
     margin-bottom: 20px;
     padding: 20px 0 30px 0;
-    background-color: $bg-secondary;
   }
 }
 

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -3,10 +3,10 @@
     <section class="bg-cl-secondary px20 product-top-section">
       <div class="container">
         <section class="row m0 data-wrapper">
-          <div class="col-xs-12 col-md-7 center-xs middle-xs image">
+          <div class="col-xs-12 col-md-6 px15 center-xs middle-xs image">
             <product-gallery :gallery="gallery" />
           </div>
-          <div class="col-md-5 col-xs-12 px15 data">
+          <div class="col-md-6 col-xs-12 px20 data">
             <breadcrumbs class="py30" :routes="breadcrumbs.routes" :active-route="breadcrumbs.name"/>
             <div class="uppercase cl-secondary">
               sku: {{ product.sku }}

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -5,9 +5,7 @@
         <breadcrumbs :routes="breadcrumbs.routes" :active-route="breadcrumbs.name"/>
         <section class="row py35 m0 data-wrapper">
           <div class="col-xs-12 col-md-7 center-xs middle-xs image">
-            <transition name="fade" appear>
-              <img class="product-image inline-flex mw-100" v-lazy="image" ref="image">
-            </transition>
+            <product-gallery :gallery="gallery" />
           </div>
           <div class="col-md-5 col-xs-12 px15 data">
             <div class="uppercase cl-secondary">
@@ -203,6 +201,7 @@ import ProductAttribute from '../components/core/ProductAttribute.vue'
 import ProductTile from '../components/core/ProductTile.vue'
 import ProductLinks from '../components/core/ProductLinks.vue'
 import focusClean from 'theme/components/theme/directives/focusClean'
+import ProductGallery from '../components/core/ProductGallery'
 
 export default {
   asyncData ({ store, route }) {
@@ -217,6 +216,7 @@ export default {
     }
   },
   components: {
+    ProductGallery,
     AddToCart,
     GenericSelector,
     ColorSelector,


### PR DESCRIPTION
I created the array of gallery img in the [product page](https://github.com/bitbull-team/vue-storefront/blob/feature/99-gallery/core/pages/Product.vue) but I think that this job should be done within vue-storefront-api and it should include the whole gallery.

Zoom opens when double clicked because the click event was intercepted by the swipe. If you have better ideas let me know. 

Is SRR support for product image missing?




 