### PR TITLE
use main image when no configurable children image

### DIFF
--- a/core/store/helpers/index.js
+++ b/core/store/helpers/index.js
@@ -34,7 +34,8 @@ export function breadCrumbRoutes (categoryPath) {
 export function productThumbnailPath (product, ignoreConfig = false) {
   let thumbnail = product.image
   if ((product.type_id && product.type_id === 'configurable') && product.hasOwnProperty('configurable_children') &&
-    product.configurable_children.length && (ignoreConfig || !product.is_configured)
+    product.configurable_children.length && (ignoreConfig || !product.is_configured) &&
+    ('image' in product.configurable_children[0])
   ) {
     thumbnail = product.configurable_children[0].image
   }


### PR DESCRIPTION
We don't have images for our configurable_children so when products load there's no image.  This was added so you can have configurable products with only main images.