### PR TITLE
esc key in image zoom popup + few minor frontend improvements

### DIFF
--- a/core/components/ProductGallery.js
+++ b/core/components/ProductGallery.js
@@ -37,6 +37,10 @@ export default {
       this.selectVariant()
       this.$forceUpdate()
     }, 0)
+    document.addEventListener('keydown', this.handleEscKey)
+  },
+  beforeDestroy () {
+    document.removeEventListener('keydown', this.handleEscKey)
   },
   methods: {
     navigate (index) {
@@ -57,6 +61,11 @@ export default {
       setTimeout(() => {
         this.navigate(this.$refs.carousel.currentPage)
       }, 1)
+    },
+    handleEscKey (event) {
+      if (this.isZoomOpen && event.keyCode === 27) {
+        this.toggleZoom()
+      }
     }
   }
 }

--- a/src/themes/default/components/core/blocks/Form/BaseCheckbox.vue
+++ b/src/themes/default/components/core/blocks/Form/BaseCheckbox.vue
@@ -46,6 +46,7 @@ export default {
   $color-white: color(white);
 
   label {
+    user-select: none;
     &:before {
       content: '';
       position: absolute;
@@ -63,6 +64,7 @@ export default {
     position: absolute;
     top: 3px;
     left: 0;
+    opacity: 0;
     &:checked + label {
       &:before {
         background-color: $color-silver;
@@ -93,6 +95,8 @@ export default {
     }
     &:disabled + label {
       cursor: not-allowed;
+      opacity: 0.5;
+      pointer-events: none;
       &:hover,
       &:focus {
         &:before {

--- a/src/themes/default/components/core/blocks/Form/BaseInput.vue
+++ b/src/themes/default/components/core/blocks/Form/BaseInput.vue
@@ -67,18 +67,26 @@ export default {
   $color-hover: color(tertiary, $colors-background);
 
   input {
-   // transition: 0.3s all;
+    background: inherit;
+
     &:hover,
     &:focus {
       outline: none;
       border-color: $color-puerto-rico;
     }
-    background: inherit;
+
+    &:disabled,
+    &:disabled + label {
+      opacity: 0.5;
+      cursor: not-allowed;
+      pointer-events: none;
+    }
   }
   label {
     color:#999;
     position:absolute;
     pointer-events:none;
+    user-select: none;
     left:5px;
     top: 10px;
     transition:0.2s ease all;

--- a/src/themes/default/components/core/blocks/MainSlider/MainSlider.vue
+++ b/src/themes/default/components/core/blocks/MainSlider/MainSlider.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="main-slider w-100 bg-cl-th-accent cl-white">
     <no-ssr>
-      <carousel :per-page="1" pagination-active-color="transparent" pagination-color="#F2F2F2">
+      <carousel :per-page="1" pagination-active-color="#ffffff" pagination-color="#e0e0e0">
         <slide v-for="(slide, index) in slides" :key="index">
           <div class="container w-100" v-lazy:background-image="slide.image">
             <div class="row middle-xs center-xs">


### PR DESCRIPTION
1. ESC key now closes image zoom popup - closes #1123.
2. Active dot in MainSlider was transparent - now all dots are colored.
3. Fixed partly visible default checkbox in some browsers and added styles for disabled checkbox and input.