### PR TITLE
Fixing text clash with title on ThankYou page

### DIFF
--- a/src/themes/default/components/core/blocks/Form/BaseTextarea.vue
+++ b/src/themes/default/components/core/blocks/Form/BaseTextarea.vue
@@ -3,7 +3,7 @@
     <div class="relative">
       <textarea
         class="
-          py10 w-100 border-box brdr-none brdr-bottom-1
+          mt10 pb10 w-100 border-box brdr-none brdr-bottom-1
           brdr-cl-primary h4 sans-serif
         "
         :class="{empty: value === ''}"


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/1814

### Short description and why it's useful

It fixes the clash between a multiline text and the title in "Type your opinion" textarea of the ThankYou page. It's a UI fix.

### Screenshots of visual changes before/after (if there are any)

before:
<img width="349" alt="screen shot 2018-10-07 at 11 47 33" src="https://user-images.githubusercontent.com/15943863/46580692-f785a180-ca29-11e8-91a0-16f02675b02b.png">

after:
<img width="434" alt="screen shot 2018-10-07 at 12 09 43" src="https://user-images.githubusercontent.com/15943863/46580694-fce2ec00-ca29-11e8-8e13-d1992cc7cd86.png">

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and curently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
