### PR TITLE
Fix for #1762

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -116,6 +116,7 @@
       }
     },
     "cart": {
+      "bypassCartLoaderForAuthorizedUsers": true,
       "multisiteCommonCart": true,
       "server_merge_by_default": true,
       "synchronize": true,

--- a/core/store/modules/cart/actions.ts
+++ b/core/store/modules/cart/actions.ts
@@ -111,9 +111,6 @@ const actions: ActionTree<CartState, RootState> = {
   serverCreate (context, { guestCart = false }) {
     if (rootStore.state.config.cart.synchronize && !Vue.prototype.$isServer) {
       if ((Date.now() - context.state.cartServerCreatedAt) >= CART_CREATE_INTERVAL_MS) {
-        if (guestCart) {
-          Vue.prototype.$db.usersCollection.setItem('last-cart-bypass-ts', new Date().getTime())
-        }
         const task = { url: guestCart ? rootStore.state.config.cart.create_endpoint.replace('{{token}}', '') : rootStore.state.config.cart.create_endpoint, // sync the cart
           payload: {
             method: 'POST',
@@ -467,7 +464,7 @@ const actions: ActionTree<CartState, RootState> = {
       if (err) {
         console.error(err)
       }
-      if ((Date.now() - lastCartBypassTs) >= (1000 * 60 * 24)) { // don't refresh the shopping cart id up to 24h after last order
+      if (!rootStore.state.config.cart.bypassCartLoaderForAuthorizedUsers || (Date.now() - lastCartBypassTs) >= (1000 * 60 * 24)) { // don't refresh the shopping cart id up to 24h after last order
         rootStore.dispatch('cart/serverCreate', { guestCart: false }, { root: true })
       }
     })

--- a/core/store/modules/checkout/actions.ts
+++ b/core/store/modules/checkout/actions.ts
@@ -14,6 +14,7 @@ const actions: ActionTree<CheckoutState, RootState> = {
   placeOrder (context, { order }) {
     try {
       context.dispatch('order/placeOrder', order, {root: true}).then(result => {
+        Vue.prototype.$db.usersCollection.setItem('last-cart-bypass-ts', new Date().getTime())
         context.dispatch('cart/clear', {}, {root: true})
         if (context.state.personalDetails.createAccount) {
           context.commit(types.CHECKOUT_DROP_PASSWORD)


### PR DESCRIPTION
The cart loader bypass feature is there because we’re posting orders to Magento asynchronously - it may happen that directly after playing an order, the Magento’s user still have the same quote id and after browsing thru VS Store old items will be restored to the shopping cart. Now You can disable this behaviour by setting `config.cart.bypassCartLoaderForAuthorizedUsers=false`. I’ve also moved the place when this bypass timestamp is set (to directly after order is being created)

### Related issues

#1762 

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
