### PR TITLE
Fix link typo in documentation 'Working with Vuex'

### DIFF
--- a/doc/data/Working with Vuex.md
+++ b/doc/data/Working with Vuex.md
@@ -1,6 +1,6 @@
 # Working with Vuex
 
-All data processing and remote requests should be managed by Vuex data stores. Core module contains more than [10 default data stores](https://github.com/DivanteLtd/vue-storefront/tree/master/core/store/modules) and can be easily extended by [store extensions].(https://github.com/DivanteLtd/vue-storefront/blob/master/doc/extensions/Working%20with%20extensions.md)
+All data processing and remote requests should be managed by Vuex data stores. Core module contains more than [10 default data stores](https://github.com/DivanteLtd/vue-storefront/tree/master/core/store/modules) and can be easily extended by [store extensions](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/extensions/Working%20with%20extensions.md).
 You can modify the existing store actions by responding to events. Events are specified in the docs below and could be found in the [core module](https://github.com/DivanteLtd/vue-storefront/tree/master/core), where `EventBus.$emit` has been mostly used for Vuex Actions.
 
 **You should put all the REST calls, Elasticsearch data queries inside the Vuex Actions**. This is our default design pattern for managing the data.


### PR DESCRIPTION
I'm aware that Pull Requests should be directed to *develop* branch (according to [Contributing instructions](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)).
However it's a typo fix in documentation and maybe it would be good to place it directly in master. 
Please let me know if this PR should directed to *develop* branch or may stay as is.