### PR TITLE
Fix to the transmuted !== null check

### DIFF
--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -252,7 +252,7 @@ EventBus.$on('sync/PROCESS_QUEUE', data => {
       console.debug('Current User token = ' + currentToken)
       console.debug('Current Cart token = ' + currentCartId)
       syncTaskCollection.iterate((task, id, iterationNumber) => {
-        if (!task.transmited && !mutex[id]) { // not sent to the server yet
+        if ((task.transmited !== null && !task.transmited) && !mutex[id]) { // not sent to the server yet
           mutex[id] = true // mark this task as being processed
           fetchQueue.push(() => {
             return execute(task, currentToken, currentCartId).then(executedTask => {


### PR DESCRIPTION
### Short description and why it's useful

In older Safari there was a JS interpreter error with this condition with TypeError pointing that's .transmited is null

### Contribution and curently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and adjusted my PR according to it (details in contribition rules)
