### PR TITLE
[Bug #1326] the photo is not changing to the currently color

### DIFF
--- a/core/pages/Product.js
+++ b/core/pages/Product.js
@@ -47,16 +47,6 @@ export default {
     },
     gallery () {
       let images = []
-      if (this.product.media_gallery) {
-        for (let mediaItem of this.product.media_gallery) {
-          if (mediaItem.image) {
-            images.push({
-              'src': this.getThumbnail(mediaItem.image, 600, 744),
-              'loading': this.getThumbnail(this.product.image, 310, 300)
-            })
-          }
-        }
-      }
       let variantsGroupBy = config.products.galleryVariantsGroupAttribute
       if (this.product.configurable_children && this.product.configurable_children.length > 0 && this.product.configurable_children[0][variantsGroupBy]) {
         let groupedByAttribute = groupBy(this.product.configurable_children, child => {


### PR DESCRIPTION
The bug depended on the fact that some products  (es. https://demo.vuestorefront.io/p/WP13/portia-capri-1908/WP13) had the value media_gallery for the configurable. In these products the gallery images were added to the slideshow regardless of the "galleryVariantsGroupAttribute" configuration and had no reference to the color. 

Now the demo works but we only handle the images of simple products (grouped by configuration).

Now in task # 1327 I will list all the other possible cases so we decide how to manage them