### PR TITLE
Add oauth2 keys setup in installer

### DIFF
--- a/core/scripts/installer.js
+++ b/core/scripts/installer.js
@@ -669,71 +669,71 @@ let questions = [
     }
   },
   {
-      type: 'confirm',
-      name: 'm2_api_oauth2',
-      message: `Would You like to perform initial data import from Magento2 instance?`,
-      default: false,
-      when: function (answers) {
-          return answers.is_remote_backend === false
-      }
+    type: 'confirm',
+    name: 'm2_api_oauth2',
+    message: `Would You like to perform initial data import from Magento2 instance?`,
+    default: false,
+    when: function (answers) {
+      return answers.is_remote_backend === false
+    }
   },
   {
-      type: 'input',
-      name: 'm2_api_url',
-      message: 'Please provide the url to your magento rest api',
-      default: 'http://demo-magento2.vuestorefront.io/rest',
-      when: function (answers) {
-          return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
-      },
-      filter: function (url) {
-          let prefix = 'http://'
-          let prefixSsl = 'https://'
+    type: 'input',
+    name: 'm2_api_url',
+    message: 'Please provide the url to your magento rest api',
+    default: 'http://demo-magento2.vuestorefront.io/rest',
+    when: function (answers) {
+      return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+    },
+    filter: function (url) {
+      let prefix = 'http://'
+      let prefixSsl = 'https://'
 
-          url = url.trim()
+      url = url.trim()
 
-          // add http:// if no protocol set
-          if (url.substr(0, prefix.length) !== prefix && url.substr(0, prefixSsl.length) !== prefixSsl) {
-              url = prefix + url
-          }
+      // add http:// if no protocol set
+      if (url.substr(0, prefix.length) !== prefix && url.substr(0, prefixSsl.length) !== prefixSsl) {
+        url = prefix + url
+      }
 
-          return url;
-      }
+      return url;
+    }
   },
   {
-      type: 'input',
-      name: 'm2_api_consumer_key',
-      message: 'Please provide your consumer key',
-      default: 'byv3730rhoulpopcq64don8ukb8lf2gq',
-      when: function (answers) {
-          return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
-      }
+    type: 'input',
+    name: 'm2_api_consumer_key',
+    message: 'Please provide your consumer key',
+    default: 'byv3730rhoulpopcq64don8ukb8lf2gq',
+    when: function (answers) {
+      return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+    }
   },
   {
-      type: 'input',
-      name: 'm2_api_consumer_secret',
-      message: 'Please provide your consumer secret',
-      default: 'u9q4fcobv7vfx9td80oupa6uhexc27rb',
-      when: function (answers) {
-          return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
-      }
+    type: 'input',
+    name: 'm2_api_consumer_secret',
+    message: 'Please provide your consumer secret',
+    default: 'u9q4fcobv7vfx9td80oupa6uhexc27rb',
+    when: function (answers) {
+      return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+    }
   },
   {
-      type: 'input',
-      name: 'm2_api_access_token',
-      message: 'Please provide your access token',
-      default: '040xx3qy7s0j28o3q0exrfop579cy20m',
-      when: function (answers) {
-          return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
-      }
+    type: 'input',
+    name: 'm2_api_access_token',
+    message: 'Please provide your access token',
+    default: '040xx3qy7s0j28o3q0exrfop579cy20m',
+    when: function (answers) {
+      return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+    }
   },
   {
-      type: 'input',
-      name: 'm2_api_access_token_secret',
-      message: 'Please provide your access secret',
-      default: '7qunl3p505rubmr7u1ijt7odyialnih9',
-      when: function (answers) {
-          return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
-      }
+    type: 'input',
+    name: 'm2_api_access_token_secret',
+    message: 'Please provide your access secret',
+    default: '7qunl3p505rubmr7u1ijt7odyialnih9',
+    when: function (answers) {
+      return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+    }
   }
 ]
 

