### PR TITLE
fix/1601 incorrect productinfo

### DIFF
--- a/core/components/ProductAttribute.js
+++ b/core/components/ProductAttribute.js
@@ -16,7 +16,7 @@ export default {
   },
   computed: {
     label () {
-      return this.attribute.default_frontend_label
+      return (this.attribute && this.attribute.default_frontend_label) ? this.attribute.default_frontend_label : ''
     },
     value () {
       let parsedValues = this.product[this.attribute.attribute_code]
@@ -34,6 +34,8 @@ export default {
             })
             if (option) {
               results.push(option.label)
+            } else {
+              results.push(parsedVal)
             }
           } else {
             results.push(parsedVal)

--- a/core/components/ProductAttribute.js
+++ b/core/components/ProductAttribute.js
@@ -14,35 +14,33 @@ export default {
       default: ''
     }
   },
-  data () {
-    return {
-      label: '',
-      value: ''
-    }
-  },
-  beforeMount () {
-    this.label = this.attribute.default_frontend_label
-    let parsedValues = this.product[this.attribute.attribute_code]
+  computed: {
+    label () {
+      return this.attribute.default_frontend_label
+    },
+    value () {
+      let parsedValues = this.product[this.attribute.attribute_code]
 
-    if (!parsedValues) {
-      this.value = this.emptyPlaceholder
-    } else {
-      parsedValues = parsedValues.split(',')
-      let results = []
-      for (let parsedVal of parsedValues) {
-        if (this.attribute.options) {
-          let option = this.attribute.options.find(av => {
-            /* eslint eqeqeq: "off" */
-            return av.value == parsedVal
-          })
-          if (option) {
-            results.push(option.label)
+      if (!parsedValues) {
+        return this.emptyPlaceholder
+      } else {
+        parsedValues = parsedValues.split(',')
+        let results = []
+        for (let parsedVal of parsedValues) {
+          if (this.attribute.options) {
+            let option = this.attribute.options.find(av => {
+              /* eslint eqeqeq: "off" */
+              return av.value == parsedVal
+            })
+            if (option) {
+              results.push(option.label)
+            }
+          } else {
+            results.push(parsedVal)
           }
-        } else {
-          results.push(parsedVal)
         }
+        return results.join(', ')
       }
-      this.value = results.join(', ')
     }
   }
 }

--- a/src/themes/default/components/core/ProductAttribute.vue
+++ b/src/themes/default/components/core/ProductAttribute.vue
@@ -9,36 +9,6 @@
 import ProductAttribute from '@vue-storefront/core/components/ProductAttribute'
 
 export default {
-  mixins: [ProductAttribute],
-  computed: {
-    label () {
-      return (this.attribute && this.attribute.default_frontend_label) ? this.attribute.default_frontend_label : ''
-    },
-    value () {
-      let parsedValues = this.product[this.attribute.attribute_code]
-      if (!parsedValues) {
-        return this.emptyPlaceholder
-      } else {
-        parsedValues = parsedValues.split(',')
-        let results = []
-        for (let parsedVal of parsedValues) {
-          if (this.attribute.options) {
-            let option = this.attribute.options.find(av => {
-              /* eslint eqeqeq: "off" */
-              return av.value == parsedVal
-            })
-            if (option) {
-              results.push(option.label)
-            } else {
-              results.push(parsedVal)
-            }
-          } else {
-            results.push(parsedVal)
-          }
-        }
-        return results.join(', ')
-      }
-    }
-  }
+  mixins: [ProductAttribute]
 }
 </script>

--- a/src/themes/default/components/core/ProductAttribute.vue
+++ b/src/themes/default/components/core/ProductAttribute.vue
@@ -10,37 +10,34 @@ import ProductAttribute from '@vue-storefront/core/components/ProductAttribute'
 
 export default {
   mixins: [ProductAttribute],
-  data () {
-    return {
-      label: '',
-      value: ''
-    }
-  },
-  beforeMount () {
-    this.label = this.attribute.default_frontend_label
-    let parsedValues = this.product[this.attribute.attribute_code]
-
-    if (!parsedValues) {
-      this.value = this.emptyPlaceholder
-    } else {
-      parsedValues = parsedValues.split(',')
-      let results = []
-      for (let parsedVal of parsedValues) {
-        if (this.attribute.options) {
-          let option = this.attribute.options.find(av => {
-            /* eslint eqeqeq: "off" */
-            return av.value == parsedVal
-          })
-          if (option) {
-            results.push(option.label)
+  computed: {
+    label () {
+      return (this.attribute && this.attribute.default_frontend_label) ? this.attribute.default_frontend_label : ''
+    },
+    value () {
+      let parsedValues = this.product[this.attribute.attribute_code]
+      if (!parsedValues) {
+        return this.emptyPlaceholder
+      } else {
+        parsedValues = parsedValues.split(',')
+        let results = []
+        for (let parsedVal of parsedValues) {
+          if (this.attribute.options) {
+            let option = this.attribute.options.find(av => {
+              /* eslint eqeqeq: "off" */
+              return av.value == parsedVal
+            })
+            if (option) {
+              results.push(option.label)
+            } else {
+              results.push(parsedVal)
+            }
           } else {
             results.push(parsedVal)
           }
-        } else {
-          results.push(parsedVal)
         }
+        return results.join(', ')
       }
-      this.value = results.join(', ')
     }
   }
 }


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/1601

### Short description and why it's useful

Introduced computed properies instead of non-reactive data() properies. Fixed issue with custom product attributes have not been updated correctly when navigating from one product page directly to another product page.

@pkarw Solution propsed by you doesn't work so I decided to use different approach