### PR TITLE
Revert "added notification after removed item"

### DIFF
--- a/core/store/modules/cart/actions.js
+++ b/core/store/modules/cart/actions.js
@@ -4,7 +4,6 @@ import rootStore from '../../'
 import EventBus from '../../lib/event-bus'
 import i18n from '../../lib/i18n'
 import hash from 'object-hash'
-import { htmlDecode } from '../../lib/filters'
 import { currentStoreView } from '../../lib/multistore'
 import omit from 'lodash-es/omit'
 const CART_PULL_INTERVAL_MS = 2000
@@ -276,12 +275,6 @@ export default {
       }) */
       dispatch('serverPull', { forceClientState: true })
     }
-
-    EventBus.$emit('notification', {
-      type: 'success',
-      message: i18n.t('Product {productName} has been removed from cart!', { productName: htmlDecode(product.name) }),
-      action1: {label: i18n.t('OK'), action: 'close'}
-    })
   },
   updateQuantity ({ commit, dispatch }, { product, qty, forceServerSilence = false }) {
     commit(types.CART_UPD_ITEM, { product, qty })


### PR DESCRIPTION
Reverts DivanteLtd/vue-storefront#1524

@bartdominiak after some tests + UX consideration i have to say that this notification is unnecessary; we should show notifications just for the actions that user can be not aware of or not sure the results; when you're removing item from the cart you see that item is being removed so it makes no sense to show additional notification for that action

Sorry for removing this feature :)