--- a/core/scripts/installer.js
+++ b/core/scripts/installer.js
@@ -224,17 +224,17 @@ class Backend extends Abstract {
 
         config.imageable.whitelist.allowedHosts.push(host)
 
-        let api_url = urlParser(this.answers.m2_api_url).href
+        let apiUrl = urlParser(this.answers.m2_api_url).href
 
-        if (!api_url.length) {
+        if (!apiUrl.length) {
           throw new Error()
         }
 
-        config.magento2.api.url = api_url;
-        config.magento2.api.consumerKey = this.answers.m2_api_consumer_key;
-        config.magento2.api.consumerSecret = this.answers.m2_api_consumer_secret;
-        config.magento2.api.accessToken = this.answers.m2_api_access_token;
-        config.magento2.api.accessTokenSecret = this.answers.m2_api_access_token_secret;
+        config.magento2.api.url = apiUrl
+        config.magento2.api.consumerKey = this.answers.m2_api_consumer_key
+        config.magento2.api.consumerSecret = this.answers.m2_api_consumer_secret
+        config.magento2.api.accessToken = this.answers.m2_api_access_token
+        config.magento2.api.accessTokenSecret = this.answers.m2_api_access_token_secret
 
         jsonFile.writeFileSync(TARGET_BACKEND_CONFIG_FILE, config, {spaces: 2})
       } catch (e) {

--- a/core/scripts/installer.js
+++ b/core/scripts/installer.js
@@ -224,6 +224,18 @@ class Backend extends Abstract {
 
         config.imageable.whitelist.allowedHosts.push(host)
 
+        let api_url = urlParser(this.answers.m2_api_url).href
+
+        if (!api_url.length) {
+          throw new Error()
+        }
+
+        config.magento2.api.url = api_url;
+        config.magento2.api.consumerKey = this.answers.m2_api_consumer_key;
+        config.magento2.api.consumerSecret = this.answers.m2_api_consumer_secret;
+        config.magento2.api.accessToken = this.answers.m2_api_access_token;
+        config.magento2.api.accessTokenSecret = this.answers.m2_api_access_token_secret;
+
         jsonFile.writeFileSync(TARGET_BACKEND_CONFIG_FILE, config, {spaces: 2})
       } catch (e) {
         reject(new Error('Can\'t create backend config. Original error: ' + e))
@@ -655,6 +667,73 @@ let questions = [
       // add extra slash as suffix if was not set
       return url.slice(-1) === '/' ? url : `${url}/`
     }
+  },
+  {
+      type: 'confirm',
+      name: 'm2_api_oauth2',
+      message: `Would You like to perform initial data import from Magento2 instance?`,
+      default: false,
+      when: function (answers) {
+          return answers.is_remote_backend === false
+      }
+  },
+  {
+      type: 'input',
+      name: 'm2_api_url',
+      message: 'Please provide the url to your magento rest api',
+      default: 'http://demo-magento2.vuestorefront.io/rest',
+      when: function (answers) {
+          return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+      },
+      filter: function (url) {
+          let prefix = 'http://'
+          let prefixSsl = 'https://'
+
+          url = url.trim()
+
+          // add http:// if no protocol set
+          if (url.substr(0, prefix.length) !== prefix && url.substr(0, prefixSsl.length) !== prefixSsl) {
+              url = prefix + url
+          }
+
+          return url;
+      }
+  },
+  {
+      type: 'input',
+      name: 'm2_api_consumer_key',
+      message: 'Please provide your consumer key',
+      default: 'byv3730rhoulpopcq64don8ukb8lf2gq',
+      when: function (answers) {
+          return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+      }
+  },
+  {
+      type: 'input',
+      name: 'm2_api_consumer_secret',
+      message: 'Please provide your consumer secret',
+      default: 'u9q4fcobv7vfx9td80oupa6uhexc27rb',
+      when: function (answers) {
+          return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+      }
+  },
+  {
+      type: 'input',
+      name: 'm2_api_access_token',
+      message: 'Please provide your access token',
+      default: '040xx3qy7s0j28o3q0exrfop579cy20m',
+      when: function (answers) {
+          return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+      }
+  },
+  {
+      type: 'input',
+      name: 'm2_api_access_token_secret',
+      message: 'Please provide your access secret',
+      default: '7qunl3p505rubmr7u1ijt7odyialnih9',
+      when: function (answers) {
+          return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+      }
   }
 ]
 

--- a/core/scripts/installer.js
+++ b/core/scripts/installer.js
@@ -683,7 +683,7 @@ let questions = [
     message: 'Please provide the url to your magento rest api',
     default: 'http://demo-magento2.vuestorefront.io/rest',
     when: function (answers) {
-      return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+      return answers.m2_api_oauth2 === true
     },
     filter: function (url) {
       let prefix = 'http://'
@@ -705,7 +705,7 @@ let questions = [
     message: 'Please provide your consumer key',
     default: 'byv3730rhoulpopcq64don8ukb8lf2gq',
     when: function (answers) {
-      return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+      return answers.m2_api_oauth2 === true
     }
   },
   {
@@ -714,7 +714,7 @@ let questions = [
     message: 'Please provide your consumer secret',
     default: 'u9q4fcobv7vfx9td80oupa6uhexc27rb',
     when: function (answers) {
-      return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+      return answers.m2_api_oauth2 === true
     }
   },
   {
@@ -723,16 +723,16 @@ let questions = [
     message: 'Please provide your access token',
     default: '040xx3qy7s0j28o3q0exrfop579cy20m',
     when: function (answers) {
-      return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+      return answers.m2_api_oauth2 === true
     }
   },
   {
     type: 'input',
     name: 'm2_api_access_token_secret',
-    message: 'Please provide your access secret',
+    message: 'Please provide your access token secret',
     default: '7qunl3p505rubmr7u1ijt7odyialnih9',
     when: function (answers) {
-      return answers.is_remote_backend === false && answers.m2_api_oauth2 === true
+      return answers.m2_api_oauth2 === true
     }
   }
 ]


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/1842

### Short description and why it's useful

We can now use the installer to specify the oauth2 keys for magento2 integration.

### Screenshots of visual changes before/after (if there are any)

(if you made any changes in the UI layer please provide before/after screenshots)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

(run `yarn tests:e2e` and paste the results. If you are not using our standard backend setup or demo.vuestorefront.io you can ommit this step) 

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
