### PR TITLE
Wrong validation for Zip-code field

### DIFF
--- a/src/themes/default/components/core/blocks/MyAccount/MyShippingDetails.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyShippingDetails.vue
@@ -259,7 +259,7 @@ export default {
       },
       postcode: {
         required,
-        minLength: minLength(5)
+        minLength: minLength(3)
       },
       city: {
         required


### PR DESCRIPTION
Changed minLength validation property value for postcode in My Shipping Details page. It didn't comply with the validation error message.
https://github.com/DivanteLtd/vue-storefront/issues/1372