### PR TITLE
chore: compile core components with Babel

### DIFF
--- a/core/build/webpack.base.config.js
+++ b/core/build/webpack.base.config.js
@@ -112,7 +112,8 @@ module.exports = {
         loader: 'babel-loader',
         include: [
           '@vue-storefront',
-          path.resolve(__dirname, '../../src')
+          path.resolve(__dirname, '../../src'),
+          path.resolve(__dirname, '../../core')
         ]
       },
       {


### PR DESCRIPTION
### Related issues

### Short description and why it's useful

We still need to compile core components with Babel

### Screenshots of visual changes before/after (if there are any)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

### Contribution and curently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and adjusted my PR according to it (details in contribition rules)
