### PR TITLE
Notification name change ('cart-after' -> 'notification-after')

### DIFF
--- a/core/components/Notification.vue
+++ b/core/components/Notification.vue
@@ -27,7 +27,7 @@ export default {
   },
   methods: {
     action (action, id) {
-      this.$bus.$emit('cart-after-' + action, id)
+      this.$bus.$emit('notification-after-' + action, id)
       switch (action) {
         case 'close':
           this.notifications.splice(id, 1)


### PR DESCRIPTION
Issue #1105  

The changing of the event name is rather straightforward, however what about the default link action? @pkarw 