### PR TITLE
chore: vue-analytics should be a dependency of the extension package

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "url-parse": "^1.2.0",
     "vsf-payment-stripe": "^1.0.0",
     "vue": "^2.5.17",
-    "vue-analytics": "^5.8.0",
     "vue-carousel": "^0.6.9",
     "vue-i18n": "^8.0.0",
     "vue-lazyload": "^1.2.6",

--- a/src/extensions/google-analytics/index.js
+++ b/src/extensions/google-analytics/index.js
@@ -37,7 +37,7 @@ export default function (app, router, store, config) {
       ecommerce.send()
     })
   } else {
-    console.log('Ensure google analytic account ID is defined in config')
+    console.log('Ensure Google Analytics account ID is defined in config')
   }
 
   return { EXTENSION_KEY, extensionRoutes, extensionStore }

--- a/src/extensions/google-analytics/package.json
+++ b/src/extensions/google-analytics/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "dependencies": {
+    "vue-analytics": "^5.16.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8496,9 +8496,9 @@ vsf-payment-stripe@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/vsf-payment-stripe/-/vsf-payment-stripe-1.0.0.tgz#2657f17a993cd0cbb2dc2f4f2d8f09e5f95670b5"
 
-vue-analytics@^5.8.0:
-  version "5.12.3"
-  resolved "https://registry.yarnpkg.com/vue-analytics/-/vue-analytics-5.12.3.tgz#599bd05f9e69efd51645e9e74add81d8a26a88ea"
+vue-analytics@^5.16.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/vue-analytics/-/vue-analytics-5.16.0.tgz#82e88703a0678cba076d51acacd6569bc8f7d54c"
 
 vue-carousel@^0.6.9:
   version "0.6.15"


### PR DESCRIPTION
### Related issues

None

### Short description and why it's useful

Vue-Analytics is a dependency of the main package, but it should be a dependency of the google-analytics extension package

### Screenshots of visual changes before/after (if there are any)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

### Contribution and curently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
