### PR TITLE
Feature/preselect country based on browser language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1] - 2018-07-02
+## [1.1.0] - 2018-07-02
+
+Please keep an eye on the **[UPGRADE NOTES](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/Upgrade%20notes.md)**
+
 ### Fixed
 - Zip Code validation [#1372]
 - Get inpspired block [#968]

--- a/core/components/blocks/Checkout/Payment.js
+++ b/core/components/blocks/Checkout/Payment.js
@@ -182,7 +182,8 @@ export default {
     },
     getDefaultCountryCode () {
       if (window.navigator && window.navigator.language) {
-        return window.navigator.language.slice(3).toUpperCase()
+        var lang = window.navigator.language.toUpperCase()
+        return (lang.length === 2) ? lang : lang.slice(3)
       }
     },
     getPaymentMethod () {

--- a/core/components/blocks/Checkout/Payment.js
+++ b/core/components/blocks/Checkout/Payment.js
@@ -41,6 +41,10 @@ export default {
       }
     }
     this.changePaymentMethod()
+
+    if (!this.payment.country) {
+      this.payment.country = this.getDefaultCountryCode()
+    }
   },
   methods: {
     sendDataToCheckout () {
@@ -175,6 +179,11 @@ export default {
         }
       }
       return ''
+    },
+    getDefaultCountryCode () {
+      if (window.navigator && window.navigator.language) {
+        return window.navigator.language.slice(3).toUpperCase()
+      }
     },
     getPaymentMethod () {
       for (let i = 0; i < this.paymentMethods.length; i++) {

--- a/core/components/blocks/Checkout/Shipping.js
+++ b/core/components/blocks/Checkout/Shipping.js
@@ -140,6 +140,11 @@ export default {
         return window.navigator.language.slice(3).toUpperCase()
       }
     },
+    getCurrentShippingMethod () {
+      let shippingCode = this.shipping.shippingMethod
+      let currentMethod = this.shippingMethods.find(item => item.method_code === shippingCode)
+      return currentMethod
+    },
     changeShippingMethod () {
       let currentShippingMethod = this.getCurrentShippingMethod()
       if (currentShippingMethod) {

--- a/core/components/blocks/Checkout/Shipping.js
+++ b/core/components/blocks/Checkout/Shipping.js
@@ -55,6 +55,14 @@ export default {
       }
       this.shipping.shippingMethod = shipping.method_code
     }
+
+    if (!this.myAddressDetails.country) {
+      this.myAddressDetails.country = this.getDefaultCountryCode()
+    }
+
+    if (!this.shipping.country) {
+      this.shipping.country = this.getDefaultCountryCode()
+    }
   },
   methods: {
     sendDataToCheckout () {
@@ -127,10 +135,10 @@ export default {
     changeCountry () {
       this.$bus.$emit('checkout-before-shippingMethods', this.shipping.country)
     },
-    getCurrentShippingMethod () {
-      let shippingCode = this.shipping.shippingMethod
-      let currentMethod = this.shippingMethods.find(item => item.method_code === shippingCode)
-      return currentMethod
+    getDefaultCountryCode () {
+      if (window.navigator && window.navigator.language) {
+        return window.navigator.language.slice(3).toUpperCase()
+      }
     },
     changeShippingMethod () {
       let currentShippingMethod = this.getCurrentShippingMethod()

--- a/core/components/blocks/Checkout/Shipping.js
+++ b/core/components/blocks/Checkout/Shipping.js
@@ -137,7 +137,8 @@ export default {
     },
     getDefaultCountryCode () {
       if (window.navigator && window.navigator.language) {
-        return window.navigator.language.slice(3).toUpperCase()
+        var lang = window.navigator.language.toUpperCase()
+        return (lang.length === 2) ? lang : lang.slice(3)
       }
     },
     getCurrentShippingMethod () {

--- a/cypress/integration/basic-client-path.js
+++ b/cypress/integration/basic-client-path.js
@@ -21,6 +21,10 @@ describe('basic client path', () => {
     cy.get('[name=city]').type('Wroclaw', { force: true })
     cy.get('[name=state]').type('Lowersilesian', { force: true })
     cy.get('[name=zip-code').type('50-000', { force: true })
+    cy.window().then((window) => {
+      let country = window.navigator.language.slice(3).toUpperCase()
+      cy.get('[name=countries]').should('have.value', country)
+    })
     cy.get('[name=countries]').select('PL', { force: true })
     cy.get('[name=phone-number]').type('111 222 333', { force: true })
     cy.get('[data-testid=shippingSubmit]').click({ force: true })

--- a/src/themes/default/components/core/blocks/MyAccount/MyShippingDetails.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyShippingDetails.vue
@@ -279,8 +279,10 @@ export default {
   methods: {
     countryCodeFallback (country) {
       if (!country && window.navigator && window.navigator.language) {
-        return window.navigator.language.slice(3).toUpperCase()
+        var lang = window.navigator.language.toUpperCase()
+        return (lang.length === 2) ? lang : lang.slice(3)
       }
+
       return country
     }
   }

--- a/src/themes/default/components/core/blocks/MyAccount/MyShippingDetails.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyShippingDetails.vue
@@ -137,32 +137,21 @@
           ]"
         />
 
-        <div class="col-xs-12 col-sm-6 mb25">
-          <select
-            name="countries"
-            autocomplete="country-name"
-            v-model="shippingDetails.country"
-            :class="{ 'cl-tertiary' : !shippingDetails.country || shippingDetails.country.length === 0 }"
-          >
-            <option value="" disabled selected hidden>
-              {{ `${$t('Country')} *` }}
-            </option>
-            <option
-              v-for="country in countries"
-              :key="country.code"
-              :value="country.code"
-              class="cl-black"
-            >
-              {{ country.name }}
-            </option>
-          </select>
-          <span
-            class="validation-error"
-            v-if="!$v.shippingDetails.country.required && $v.shippingDetails.country.$error"
-          >
-            {{ $t('Field is required') }}
-          </span>
-        </div>
+        <base-select
+          class="col-xs-12 col-sm-6 mb25"
+          name="countries"
+          autocomplete="country-name"
+          :options="countryOptions"
+          :selected="countryCodeFallback(shippingDetails.country)"
+          :placeholder="$t('Country *')"
+          :validations="[
+            {
+              condition: $v.shippingDetails.country.$error && !$v.shippingDetails.country.required,
+              text: $t('Field is required')
+            }
+          ]"
+          v-model="shippingDetails.country"
+        />
 
         <base-input
           class="col-xs-12 col-sm-6 mb25"
@@ -239,13 +228,15 @@ import ButtonFull from 'theme/components/theme/ButtonFull'
 import Tooltip from 'theme/components/core/Tooltip'
 import BaseCheckbox from 'theme/components/core/blocks/Form/BaseCheckbox'
 import BaseInput from 'theme/components/core/blocks/Form/BaseInput'
+import BaseSelect from 'theme/components/core/blocks/Form/BaseSelect'
 
 export default {
   components: {
     ButtonFull,
     Tooltip,
     BaseCheckbox,
-    BaseInput
+    BaseInput,
+    BaseSelect
   },
   mixins: [MyShippingDetails],
   validations: {
@@ -273,6 +264,25 @@ export default {
       city: {
         required
       }
+    }
+  },
+  computed: {
+    countryOptions () {
+      return this.countries.map((item) => {
+        return {
+          value: item.code,
+          label: item.name
+        }
+      })
+    }
+  },
+  methods: {
+    countryCodeFallback (country) {
+      debugger
+      if (!country && window.navigator && window.navigator.language) {
+        return window.navigator.language.slice(3).toUpperCase()
+      }
+      return country
     }
   }
 }

--- a/src/themes/default/components/core/blocks/MyAccount/MyShippingDetails.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyShippingDetails.vue
@@ -278,7 +278,6 @@ export default {
   },
   methods: {
     countryCodeFallback (country) {
-      debugger
       if (!country && window.navigator && window.navigator.language) {
         return window.navigator.language.slice(3).toUpperCase()
       }


### PR DESCRIPTION
Adds default country select functionality according to issue: [#312 Add default user's country selection based on browser language](https://github.com/DivanteLtd/vue-storefront/issues/312)

Read the last two characters from navigation.language and preselect country selects in checkout and my account accordingly.

Example:
Users with a German browser would have de-DE as a language. This would select Germany by default.
sv-SE => Sweden
en-UK => United kingdom

### Before & after:
##### Checkout Shipping
![shipping-after](https://user-images.githubusercontent.com/329627/42132934-52e8f686-7d21-11e8-9565-08abe8d11979.png)

##### Checkout Shipping (before) (before)
![shipping-before](https://user-images.githubusercontent.com/329627/42132941-676b4b40-7d21-11e8-8cb0-cefcfbc1058e.png)

##### Checkout Payments (after)
![payment-after](https://user-images.githubusercontent.com/329627/42132953-cab11680-7d21-11e8-87da-624263de3d4f.png)

##### Checkout Payments (before)
![payment-before](https://user-images.githubusercontent.com/329627/42132942-6b9ed65a-7d21-11e8-9f8e-52cbe8c734c4.png)

##### My account shipping details (after)
![myaccount-shippingdetails-after](https://user-images.githubusercontent.com/329627/42132940-62fccf84-7d21-11e8-8564-c5de2b3ae646.png)


##### My account shipping details (before)
![myaccount-shippingdetails-before](https://user-images.githubusercontent.com/329627/42132951-c05f0c3c-7d21-11e8-82b6-f5b4a99e0ba4.png)