### PR TITLE
Fix for #1775 - Added missing voume mounts to docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - './package.json:/var/www/package.json'
       - './src:/var/www/src'
       - './var:/var/www/var'
+      - './tsconfig.json:/var/www/tsconfig.json'
+      - './shims.d.ts:/var/www/shims.d.ts'
     tmpfs:
       - /var/www/dist
     ports:


### PR DESCRIPTION
### Related issues

#1775 


### Short description and why it's useful

Added missing volume mounts to default docker-compose.yml file


