### PR TITLE
Update lazy loading library and fix images switching between product variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vue-analytics": "^5.8.0",
     "vue-carousel": "^0.6.9",
     "vue-i18n": "^7.4.2",
-    "vue-lazyload": "^1.2.3",
+    "vue-lazyload": "^1.2.6",
     "vue-meta": "^1.4.3",
     "vue-no-ssr": "^0.2.2",
     "vue-observe-visibility": "^0.3.1",

--- a/src/themes/default/components/core/ProductGallery.vue
+++ b/src/themes/default/components/core/ProductGallery.vue
@@ -20,8 +20,8 @@
           <div class="thumbnails">
             <div
               class="bg-cl-secondary"
-              v-for="(images, key) in gallery"
-              :key="key">
+              v-for="images in gallery"
+              :key="images.src">
               <transition name="fade" appear>
                 <img
                   v-lazy="images"
@@ -55,8 +55,8 @@
               ref="carousel"
             >
               <slide
-                v-for="(images, key) in gallery"
-                :key="key">
+                v-for="images in gallery"
+                :key="images.src">
                 <div class="bg-cl-secondary">
                   <img
                     class="product-image inline-flex pointer mw-100"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3113,17 +3113,6 @@ ejs@^2.5.9:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
 
-elasticsearch@^14.2.2:
-  version "14.2.2"
-  resolved "https://registry.yarnpkg.com/elasticsearch/-/elasticsearch-14.2.2.tgz#6bbb63b19b17fa97211b22eeacb0f91197f4d6b6"
-  dependencies:
-    agentkeepalive "^3.4.1"
-    chalk "^1.0.0"
-    lodash "2.4.2"
-    lodash.get "^4.4.2"
-    lodash.isempty "^4.4.0"
-    lodash.trimend "^4.5.1"
-
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.47:
   version "1.3.48"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz#d3b0d8593814044e092ece2108fc3ac9aea4b900"
@@ -5861,10 +5850,6 @@ lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -5872,10 +5857,6 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-
-lodash.isempty@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
@@ -5918,10 +5899,6 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash.trimend@^4.5.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/lodash.trimend/-/lodash.trimend-4.5.1.tgz#12804437286b98cad8996b79414e11300114082f"
-
 lodash.union@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
@@ -5933,10 +5910,6 @@ lodash.uniq@^4.5.0, lodash.uniq@~4.5.0:
 lodash.without@~4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
-
-lodash@2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
 
 lodash@4.17.4:
   version "4.17.4"
@@ -9949,9 +9922,9 @@ vue-i18n@^7.4.2:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-7.8.0.tgz#fa49c3f90d20edab2048e9ef825774d39f1906d9"
 
-vue-lazyload@^1.2.3:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/vue-lazyload/-/vue-lazyload-1.2.4.tgz#e6c8de1e6e11ef6f61a9bbcee508b893586215ef"
+vue-lazyload@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/vue-lazyload/-/vue-lazyload-1.2.6.tgz#baa04c172d52a812608eb12c7a6bfb14f5c91079"
 
 vue-loader@^15.1.0:
   version "15.2.4"


### PR DESCRIPTION
Updating lazy loading library seems to fix issue with some images failing to load.
Also changed keys in gallery carousel to correctly replace nodes when changing product variant.