### PR TITLE
Feature #1641 - output caching with dynamic tags

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -4,8 +4,15 @@
       "port": 3000,
       "protocol": "http",
       "api": "api",
-      "useOutputCacheTagging": false
+      "useOutputCacheTagging": false,
+      "useOutputCache": false,
+      "outputCacheDefaultTtl": 86400
     },
+    "redis": {
+      "host": "localhost",
+      "port": 6379,
+      "db": 0
+    },    
     "graphql":{
       "host": "localhost",
       "port": 8080

--- a/core/package.json
+++ b/core/package.json
@@ -22,6 +22,7 @@
     "lodash-es": "^4.17.10",
     "lru-cache": "^4.0.1",
     "mkdirp": "^0.5.1",
+    "redis-tag-cache": "^1.2.1",
     "url-parse": "^1.2.0",
     "vue": "^2.5.17",
     "vue-carousel": "^0.6.9",

--- a/core/pages/Category.js
+++ b/core/pages/Category.js
@@ -81,6 +81,7 @@ export default {
   asyncData ({ store, route }) { // this is for SSR purposes to prefetch data
     return new Promise((resolve, reject) => {
       console.log('Entering asyncData for Category root ' + new Date())
+      store.state.requestContext.outputCacheTags.add(`category`)
       const defaultFilters = config.products.defaultFilters
       store.dispatch('category/list', { includeFields: config.entities.optimize && Vue.prototype.$isServer ? config.entities.category.includeFields : null }).then((categories) => {
         store.dispatch('attribute/list', { // load filter attributes for this specific category

--- a/core/pages/Home.js
+++ b/core/pages/Home.js
@@ -15,6 +15,7 @@ export default {
   },
   asyncData ({ store, route }) { // this is for SSR purposes to prefetch data
     return new Promise((resolve, reject) => {
+      store.state.requestContext.outputCacheTags.add(`home`)
       console.log('Entering asyncData for Home root ' + new Date())
       EventBus.$emitFilter('home-after-load', { store: store, route: route }).then((results) => {
         return resolve()

--- a/core/pages/Product.js
+++ b/core/pages/Product.js
@@ -63,6 +63,7 @@ export default {
   },
   asyncData ({ store, route }) { // this is for SSR purposes to prefetch data
     EventBus.$emit('product-before-load', { store: store, route: route })
+    store.state.requestContext.outputCacheTags.add(`product`)
     return store.dispatch('product/fetchAsync', { parentSku: route.params.parentSku, childSku: route && route.params && route.params.childSku ? route.params.childSku : null })
   },
   watch: {

--- a/core/scripts/server.js
+++ b/core/scripts/server.js
@@ -4,11 +4,21 @@ const express = require('express')
 const rootPath = require('app-root-path').path
 const resolve = file => path.resolve(rootPath, file)
 const config = require('config')
+const TagCache = require('redis-tag-cache').default
 
 const isProd = process.env.NODE_ENV === 'production'
 process.noDeprecation = true
 
 const app = express()
+
+let cache
+if (config.server.useOutputCache) {
+  cache = new TagCache({
+    redis: config.redis,
+    defaultTimeout: config.server.outputCacheDefaultTtl // Expire records after a day (even if they weren't invalidated)
+  })
+  console.log('Redis cache set', config.redis)
+}
 
 let renderer
 if (isProd) {
@@ -52,26 +62,31 @@ app.use('/service-worker.js', serve('dist/service-worker.js', {
   setHeaders: {'Content-Type': 'text/javascript; charset=UTF-8'}
 }))
 
-app.get('*', (req, res) => {
-  if (!res.get('Content-Type')) {
-    res.append('Content-Type', 'text/html')
+app.get('/invalidate', (req, res, next) => {
+  if (req.query.tag) { // clear cache pages for specific query tag
+    console.log(`Clear cache request for [${req.query.tag}]`)
+    let tags = []
+    if (req.query.tag === '*') {
+      tags = ['product', 'category', 'home']
+    } else {
+      tags = req.query.tag.split(',')
+    }
+    const subPromises = []
+    tags.forEach(tag => {
+      subPromises.push(cache.invalidate(tag).then(() => {
+        console.log(`Tags invalidated successfully for [${tag}]`)
+      }))
+    })
+    Promise.all(subPromises).then(r => {
+      console.log('Tags invalidated successfully!')
+      res.end(`Tags invalidated successfully [${req.query.tag}]`)
+      next()
+    }).catch(next)
   }
+})
 
-  if (!renderer) {
-    return res.end('<html lang="en">\n' +
-        '    <head>\n' +
-        '      <meta charset="utf-8">\n' +
-        '      <title>Loading</title>\n' +
-        '      <meta http-equiv="refresh" content="10">\n' +
-        '    </head>\n' +
-        '    <body>\n' +
-        '      Vue Storefront: waiting for compilation... refresh in 30s :-) Thanks!\n' +
-        '    </body>\n' +
-        '  </html>')
-  }
-
+app.get('*', (req, res, next) => {
   const s = Date.now()
-
   const errorHandler = err => {
     if (err && err.code === 404) {
       res.redirect('/page-not-found')
@@ -81,25 +96,74 @@ app.get('*', (req, res) => {
       res.status(500).end('500 | Internal Server Error')
       console.error(`Error during render : ${req.url}`)
       console.error(err)
+      next()
     }
   }
 
-  const context = { url: req.url, storeCode: req.header('x-vs-store-code') ? req.header('x-vs-store-code') : process.env.STORE_CODE }
-  if (config.server.useOutputCacheTagging) {
-    renderer.renderToString(context).then(output => {
-      const cacheTags = Array.from(context.state.requestContext.outputCacheTags).join(' ')
-      res.setHeader('X-VS-Cache-Tags', cacheTags)
-      res.send(output).end()
-      console.log(`cache tags for the request: ${cacheTags}`)
-      console.log(`whole request: ${Date.now() - s}ms`)
-    })
+  const dynamicRequestHandler = renderer => {
+    if (!renderer) {
+      res.end('<html lang="en">\n' +
+          '    <head>\n' +
+          '      <meta charset="utf-8">\n' +
+          '      <title>Loading</title>\n' +
+          '      <meta http-equiv="refresh" content="10">\n' +
+          '    </head>\n' +
+          '    <body>\n' +
+          '      Vue Storefront: waiting for compilation... refresh in 30s :-) Thanks!\n' +
+          '    </body>\n' +
+          '  </html>')
+      return next()
+    }
+    const context = { url: req.url, storeCode: req.header('x-vs-store-code') ? req.header('x-vs-store-code') : process.env.STORE_CODE }
+    if (config.server.useOutputCacheTagging) {
+      renderer.renderToString(context).then(output => {
+        const tagsArray = Array.from(context.state.requestContext.outputCacheTags)
+        const cacheTags = tagsArray.join(' ')
+        res.setHeader('X-VS-Cache-Tags', cacheTags)
+        res.end(output)
+        console.log(`cache tags for the request: ${cacheTags}`)
+        console.log(`whole request [${req.url}]: ${Date.now() - s}ms`)
+        if (config.server.useOutputCache && cache) {
+          cache.set(
+            'page:' + req.url,
+            output,
+            tagsArray
+          ).catch(errorHandler)
+        }
+        next()
+      }).catch(errorHandler)
+    } else {
+      renderer.renderToStream(context) // TODO: pass the store code from the headers
+        .on('error', errorHandler)
+        .on('end', () => {
+          console.log(`whole request: ${Date.now() - s}ms`)
+          next()
+        })
+        .pipe(res)
+    }
+  }
+
+  if (!res.get('Content-Type')) {
+    res.append('Content-Type', 'text/html')
+  }
+
+  if (config.server.useOutputCache && cache) {
+    cache.get(
+      'page:' + req.url
+    ).then(output => {
+      if (output !== null) {
+        res.setHeader('X-VS-Cache', 'Hit')
+        res.end(output)
+        console.log(`cache hit [${req.url}], cached request: ${Date.now() - s}ms`)
+        next()
+      } else {
+        res.setHeader('X-VS-Cache', 'Miss')
+        console.log(`cache miss [${req.url}], request: ${Date.now() - s}ms`)
+        dynamicRequestHandler(renderer) // render response
+      }
+    }).catch(errorHandler)
   } else {
-    renderer.renderToStream(context) // TODO: pass the store code from the headers
-      .on('error', errorHandler)
-      .on('end', () => {
-        console.log(`whole request: ${Date.now() - s}ms`)
-      })
-      .pipe(res)
+    dynamicRequestHandler(renderer)
   }
 })
 

--- a/doc/SSR Cache.md
+++ b/doc/SSR Cache.md
@@ -1,0 +1,56 @@
+# SSR Cache
+
+Vue Storefront generates the Server Side rendered pages to improve the SEO results. In the latest version of Vue Storefront we've added the Output cache option (disabled by default) to improve the performance.
+
+The output cache is set by the following `config/local.json` variables:
+
+```json
+    "server": {
+      "host": "localhost",
+      "port": 3000,
+      "protocol": "http",
+      "api": "api",
+      "useOutputCacheTagging": true,
+      "useOutputCache": true,
+      "outputCacheDefaultTtl": 86400
+    },
+    "redis": {
+      "host": "localhost",
+      "port": 6379,
+      "db": 0
+    },  
+```
+
+## Dynamic tags
+
+The dynamic tags config uption:  `useOutputCacheTaging` - if set to true, Vue Storefront is generating the special HTTP Header `X-VS-Cache-Tags`
+```js
+        res.setHeader('X-VS-Cache-Tags', cacheTags)
+```
+
+Cache tags are assigned regarding the products and categories which are used on the specific page. Typical `X-VS-Cache-Tags` tag looks like this:
+```
+X-VS-Cache-Tags: P1852 P198 C20
+```
+
+The tags can be used to invalidate the Varnish cache if You're using it. [Read more on that](https://www.drupal.org/docs/8/api/cache-api/cache-tags-varnish).
+
+## Redis
+
+If both `useOutputCache` and `useOutputCacheTagging` options are set to `true` - Vue Storefront is using Output Cache stored in Redis (configured in the `redis` section of the config file). Cache is tagged with Dynamic tags and can be invalidated using special webhook:
+
+Example call to clear all pages containing specific product and category:
+`curl http://localhost:3000/invalidate?tag=P1852,C20`
+
+Example call to clear all product, category and home pages:
+`curl http://localhost:3000/invalidate?tag=product,category,home`
+
+**WARNING:**
+We strongly recommend You to NOT USE Output cache in the development mode. By using it You won't be able to refresh the UI changes after modyfing the Vue components etc.
+
+**Cache invalidation:** Recent version of [mage2vuestorefront](https://github.com/DivanteLtd/mage2vuestorefront) do support output cache invalidation. Output cache is being tagged with the product and categories id (products and categories used on specific page). Mage2vuestorefront can invalidate cache of product and category pages if You set the following ENV variables:
+
+```bash
+export VS_INVALIDATE_CACHE_URL=http://localhost:3000/invalidate?tag=
+export VS_INVALIDATE_CACHE=1
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,6 +1969,10 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
+cluster-key-slot@^1.0.6:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.0.12.tgz#d5deff2a520717bc98313979b687309b2d368e29"
+
 cmd-shim@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-2.0.2.tgz#6fcbda99483a8fd15d7d30a196ca69d688a2efdb"
@@ -2749,6 +2753,10 @@ delayed-stream@~1.0.0:
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+
+denque@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.3.0.tgz#681092ef44a630246d3f6edb2a199230eae8e76b"
 
 depd@1.1.1:
   version "1.1.1"
@@ -3662,6 +3670,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+flexbuffer@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/flexbuffer/-/flexbuffer-0.0.6.tgz#039fdf23f8823e440c38f3277e6fef1174215b30"
+
 flush-write-stream@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.3.tgz#c5d586ef38af6097650b49bc41b55fabb19f35bd"
@@ -4550,6 +4562,32 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
+ioredis@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.0.0.tgz#fabf1cf8724f14fd0885233cf2f4fbc6e1e59da2"
+  dependencies:
+    cluster-key-slot "^1.0.6"
+    debug "^3.1.0"
+    denque "^1.1.0"
+    flexbuffer "0.0.6"
+    lodash.bind "^4.2.1"
+    lodash.clone "^4.5.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.defaults "^4.2.0"
+    lodash.difference "^4.5.0"
+    lodash.flatten "^4.4.0"
+    lodash.foreach "^4.5.0"
+    lodash.isempty "^4.4.0"
+    lodash.partial "^4.2.1"
+    lodash.pick "^4.4.0"
+    lodash.sample "^4.2.1"
+    lodash.shuffle "^4.2.0"
+    lodash.values "^4.3.0"
+    redis-commands "^1.2.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^1.0.0"
+
 ip@^1.1.2, ip@^1.1.4, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -5311,11 +5349,19 @@ lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
+lodash.bind@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
-lodash.clonedeep@^4.3.2:
+lodash.clone@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
+
+lodash.clonedeep@^4.3.2, lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
@@ -5327,13 +5373,29 @@ lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+
 lodash.findindex@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.findindex/-/lodash.findindex-4.6.0.tgz#a3245dee61fb9b6e0624b535125624bb69c11106"
 
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+
+lodash.foreach@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.isempty@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
 
 lodash.isequal@^4.0.0:
   version "4.5.0"
@@ -5355,6 +5417,22 @@ lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
+lodash.partial@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.partial/-/lodash.partial-4.2.1.tgz#49f3d8cfdaa3bff8b3a91d127e923245418961d4"
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.sample@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.sample/-/lodash.sample-4.2.1.tgz#5e4291b0c753fa1abeb0aab8fb29df1b66f07f6d"
+
+lodash.shuffle@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz#145b5053cf875f6f5c2a33f48b6e9948c6ec7b4b"
+
 lodash.tail@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
@@ -5375,6 +5453,10 @@ lodash.templatesettings@^4.0.0:
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+
+lodash.values@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
 
 lodash@4.17.10, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.9.0, lodash@~4.17.10:
   version "4.17.10"
@@ -7038,9 +7120,25 @@ redis-commands@^1.2.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.3.5.tgz#4495889414f1e886261180b1442e7295602d83a2"
 
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+
 redis-parser@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  dependencies:
+    redis-errors "^1.0.0"
+
+redis-tag-cache@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/redis-tag-cache/-/redis-tag-cache-1.2.1.tgz#07d6e1f945d9d5c8186602129cb10573167d7534"
+  dependencies:
+    ioredis "^4.0.0"
 
 redis@^2.7.1:
   version "2.8.0"
@@ -7854,6 +7952,10 @@ ssri@^5.2.4:
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-5.3.0.tgz#ba3872c9c6d33a0704a7d71ff045e5ec48999d06"
   dependencies:
     safe-buffer "^5.1.1"
+
+standard-as-callback@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-1.0.1.tgz#2e9e1e9d278d7d77580253faaec42269015e3c1d"
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
# SSR Cache

Vue Storefront generates the Server Side rendered pages to improve the SEO results. In the latest version of Vue Storefront we've added the Output cache option (disabled by default) to improve the performance.

The output cache is set by the following `config/local.json` variables:

```json
    "server": {
      "host": "localhost",
      "port": 3000,
      "protocol": "http",
      "api": "api",
      "useOutputCacheTagging": true,
      "useOutputCache": true,
      "outputCacheDefaultTtl": 86400
    },
    "redis": {
      "host": "localhost",
      "port": 6379,
      "db": 0
    },  
```

## Dynamic tags

The dynamic tags config uption:  `useOutputCacheTaging` - if set to true, Vue Storefront is generating the special HTTP Header `X-VS-Cache-Tags`
```js
        res.setHeader('X-VS-Cache-Tags', cacheTags)
```

Cache tags are assigned regarding the products and categories which are used on the specific page. Typical `X-VS-Cache-Tags` tag looks like this:
```
X-VS-Cache-Tags: P1852 P198 C20
```

The tags can be used to invalidate the Varnish cache if You're using it. [Read more on that](https://www.drupal.org/docs/8/api/cache-api/cache-tags-varnish).

## Redis

If both `useOutputCache` and `useOutputCacheTagging` options are set to `true` - Vue Storefront is using Output Cache stored in Redis (configured in the `redis` section of the config file). Cache is tagged with Dynamic tags and can be invalidated using special webhook:

Example call to clear all pages containing specific product and category:
`curl http://localhost:3000/invalidate?tag=P1852,C20`

Example call to clear all product, category and home pages:
`curl http://localhost:3000/invalidate?tag=product,category,home`

**WARNING:**
We strongly recommend You to NOT USE Output cache in the development mode. By using it You won't be able to refresh the UI changes after modyfing the Vue components etc.

**Cache invalidation:** Recent version of [mage2vuestorefront](https://github.com/DivanteLtd/mage2vuestorefront) do support output cache invalidation. Output cache is being tagged with the product and categories id (products and categories used on specific page). Mage2vuestorefront can invalidate cache of product and category pages if You set the following ENV variables:

```bash
export VS_INVALIDATE_CACHE_URL=http://localhost:3000/invalidate?tag=
export VS_INVALIDATE_CACHE=1
```
### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
