### PR TITLE
[#1520] Fix shipping carrier code assignment

### DIFF
--- a/core/components/blocks/Checkout/Shipping.js
+++ b/core/components/blocks/Checkout/Shipping.js
@@ -54,9 +54,8 @@ export default {
         shipping = this.shippingMethods[0]
       }
       this.shipping.shippingMethod = shipping.method_code
-      this.shipping.shippingCarier = shipping.carrier_code
+      this.shipping.shippingCarrier = shipping.carrier_code
     }
-    this.changeShippingMethod()
   },
   methods: {
     sendDataToCheckout () {
@@ -97,7 +96,8 @@ export default {
           apartmentNumber: this.myAddressDetails.street[1],
           zipCode: this.myAddressDetails.postcode,
           phoneNumber: this.myAddressDetails.telephone,
-          shippingMethod: this.$store.state.checkout.shippingDetails.shippingMethod
+          shippingMethod: this.$store.state.checkout.shippingDetails.shippingMethod,
+          shippingCarrier: this.$store.state.checkout.shippingDetails.shippingCarrier
         }
       } else {
         this.shipping = this.$store.state.checkout.shippingDetails


### PR DESCRIPTION
### Related issues

#1520 

### Short description and why it's useful

Fixed carrier code assignment on default to avoid event emit about shipping change. It should not be required on mounted shipping component. 

### Contribution and curently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
