### PR TITLE
[#1520] Set carrier code on component mount

### DIFF
--- a/core/components/blocks/Checkout/Shipping.js
+++ b/core/components/blocks/Checkout/Shipping.js
@@ -54,8 +54,8 @@ export default {
         shipping = this.shippingMethods[0]
       }
       this.shipping.shippingMethod = shipping.method_code
+      this.shipping.shippingCarier = shipping.carrier_code
     }
-    this.changeShippingMethod()
   },
   methods: {
     sendDataToCheckout () {

--- a/core/pages/Checkout.js
+++ b/core/pages/Checkout.js
@@ -314,7 +314,7 @@ export default {
             vat_id: this.payment.taxId
           },
           shipping_method_code: this.shippingMethod.method_code ? this.shippingMethod.method_code : this.shipping.shippingMethod,
-          shipping_carrier_code: this.shippingMethod.carrier_code ? this.shippingMethod.carrier_code : this.shipping.shippingMethod,
+          shipping_carrier_code: this.shippingMethod.carrier_code ? this.shippingMethod.carrier_code : this.shipping.shippingCarrier,
           payment_method_code: this.getPaymentMethod(),
           payment_method_additional: this.payment.paymentMethodAdditional,
           shippingExtraFields: this.shipping.extraFields


### PR DESCRIPTION
### Related issues

#1520 #1523 

### Short description and why it's useful

In previous solution I didn't set carrier code on component mount lifecycle. It worked only after shipping change.

### Contribution and curently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
