### PR TITLE
[#1706] fixed typescript docker configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - './.eslintignore:/var/www/.eslintignore'
       - './.eslintrc.js:/var/www/.eslintrc.js'
       - './lerna.json:/var/www/lerna.json'
+      - './tsconfig.json:/var/www/tsconfig.json'
+      - './shims.d.ts:/var/www/shims.d.ts'
       - './package.json:/var/www/package.json'
       - './src:/var/www/src'
       - './var:/var/www/var'


### PR DESCRIPTION
### Related issues

[#1706] Getting error while starting VS in docker after upgrade to v1.3.1

### Short description and why it's useful

- fixed typescript docker docker-compose.yml configuration (added new files to the 'volumes'), docker didn't mount all files before.

### Screenshots of visual changes before/after (if there are any)
***Before:***
<img width="697" alt="docker-error" src="https://user-images.githubusercontent.com/10535709/45303878-7ec12180-b51f-11e8-834d-b3161f150280.png">
***After:***
docker starts without errors.

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

![docker-test](https://user-images.githubusercontent.com/10535709/45304251-6271b480-b520-11e8-9533-682579cbdac7.jpg)

### Contribution and currently important rules acceptance

- [ x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
