### PR TITLE
Proper naming for canceling/confirming ALL orders.  Minor typo fix

### DIFF
--- a/core/modules/newsletter/features/subscribe.ts
+++ b/core/modules/newsletter/features/subscribe.ts
@@ -2,7 +2,7 @@
  * Functionality for subscribing newsletter
  *
  * #### Methods
- * - **`subscribe(email)`** adds passed email to subscribtion list
+ * - **`subscribe(email)`** adds passed email to subscription list
  *
  * Part of [Newsletter API Module](https://github.com/DivanteLtd/vue-storefront/tree/master/doc/api-modules)
  */

--- a/core/modules/newsletter/features/unsubscribe.ts
+++ b/core/modules/newsletter/features/unsubscribe.ts
@@ -2,7 +2,7 @@
  * Functionality for unsubscribing newsletter
  *
  * #### Methods
- * - **`unsubscribe(email)`** removes passed email from subscribtion list
+ * - **`unsubscribe(email)`** removes passed email from subscription list
  *
  * Part of [Newsletter API Module](https://github.com/DivanteLtd/vue-storefront/tree/master/doc/api-modules)
  */

--- a/core/modules/offline-order/features/cancelOrders.ts
+++ b/core/modules/offline-order/features/cancelOrders.ts
@@ -2,7 +2,7 @@
  * Functionality for cancelling orders placed offline
  *
  * #### Methods
- * - **`cancelOrder()`** removes not transmitted orders from Local Storage
+ * - **`cancelOrders()`** removes not transmitted orders from Local Storage
  *
  * Part of [Offline order API Module](https://github.com/DivanteLtd/vue-storefront/tree/master/doc/api-modules)
  */
@@ -12,9 +12,9 @@ import config from 'config'
 import EventBus from '@vue-storefront/core/plugins/event-bus'
 import UniversalStorage from '@vue-storefront/store/lib/storage'
 
-export const cancelOrder = {
+export const cancelOrders = {
   methods: {
-    cancelOrder () {
+    cancelOrders () {
       const ordersCollection = new UniversalStorage(localForage.createInstance({
         name: 'shop',
         storeName: 'orders',

--- a/core/modules/offline-order/features/confirmOrders.ts
+++ b/core/modules/offline-order/features/confirmOrders.ts
@@ -2,16 +2,16 @@
  * Functionality for confirming orders placed offline
  *
  * #### Methods
- * - **`confirmOrder()`** emits event to send orders placed offline to server
+ * - **`confirmOrders()`** emits event to send orders placed offline to server
  *
  * Part of [Offline order API Module](https://github.com/DivanteLtd/vue-storefront/tree/master/doc/api-modules)
  */
 import EventBus from '@vue-storefront/core/plugins/event-bus'
 import config from 'config'
 
-export const confirmOrder = {
+export const confirmOrders = {
   methods: {
-    confirmOrder () {
+    confirmOrders () {
       EventBus.$emit('order/PROCESS_QUEUE', { config: config })
       EventBus.$emit('sync/PROCESS_QUEUE', { config: config })
       this.$store.dispatch('cart/load')

--- a/core/modules/offline-order/features/index.ts
+++ b/core/modules/offline-order/features/index.ts
@@ -1,7 +1,7 @@
-import { confirmOrder } from './confirmOrder'
-import { cancelOrder } from './cancelOrder'
+import { confirmOrders } from './confirmOrders'
+import { cancelOrders } from './cancelOrders'
 
 export {
-  confirmOrder,
-  cancelOrder
+  confirmOrders,
+  cancelOrders
 }

--- a/doc/api-modules/offline-order.md
+++ b/doc/api-modules/offline-order.md
@@ -4,11 +4,11 @@ The offline order module as name suggests is a set of mixins responsible for sup
 
 ## Content
 
-#### confirmOrder
-- [method] confirmOrder()
+#### confirmOrders
+- [method] confirmOrders()
 
-#### cancelOrder
-- [method] cancelOrder()
+#### cancelOrders
+- [method] cancelOrders()
 
 ## Helpers
 
@@ -20,15 +20,15 @@ The offline order module as name suggests is a set of mixins responsible for sup
 ````javascript
 // Inside Vue component
 import {
-  confirmOrder,
-  cancelOrder
+  confirmOrders,
+  cancelOrders
 } from '@vue-storefront/core/api/offline-order'
 
 export default {
   //...other properties
   mixins: [
-    confirmOrder,
-    cancelOrder
+    confirmOrders,
+    cancelOrders
   ]
 }
 ````

--- a/src/themes/default/components/core/blocks/Checkout/OrderConfirmation.vue
+++ b/src/themes/default/components/core/blocks/Checkout/OrderConfirmation.vue
@@ -34,10 +34,10 @@
       </div>
       <div class="row between-xs middle-xs mt40">
         <div class="col-xs-12 col-sm-6 cancel-order">
-          <a href="#" @click.prevent="cancelOrder()">{{ $t('Cancel') }}</a>
+          <a href="#" @click.prevent="cancelOrders()">{{ $t('Cancel') }}</a>
         </div>
         <div class="col-xs-12 col-sm-6">
-          <button-full @click.native="confirmOrder()">
+          <button-full @click.native="confirmOrders()">
             {{ $t('Confirm your order') }}
           </button-full>
         </div>
@@ -47,7 +47,7 @@
 </template>
 
 <script>
-import { confirmOrder, cancelOrder } from '@vue-storefront/core/modules/offline-order/features'
+import { confirmOrders, cancelOrders } from '@vue-storefront/core/modules/offline-order/features'
 
 import Modal from 'theme/components/core/Modal'
 import ButtonFull from 'theme/components/theme/ButtonFull.vue'
@@ -64,7 +64,7 @@ export default {
     Modal,
     ButtonFull
   },
-  mixins: [ confirmOrder, cancelOrder ]
+  mixins: [ confirmOrders, cancelOrders ]
 }
 </script>
 


### PR DESCRIPTION
### Related issues

### Short description and why it's useful

I just changed the names of `cancelOrder` and `confirmOrder` methods to `cancelOrders` `confirmOrders` since they are applying to all orders made offline. 

### Screenshots of visual changes before/after (if there are any)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

### Contribution and curently important rules acceptance

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
