### PR TITLE
Added misssing host var to app.listen

### DIFF
--- a/core/scripts/server.js
+++ b/core/scripts/server.js
@@ -96,6 +96,6 @@ app.get('*', (req, res) => {
 
 const port = process.env.PORT || config.server.port
 const host = process.env.HOST || config.server.host
-app.listen(port, () => {
+app.listen(port, host, () => {
   console.log(`Vue Storefront Server started at http://${host}:${port}`)
 })


### PR DESCRIPTION
The host variable is missing, so vue storefront is always starting on localhost.