### PR TITLE
Fix add config var for attributes referenced by attribute_code rather than label

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -24,6 +24,7 @@
       "alwaysSyncPlatformPricesOver": false,
       "clearPricesBeforePlatformSync": false,
       "waitForPlatformSync": false,
+      "setupVariantAttributesByCode": false,
       "endpoint": "http://localhost:8080/api/product",
       "defaultFilters": ["color", "size", "price", "erin_recommends"]
     },

--- a/config/default.json
+++ b/config/default.json
@@ -24,7 +24,7 @@
       "alwaysSyncPlatformPricesOver": false,
       "clearPricesBeforePlatformSync": false,
       "waitForPlatformSync": false,
-      "setupVariantAttributesByCode": false,
+      "setupVariantByAttributeCode": false,
       "endpoint": "http://localhost:8080/api/product",
       "defaultFilters": ["color", "size", "price", "erin_recommends"]
     },

--- a/core/store/modules/product/actions.js
+++ b/core/store/modules/product/actions.js
@@ -179,7 +179,7 @@ export default {
           }
           context.state.current_configuration[attr.attribute_code] = confVal
           // @deprecated fallback for VS <= 1.0RC
-          if (!('setupVariantAttributesByCode' in config.products) || config.products.setupVariantAttributesByCode === false) {
+          if (!('setupVariantByAttributeCode' in config.products) || config.products.setupVariantByAttributeCode === false) {
             const fallbackKey = attr.frontend_label ? attr.frontend_label : attr.default_frontend_label
             context.state.current_configuration[fallbackKey.toLowerCase()] = confVal // @deprecated fallback for VS <= 1.0RC
           }

--- a/core/store/modules/product/actions.js
+++ b/core/store/modules/product/actions.js
@@ -178,8 +178,11 @@ export default {
             label: optionLabel(context.rootState.attribute, { attributeKey: selectedOption.attribute_code, searchBy: 'code', optionId: selectedOption.value })
           }
           context.state.current_configuration[attr.attribute_code] = confVal
-          const fallbackKey = attr.frontend_label ? attr.frontend_label : attr.default_frontend_label
-          context.state.current_configuration[fallbackKey.toLowerCase()] = confVal // @deprecated fallback for VS <= 1.0RC
+          // @deprecated fallback for VS <= 1.0RC
+          if (!('setupVariantAttributesByCode' in config.products) || config.products.setupVariantAttributesByCode === false) {
+            const fallbackKey = attr.frontend_label ? attr.frontend_label : attr.default_frontend_label
+            context.state.current_configuration[fallbackKey.toLowerCase()] = confVal // @deprecated fallback for VS <= 1.0RC
+          }
         }
       }).catch(err => {
         console.error(err)


### PR DESCRIPTION
Fix for product attributes with similar names that are broken when referencing by label. This allows using attribute_code rather than the attribute label.