### PR TITLE
apache2 as nginx alternate

### DIFF
--- a/doc/Production setup (WIP).md
+++ b/doc/Production setup (WIP).md
@@ -198,6 +198,24 @@ The next proxy section is used for serving the API. It's a proxy to [`vue-storef
 ```
 The last proxy  is used for serving the product images. It's a proxy to [`vue-storefront-api`](https://github.com/DivanteLtd/vue-storefront-api) app. running on `8080` port (default config). The `/img` endpoint. Images will be available under: https://prod.vuestorefront.io/img
 
+#### Apache2 configuration
+In case you are already using the apache2 web-server in your environmen as well and can't  (or don'T want) to use nginx, you can also set up apache2 as an reverse proxy instead of nginx. This is done by adding this block to your apache2 vitual host.
+```
+ProxyRequests off
+ 
+ProxyPass /api http://localhost:8080/
+ProxyPassReverse /api http://localhost:8080/
+ 
+ProxyPass /img http://localhost:8080/
+ProxyPassReverse /img http://localhost:8080/
+ 
+ProxyPass /assets http://localhost:3000/
+ProxyPassReverse /assets http://localhost:3000/
+ 
+ProxyPass / http://localhost:3000/
+ProxyPassReverse / http://localhost:3000/
+```
+You also need to  enable [mod_proxy](https://httpd.apache.org/docs/current/mod/mod_proxy.html) for this.
 
 ### Vue Storefront and Vue Storefront API
 


### PR DESCRIPTION
### Short description and why it's useful
added apache2 configuration as an alternative to nginx

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
