### PR TITLE
Issue #1395: Fix the SearchPanel query

### DIFF
--- a/core/components/blocks/SearchPanel/SearchPanel.js
+++ b/core/components/blocks/SearchPanel/SearchPanel.js
@@ -36,12 +36,16 @@ export default {
         query = query.andQuery('match', 'stock.is_in_stock', true)
       }
 
-      query = query.andQuery('bool', b => b.orQuery('match', 'name', { query: queryText, boost: 3 })
-        .orQuery('match', 'category.name', { query: queryText, boost: 1 })
-        .orQuery('match', 'sku', { query: queryText, boost: 1 })
-        .orQuery('match', 'configurable_children.sku', { query: queryText, boost: 1 })
-        .orQuery('match', 'short_description', { query: queryText, boost: 2 })
-        .orQuery('match', 'description', { query: queryText, boost: 1 }))
+      query = query.andQuery('bool', b => b.orQuery('match_phrase_prefix', 'name', { query: queryText, boost: 3, slop: 2 })
+        .orQuery('match_phrase', 'category.name', { query: queryText, boost: 1 })
+        .orQuery('match_phrase', 'short_description', { query: queryText, boost: 1 })
+        .orQuery('match_phrase', 'description', { query: queryText, boost: 1 })
+        .orQuery('bool', b => b.orQuery('terms', 'sku', queryText.split('-'))
+          .orQuery('terms', 'configurable_children.sku', queryText.split('-'))
+          .orQuery('match_phrase', 'sku', { query: queryText, boost: 1 })
+          .orQuery('match_phrase', 'configurable_children.sku', { query: queryText, boost: 1 }))
+      )
+
       query = query.build()
 
       this.$store.dispatch('product/list', { query, start, size, updateState: false }).then((resp) => {


### PR DESCRIPTION
There is problem with SKU fields which have dashes and elastic use dash as default symbol to split phrases. I've tried to change SKu field mapping in VS Api but this not working so solution for this is to use terms query and split queryText by dash.