### PR TITLE
Work on #912. Add validation to personal details form.

### DIFF
--- a/core/components/blocks/Checkout/PersonalDetails.vue
+++ b/core/components/blocks/Checkout/PersonalDetails.vue
@@ -6,6 +6,7 @@
 
 <script>
 import { mapState } from 'vuex'
+import i18n from 'core/lib/i18n'
 
 export default {
   name: 'PersonalDetails',
@@ -33,9 +34,19 @@ export default {
   methods: {
     sendDataToCheckout () {
       if (this.createAccount) {
+        if (this.$v.$invalid) {
+          this.$v.$touch()
+          this.validationError()
+          return
+        }
         this.personalDetails.password = this.password
         this.personalDetails.createAccount = true
       } else {
+        if (this.$v.personalDetails.$invalid) {
+          this.$v.personalDetails.$touch()
+          this.validationError()
+          return
+        }
         this.personalDetails.createAccount = false
       }
       this.$bus.$emit('checkout-after-personalDetails', this.personalDetails, this.$v)
@@ -49,6 +60,13 @@ export default {
     },
     gotoAccount () {
       this.$bus.$emit('modal-show', 'modal-signup')
+    },
+    validationError () {
+      this.$bus.$emit('notification', {
+        type: 'error',
+        message: i18n.t('Please fix the validation errors'),
+        action1: { label: 'OK', action: 'close' }
+      })
     }
   },
   created () {

--- a/src/themes/default/components/core/blocks/Checkout/PersonalDetails.vue
+++ b/src/themes/default/components/core/blocks/Checkout/PersonalDetails.vue
@@ -154,7 +154,6 @@
           <div class="col-xs-12 col-md-8 col-lg-6 my30 px20 button-container">
             <button-full
               @click.native="sendDataToCheckout"
-              :class="{ 'button-disabled' : (createAccount ? $v.$invalid : $v.personalDetails.$invalid) }"
             >
               {{ $t('Continue to shipping') }}
             </button-full>


### PR DESCRIPTION
To achieve this we remove the disabling of the button and instead on click, check the form validation and add a validation error message if needed. This follows the user experience that's currently on the account registration page.

Again, not written vue before so let me know if this is the right sort of approach to solve this problem. If it is, or I get advice on a better way of approaching it, I can implement the other checkout steps.

<img width="359" alt="screen shot 2018-04-21 at 15 32 14" src="https://user-images.githubusercontent.com/553566/39089327-4183f178-4579-11e8-862a-3e15c0184f54.png">
<img width="376" alt="screen shot 2018-04-21 at 15 32 21" src="https://user-images.githubusercontent.com/553566/39089328-434467ea-4579-11e8-93d4-8106c9a2e3c4.png">
