### PR TITLE
Google Lighthouse test: minor issues

### DIFF
--- a/src/themes/default/assets/manifest.json
+++ b/src/themes/default/assets/manifest.json
@@ -1,5 +1,5 @@
 {
-    "short_name": "Vue Storefront",
+    "short_name": "VSF Demo",
     "name": "Vue Storefront",
     "background_color": "#ffffff",
     "display": "standalone",

--- a/src/themes/default/css/base/_text.scss
+++ b/src/themes/default/css/base/_text.scss
@@ -1,6 +1,6 @@
 // Global styles for text
 body {
-  font-size: 14px;
+  font-size: 16px;
   font-family: 'Roboto', sans-serif;
   font-weight: 400;
 }

--- a/src/themes/default/resource/head.js
+++ b/src/themes/default/resource/head.js
@@ -6,7 +6,7 @@ export default {
   },
   meta: [
     { charset: 'utf-8' },
-    { vmid: 'description', description: 'Vue Storefront is a standalone PWA storefront for your eCommerce, possible to connect with any eCommerce backend (eg. Magento, Prestashop or Shopware) through the API.' },
+    { vmid: 'description', name: 'description', content: 'Vue Storefront is a standalone PWA storefront for your eCommerce, possible to connect with any eCommerce backend (eg. Magento, Prestashop or Shopware) through the API.' },
     { name: 'viewport', content: 'width=device-width, initial-scale=1, minimal-ui' },
     { name: 'mobile-web-app-capable', content: 'yes' },
     { name: 'theme-color', content: '#ffffff' },

--- a/src/themes/theme-starter/assets/manifest.json
+++ b/src/themes/theme-starter/assets/manifest.json
@@ -1,5 +1,5 @@
 {
-    "short_name": "Vue Storefront",
+    "short_name": "VSF Demo",
     "name": "Vue Storefront - theme starter",
     "background_color": "#ffffff",
     "display": "standalone",

--- a/src/themes/theme-starter/resource/head.js
+++ b/src/themes/theme-starter/resource/head.js
@@ -6,7 +6,7 @@ export default {
   },
   meta: [
     { charset: 'utf-8' },
-    { vmid: 'description', description: 'Vue Storefront is a standalone PWA storefront for your eCommerce, possible to connect with any eCommerce backend (eg. Magento, Prestashop or Shopware) through the API.' },
+    { vmid: 'description', name: 'description', content: 'Vue Storefront is a standalone PWA storefront for your eCommerce, possible to connect with any eCommerce backend (eg. Magento, Prestashop or Shopware) through the API.' },
     { name: 'viewport', content: 'width=device-width, initial-scale=1, minimal-ui' },
     { name: 'mobile-web-app-capable', content: 'yes' },
     { name: 'theme-color', content: '#f60' },


### PR DESCRIPTION
The Lighthouse test (https://developers.google.com/web/tools/lighthouse/#devtools) complains about two things:
- Missing meta description
- Default font size should be 16px

In addition "best practise" is to have at most 12 characters for the short_name in the manifest.

The pull requests fixes the three issues which increases the overall Lighthouse score.