### PR TITLE
Fix/typescript config

### DIFF
--- a/core/build/webpack.base.config.js
+++ b/core/build/webpack.base.config.js
@@ -71,7 +71,7 @@ module.exports = {
       path.resolve(__dirname, extensionsRoot),
       path.resolve(__dirname, themesRoot)
     ],
-    extensions: ['.js', '.vue', 'ts'],
+    extensions: ['.js', '.vue', '.ts'],
     alias: {
       // Main aliases
       'config': path.resolve(__dirname, './config.json'),

--- a/src/themes/default/components/core/AddToCart.vue
+++ b/src/themes/default/components/core/AddToCart.vue
@@ -5,8 +5,8 @@
 </template>
 
 <script lang="ts">
-import Product from 'core/typings/Product.ts'
-import { formatProductMessages } from 'core/filters/product-messages/typed.ts'
+import Product from 'core/typings/Product'
+import { formatProductMessages } from 'core/filters/product-messages/typed'
 import focusClean from 'theme/components/theme/directives/focusClean'
 import ButtonFull from 'theme/components/theme/ButtonFull.vue'
 import addToCart from '@vue-storefront/core/components/AddToCart'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,12 @@
     "strict": false,
     "allowJs": true,
     "module": "commonjs",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "paths": {
+      "core/*": ["core/*"],
+      "theme/*": ["src/themes/default/*"], //needs testing with non-default theme!
+    }
   },
-  "files": [
-    "vue.d.ts"
-  ]
+  "files": ["vue.d.ts"]
 }


### PR DESCRIPTION
Based on to [#1538](https://github.com/DivanteLtd/vue-storefront/pull/1538) with some little fixes:

- added aliases to `tsconfig.json` to handle file imports nicely and prevent IDE error highlighting on imports;
- fixed `ts` extension in webpack config to be `.ts`
