### PR TITLE
Remove any reference to imagemagick

### DIFF
--- a/doc/Installing on Linux and MacOS.md
+++ b/doc/Installing on Linux and MacOS.md
@@ -36,18 +36,11 @@ Done? Ok! Let's proceed!
   <br>
   Using Homebrew `$ brew install docker docker-compose docker-machine xhyve docker-machine-driver-xhyve`
 
-- **ImageMagick**
-  <br> 
-  `$ brew install imagemagick`
-  
-<br>
-
 To test if the software is installed, run these commands in Terminal:
 
 - **for Node.js:** `node -v`
 - **for NPM:** `npm -v`
 - **for Docker:** `docker version` or simply Check your `/Applications/` directory and look for the `Docker.app` and `Docker Quickstart Terminal.app`
-- **for ImageMagick**: ` convert -version`
 
 <br>
 
@@ -60,8 +53,6 @@ To test if the software is installed, run these commands in Terminal:
   - **Docker** https://docs.docker.com/docker-for-mac/install/
 
   - **Docker Compose** https://docs.docker.com/compose/install/
-
-  - **ImageMagick** http://www.besavvy.com/documentation/4-5/Editor/031350_installimgk.htm
 
 <br>
 <br>

--- a/doc/Installing on Windows.md
+++ b/doc/Installing on Windows.md
@@ -27,7 +27,7 @@ Vue storefront is based on open source technologies which SHOULD (in theory ;)) 
 3. Go to vue-storefront in dir: `cd vue-storefront`
 4. Install dependencies: `yarn install`
 5. Copy `config/default.json` to `config/local.json`
-6. Images: because vue-storefront-api uses `imagemagick` and some nodejs cmdline bindings it can be dificult to run the image proxy on localhost/windows machine. Please point out the vue-storefront to image proxy provided by changing `config/local.json` images.baseUrl:
+6. Images: because vue-storefront-api uses some nodejs cmdline bindings it can be difficult to run the image proxy on localhost/windows machine. Please point out the vue-storefront to image proxy provided by changing `config/local.json` images.baseUrl:
 
 ```js
 export default {

--- a/doc/Production setup (WIP).md
+++ b/doc/Production setup (WIP).md
@@ -58,7 +58,6 @@ dpkg -i elasticsearch-5.6.9.deb
 /etc/init.d/elasticsearch start
 
 
-apt-get install imagemagick
 apt-get install nginx
 ```
 


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/1844

### Short description and why it's useful

It should be useful since it is very confusing to still reference `imagemagick` in the documentation although it is not used anymore.

### Screenshots of visual changes before/after (if there are any)

(if you made any changes in the UI layer please provide before/after screenshots)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

(run `yarn tests:e2e` and paste the results. If you are not using our standard backend setup or demo.vuestorefront.io you can ommit this step) 

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and curently important rules acceptance

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
