### PR TITLE
defaultSotreCode check in the localizedRoute()

### DIFF
--- a/core/store/lib/multistore.js
+++ b/core/store/lib/multistore.js
@@ -54,7 +54,7 @@ export function adjustMultistoreApiUrl (url) {
 }
 
 export function localizedRoute (routeObj, storeCode) {
-  if (storeCode && routeObj) {
+  if (storeCode && routeObj && config.defaultStoreCode !== storeCode) {
     if (typeof routeObj === 'object') {
       if (routeObj.name) {
         routeObj.name = storeCode + '-' + routeObj.name


### PR DESCRIPTION
Fix for the multistore - multitenant installation (to allow users not add "/en", "/de" .. prefix to the url when config.defaultStoreCode set)