### PR TITLE
Hotfix - webpack templates clean up

### DIFF
--- a/core/build/webpack.base.config.js
+++ b/core/build/webpack.base.config.js
@@ -48,15 +48,18 @@ module.exports = {
     // generate output HTML
     new HTMLPlugin({
       template: fs.existsSync(themedIndex) ? themedIndex : 'src/index.template.html',
-      filename: 'index.html'
+      filename: 'index.html',
+      inject: false
     }),
     new HTMLPlugin({
       template: fs.existsSync(themedIndex) ? themedIndexMinimal : 'src/index.minimal.template.html',
-      filename: 'index.minimal.html'
+      filename: 'index.minimal.html',
+      inject: false
     }),
     new HTMLPlugin({
       template: fs.existsSync(themedIndex) ? themedIndexBasic: 'src/index.basic.template.html',
-      filename: 'index.basic.html'
+      filename: 'index.basic.html',
+      inject: false
     })    
   ],
   devtool: 'source-map',
@@ -108,7 +111,6 @@ module.exports = {
         test: /\.vue$/,
         loader: 'vue-loader',
         options: {
-          optimizeSSR: false,
           preserveWhitespace: false,
           postcss: [autoprefixer()],
         }

--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -54,6 +54,8 @@ function _ssrHydrateSubcomponents (components, next, to) {
         store,
         route: to
       })
+    } else {
+      return Promise.resolve(null)
     }
   })).then(() => {
     next()

--- a/core/server-entry.ts
+++ b/core/server-entry.ts
@@ -23,6 +23,8 @@ function _ssrHydrateSubcomponents (components, store, router, resolve, reject, a
         route: router.currentRoute,
         context
       })
+    } else {
+      return Promise.resolve(null)
     }
   })).then(() => {
     if (buildTimeConfig.ssr.useInitialStateFilter) {

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -18,11 +18,6 @@
 				s.parentNode.insertBefore(wf, s);
 			})(); 
 		</script>
-
-    <% for (var chunk of webpack.chunks) {
-        for (var file of chunk.files) {
-          if (file.match(/\.(js|css)$/)) { %>
-    <link rel="<%= chunk.initial?'preload':'prefetch' %>" href="<%= htmlWebpackPlugin.files.publicPath + file %>" as="<%= file.match(/\.css$/)?'style':'script' %>"><% }}} %>
 		{{{ renderResourceHints() }}}
     {{{ renderStyles() }}}
 	</head>

--- a/src/themes/default/index.template.html
+++ b/src/themes/default/index.template.html
@@ -20,10 +20,6 @@
 				s.parentNode.insertBefore(wf, s);
 			})(); 
 		</script>
-    <% for (var chunk of webpack.chunks) {
-        for (var file of chunk.files) {
-          if (file.match(/\.(js|css)$/)) { %>
-    <link rel="<%= chunk.initial?'preload':'prefetch' %>" href="<%= htmlWebpackPlugin.files.publicPath + file %>" as="<%= file.match(/\.css$/)?'style':'script' %>"><% }}} %>
 		{{{ renderResourceHints() }}}
     {{{ renderStyles() }}}
 	</head>


### PR DESCRIPTION
### Related issues

In some environments previous webpack config could have generated duplicated script injections in html template.

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and curently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
