### PR TITLE
Fix for #1765

### DIFF
--- a/core/store/modules/category/actions.ts
+++ b/core/store/modules/category/actions.ts
@@ -12,6 +12,7 @@ import { optionLabel } from '../attribute/helpers'
 import RootState from '../../types/RootState'
 import CategoryState from './types/CategoryState'
 import SearchQuery from 'core/store/lib/search/searchQuery'
+import { currentStoreView } from '@vue-storefront/store/lib/multistore'
 
 const actions: ActionTree<CategoryState, RootState> = {
   /**
@@ -248,6 +249,8 @@ const actions: ActionTree<CategoryState, RootState> = {
                 }
               });
             } else { // special case is range filter for prices
+              const storeView = currentStoreView()
+              const currencySign = storeView.i18n.currencySign
               if (res.aggregations['agg_range_' + attrToFilter]) {
                 let index = 0
                 let count = res.aggregations['agg_range_' + attrToFilter].buckets.length
@@ -256,7 +259,7 @@ const actions: ActionTree<CategoryState, RootState> = {
                     id: option.key,
                     from: option.from,
                     to: option.to,
-                    label: (index === 0 || (index === count - 1)) ? (option.to ? '< $' + option.to : '> $' + option.from) : '$' + option.from + (option.to ? ' - ' + option.to : '')// TODO: add better way for formatting, extract currency sign
+                    label: (index === 0 || (index === count - 1)) ? (option.to ? '< ' + currencySign + option.to : '> ' + currencySign + option.from) : currencySign + option.from + (option.to ? ' - ' + option.to : '')// TODO: add better way for formatting, extract currency sign
                   })
                   index++
                 }


### PR DESCRIPTION
### Related issues

#1765 

### Short description and why it's useful

A quick fix for currency sign displayed in the category filters

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
