### PR TITLE
Added proper status code when vue-storefront is compilinh

### DIFF
--- a/core/scripts/server.js
+++ b/core/scripts/server.js
@@ -117,7 +117,7 @@ app.get('*', (req, res, next) => {
   const dynamicRequestHandler = renderer => {
     if (!renderer) {
       res.setHeader('Content-Type', 'text/html')
-      res.end('<html lang="en">\n' +
+      res.status(202).end('<html lang="en">\n' +
           '    <head>\n' +
           '      <meta charset="utf-8">\n' +
           '      <title>Loading</title>\n' +


### PR DESCRIPTION
### Related issues

(put links to related issues here)

### Short description and why it's useful
200 should be used when a site is found as intended. Using 200 when loading says it ready when its not
### Screenshots of visual changes before/after (if there are any)

None

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)


### Contribution and curently important rules acceptance

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
