### PR TITLE
[SCSS] Adding brdr-right & brdr-left in _border.scss

### DIFF
--- a/src/themes/default/css/layout/_border.scss
+++ b/src/themes/default/css/layout/_border.scss
@@ -20,6 +20,14 @@ $border-radius: (
       border-bottom-width: #{$i}px;
       border-bottom-style: solid;
     }
+    .brdr-left-#{$i} {
+      border-left-width: #{$i}px;
+      border-left-style: solid;
+    }
+    .brdr-right-#{$i} {
+      border-right-width: #{$i}px;
+      border-right-style: solid;
+    }
   }
   @each $name, $value in $border-radius {
     .brdr-#{$name} {


### PR DESCRIPTION
Why is there only brdr-top and brdr-bottom ? 

So I added brdr-left and brdr-right in _border.scss

I hope there is ok for you