### PR TITLE
add proceed to checkout action to add to cart notification

### DIFF
--- a/core/components/Notification.vue
+++ b/core/components/Notification.vue
@@ -27,6 +27,11 @@ export default {
       switch (action) {
         case 'close':
           this.notifications.splice(id, 1)
+          break
+        case 'goToCheckout':
+          this.$router.push('/checkout')
+          this.notifications.splice(id, 1)
+          break
       }
     }
   }

--- a/core/store/modules/cart/actions.js
+++ b/core/store/modules/cart/actions.js
@@ -224,7 +224,8 @@ export default {
           EventBus.$emit('notification', {
             type: 'success',
             message: i18n.t('Product has been added to the cart!'),
-            action1: { label: 'OK', action: 'close' }
+            action1: { label: 'OK', action: 'close' },
+            action2: { label: 'Proceed to checkout', action: 'goToCheckout' }
           })
         }
       })

--- a/src/themes/default/components/core/Notification.vue
+++ b/src/themes/default/components/core/Notification.vue
@@ -15,11 +15,19 @@
         <div class="message p20">
           {{ notification.message }}
         </div>
-        <div
-          class="actions py10 px20 pointer weight-400 uppercase"
-          @click="action(notification.action1.action, index)"
-        >
-          {{ notification.action1.label }}
+        <div class="actions">
+          <div
+            class="py10 px20 pointer weight-400 uppercase"
+            @click="action(notification.action1.action, index)"
+          >
+            {{ notification.action1.label }}
+          </div>
+          <div
+            class="py10 px20 pointer weight-400 uppercase"
+            @click="action(notification.action2.action, index)"
+          >
+            {{ notification.action2.label }}
+          </div>
         </div>
       </div>
     </transition-group>
@@ -71,8 +79,10 @@ $color-action: color(black);
     margin-top: 0;
   }
 }
+
 .actions {
   background: rgba($color-action, .2);
+  display: flex;
 }
 .success {
   background: $color-success;


### PR DESCRIPTION
**Ref:** #897
 
**Changes:**
add action2 goToCheckout (and btn to add to cart notification) that redirect to checkout page

**Before:**
![before-desktop](https://user-images.githubusercontent.com/7412776/39061974-7a24bb3a-449c-11e8-85d4-73fbe0ad3b05.png)
![before-mobile](https://user-images.githubusercontent.com/7412776/39061975-7a5eb6c8-449c-11e8-8cd9-f5ccb1fc0e86.png)

**After:**
<img width="262" alt="after-desktop" src="https://user-images.githubusercontent.com/7412776/39061976-7dc86a52-449c-11e8-82fc-3066d5fee06e.png">
![after-desktop2](https://user-images.githubusercontent.com/7412776/39061977-7de3308a-449c-11e8-99b3-ac946281f7db.png)

