### PR TITLE
Improve the UI of Notifications pop up

### DIFF
--- a/src/themes/default/components/core/Notification.vue
+++ b/src/themes/default/components/core/Notification.vue
@@ -13,6 +13,7 @@
         }"
       >
         <div
+          @click="action(notification.action1.action, index)"
           class="message p20"
           data-testid="notificationMessage"
         >
@@ -20,14 +21,16 @@
         </div>
         <div class="actions">
           <div
-            class="py10 px20 pointer weight-400 uppercase"
+            class="py10 px20 pointer weight-400 notification-action uppercase"
+            id="notificationAction1"
             data-testid="notificationAction1"
             @click="action(notification.action1.action, index)"
           >
             {{ notification.action1.label }}
           </div>
           <div
-            class="py10 px20 pointer weight-400 uppercase"
+            class="py10 px20 pointer weight-400 notification-action align-center uppercase"
+            id="notificationAction2"
             data-testid="notificationAction2"
             @click="action(notification.action2.action, index)"
             v-if="notification.action2"
@@ -87,8 +90,20 @@ $color-action: color(black);
 }
 
 .actions {
-  background: rgba($color-action, .2);
   display: flex;
+  justify-content: space-between;
+
+  .notification-action {
+    background: rgba($color-action, .2);
+  }
+
+  #notificationAction1 {
+    border-right: 2px solid $color-success;
+  }
+
+  #notificationAction2 {
+    width: 100%;
+  }
 }
 .success {
   background: $color-success;


### PR DESCRIPTION
Updated the Notifications popup with new UI, to better differientiate the buttons. They are now separated by a border to indicate they perform different actions.
<img width="410" alt="zrzut ekranu 2018-08-03 o 14 40 52" src="https://user-images.githubusercontent.com/20928689/43643368-5c341b2a-972b-11e8-885b-dad662d98497.png">
