### PR TITLE
Fixes #954: Better heading spacing for headers.

### DIFF
--- a/src/themes/default/css/base/_text.scss
+++ b/src/themes/default/css/base/_text.scss
@@ -33,6 +33,13 @@ h2,
 h3,
 .h3 {
   font-size: 24px;
+  margin-top: 35px;
+  margin-bottom: 10px;
+
+  @media  (min-width: 767px) {
+      margin-top: 40px;
+      margin-bottom: 25px;
+  }
 }
 h4,
 .h4 {


### PR DESCRIPTION
Took a quick look at #954. I read up on atomic CSS but it seems that because this is loaded from markdown files through StaticContent element, I can't do this through the use of classes on elements. Is that correct?

So I went with the route of doing this in the _text.scss file as my best guess. The original ticket wasn't clear, maybe i'll want to restrict this to h3's within static-content class? And maybe I want to consider other header elements. 

Anyway, I don't expect this PR to be approved without some changes but it'll start a conversation at least!

<img width="962" alt="screen shot 2018-04-21 at 13 55 37" src="https://user-images.githubusercontent.com/553566/39088742-56d5c176-456c-11e8-9c85-554d46a9133e.png">
<img width="485" alt="screen shot 2018-04-21 at 13 55 46" src="https://user-images.githubusercontent.com/553566/39088743-56f7064c-456c-11e8-9dea-bd3e83f1a010.png">
