### PR TITLE
Docs update + deploy before 1.4

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+# abort on errors
+set -e
+
+# build
+npm run docs:build
+
+# navigate into the build output directory
+cd .vuepress/dist
+
+# if you are deploying to a custom domain
+# echo 'www.example.com' > CNAME
+
+git init
+git add -A
+git commit -m 'deploy'
+
+# if you are deploying to https://<USERNAME>.github.io
+# git push -f git@github.com:<USERNAME>/<USERNAME>.github.io.git master
+
+# if you are deploying to https://<USERNAME>.github.io/<REPO>
+git push -f git@github.com:DivanteLtd/vue-storefront.git master:gh-pages
+
+cd -

--- a/docs/guide/installation/linux-mac.md
+++ b/docs/guide/installation/linux-mac.md
@@ -142,8 +142,8 @@ Depending on the selected mode, execute the following commands:
   ```
 - **standard** mode:
   ```bash
-  docker exec -it vue-storefront-api_app_1 yarn restore
-  docker exec -it vue-storefront-api_app_1 yarn migrate
+  docker exec -it vuestorefrontapi_app_1 yarn restore
+  docker exec -it vuestorefrontapi_app_1 yarn migrate
   ```
 
 Clone the image files for default product database (we're using [Magento2 example products dataset](https://github.com/magento/magento2-sample-data). Please execute the following command in **the root folder of vue-storefront-api project**:


### PR DESCRIPTION
Docs update + deploy

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and curently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
