### PR TITLE
reverted previous base-components event solution due to bug on safari

### DIFF
--- a/core/components/blocks/Form/BaseCheckbox.js
+++ b/core/components/blocks/Form/BaseCheckbox.js
@@ -1,15 +1,11 @@
 export default {
   name: 'BaseCheckbox',
-  model: {
-    prop: 'checked',
-    event: 'change'
-  },
   props: {
     id: {
       type: String,
       required: true
     },
-    checked: {
+    value: {
       type: Boolean,
       required: true
     },
@@ -22,14 +18,6 @@ export default {
       type: Boolean,
       required: false,
       default: false
-    }
-  },
-  computed: {
-    listeners () {
-      return {
-        ...this.$listeners,
-        change: event => this.$emit('change', event.target.checked)
-      }
     }
   }
 }

--- a/core/components/blocks/Form/BaseInput.js
+++ b/core/components/blocks/Form/BaseInput.js
@@ -69,14 +69,6 @@ export default {
       }
     }
   },
-  computed: {
-    listeners () {
-      return {
-        ...this.$listeners,
-        input: event => this.$emit('input', event.target.value)
-      }
-    }
-  },
   created () {
     if (this.type === 'password') {
       this.iconActive = true

--- a/core/components/blocks/Form/BaseRadiobutton.js
+++ b/core/components/blocks/Form/BaseRadiobutton.js
@@ -1,15 +1,11 @@
 export default {
   name: 'BaseRadiobutton',
-  model: {
-    prop: 'checked',
-    event: 'change'
-  },
   props: {
     id: {
       type: String,
       required: true
     },
-    checked: {
+    value: {
       type: Boolean,
       required: true
     },
@@ -22,14 +18,6 @@ export default {
       type: Boolean,
       required: false,
       default: false
-    }
-  },
-  computed: {
-    listeners () {
-      return {
-        ...this.$listeners,
-        change: event => this.$emit('change', event.target.checked)
-      }
     }
   }
 }

--- a/core/components/blocks/Form/BaseSelect.js
+++ b/core/components/blocks/Form/BaseSelect.js
@@ -1,9 +1,5 @@
 export default {
   name: 'BaseSelect',
-  model: {
-    prop: 'selected',
-    event: 'change'
-  },
   props: {
     id: {
       type: String,
@@ -38,14 +34,6 @@ export default {
       type: Array,
       required: false,
       default: () => []
-    }
-  },
-  computed: {
-    listeners () {
-      return {
-        ...this.$listeners,
-        change: event => this.$emit('change', event.target.value)
-      }
     }
   }
 }

--- a/core/components/blocks/Form/BaseTextarea.js
+++ b/core/components/blocks/Form/BaseTextarea.js
@@ -51,14 +51,6 @@ export default {
       default: () => []
     }
   },
-  computed: {
-    listeners () {
-      return {
-        ...this.$listeners,
-        input: event => this.$emit('input', event.target.value)
-      }
-    }
-  },
   mounted () {
     if (this.focus) {
       this.$refs[this.name].focus()

--- a/src/themes/default/components/core/blocks/Form/BaseCheckbox.vue
+++ b/src/themes/default/components/core/blocks/Form/BaseCheckbox.vue
@@ -5,8 +5,11 @@
         class="m0 no-outline"
         type="checkbox"
         :id="id"
-        :checked="checked"
-        v-on="listeners"
+        :checked="value"
+        @keyup.enter="$emit('click')"
+        @click="$emit('click')"
+        @blur="$emit('blur')"
+        @change="$emit('change')"
         :disabled="disabled"
       >
       <label

--- a/src/themes/default/components/core/blocks/Form/BaseInput.vue
+++ b/src/themes/default/components/core/blocks/Form/BaseInput.vue
@@ -12,8 +12,11 @@
         :autocomplete="autocomplete"
         :value="value"
         :autofocus="autofocus"
-        :ref="focus ? name : false"
-        v-on="listeners"
+        :ref="name"
+        @input="$emit('input', $event.target.value)"
+        @blur="$emit('blur')"
+        @keyup.enter="$emit('keyup.enter', $event.target.value)"
+        @keyup="$emit('keyup', $event)"
       >
       <label>{{ placeholder }}</label>
     </div>

--- a/src/themes/default/components/core/blocks/Form/BaseRadiobutton.vue
+++ b/src/themes/default/components/core/blocks/Form/BaseRadiobutton.vue
@@ -5,8 +5,11 @@
         class="m0 no-outline"
         type="radio"
         :id="id"
-        :checked="checked"
-        v-on="listeners"
+        :checked="value"
+        @keyup.enter="$emit('click')"
+        @click="$emit('click')"
+        @blur="$emit('blur')"
+        @change="$emit('change')"
         :disabled="disabled"
       >
       <label

--- a/src/themes/default/components/core/blocks/Form/BaseSelect.vue
+++ b/src/themes/default/components/core/blocks/Form/BaseSelect.vue
@@ -7,7 +7,9 @@
         'empty': !selected
       }"
       :autocomplete="autocomplete"
-      v-on="listeners"
+      @focus="$emit('focus');"
+      @blur="$emit('blur');"
+      @change="$emit('input', $event.target.value)"
     >
       <option v-if="!selected"/>
       <option

--- a/src/themes/default/components/core/blocks/Form/BaseTextarea.vue
+++ b/src/themes/default/components/core/blocks/Form/BaseTextarea.vue
@@ -13,7 +13,10 @@
         :value="value"
         :autofocus="autofocus"
         :ref="focus ? name : false"
-        v-on="listeners"
+        @input="$emit('input', $event.target.value)"
+        @blur="$emit('blur')"
+        @keyup.enter="$emit('keyup.enter', $event.target.value)"
+        @keyup="$emit('keyup', $event)"
       />
       <label>
         {{ placeholder }}


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/1529

### Short description and why it's useful

I reverted my changes in event management on in base components due to reported bug in Safari. I will work on this on my branch and push changes when I'll make sure that everything works fine.

### Contribution and curently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and adjusted my PR according to it (details in contribition rules)
