### PR TITLE
improvement/seo-image-alt-tags-on-product-page

### DIFF
--- a/core/components/ProductGallery.js
+++ b/core/components/ProductGallery.js
@@ -21,6 +21,10 @@ export default {
     offline: {
       type: Object,
       required: true
+    },
+    product: {
+      type: Object,
+      required: true
     }
   },
   data () {

--- a/src/themes/default/components/core/ProductGallery.vue
+++ b/src/themes/default/components/core/ProductGallery.vue
@@ -26,7 +26,7 @@
                 <img
                   v-lazy="images"
                   class="mw-100 pointer" ref="images" @click="navigate(key)"
-                  alt=""
+                  :alt="product.name | htmlDecode"
                 >
               </transition>
             </div>
@@ -39,7 +39,7 @@
               v-lazy="defaultImage"
               class="mw-100 pointer"
               ref="defaultImage"
-              alt=""
+              :alt="product.name | htmlDecode"
               itemprop="image"
             >
           </transition>
@@ -65,7 +65,7 @@
                     v-lazy="images"
                     ref="images"
                     @dblclick="toggleZoom"
-                    alt=""
+                    :alt="product.name | htmlDecode"
                     data-testid="productGalleryImage"
                     itemprop="image"
                   >

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -8,6 +8,7 @@
               :gallery="gallery"
               :offline="offlineImage"
               :configuration="configuration"
+              :product="product"
             />
           </div>
           <div class="col-xs-12 col-md-5 data">


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/1591

### Short description and why it's useful

Product page main photos now have proper alt attributes. This should improve slightly SEO for products in general.