### PR TITLE
added multistore support for mailchimp module

### DIFF
--- a/core/modules/mailchimp/components/Subscribe.ts
+++ b/core/modules/mailchimp/components/Subscribe.ts
@@ -1,4 +1,3 @@
-
 import { required, email } from 'vuelidate/lib/validators'
 
 /**

--- a/core/modules/mailchimp/store/index.ts
+++ b/core/modules/mailchimp/store/index.ts
@@ -2,10 +2,13 @@ import * as TYPES from './mutation-types'
 import config from 'config'
 import * as localForage from 'localforage'
 import UniversalStorage from '@vue-storefront/core/store/lib/storage'
+import { currentStoreView } from '@vue-storefront/store/lib/multistore'
 
+const storeView = currentStoreView()
+const dbNamePrefix = storeView.storeCode ? storeView.storeCode + '-' : ''
 const cacheStorage = new UniversalStorage(localForage.createInstance({
-  name: 'shop',
-  storeName: 'mailchimpModule'
+  name: dbNamePrefix + 'shop',
+  storeName: 'mailchimp'
 }))
 
 export default {
@@ -26,7 +29,6 @@ export default {
     }
   },
   actions: {
-
     subscribe ({ commit, state }, email) {
       if (!state.isSubscribed) {
         return new Promise((resolve, reject) => {
@@ -38,6 +40,7 @@ export default {
           }).then(res => {
             commit(TYPES.NEWSLETTER_SUBSCRIBE)
             commit(TYPES.SET_EMAIL, email)
+            cacheStorage.setItem('email', email)
             resolve(res)
           }).catch(err => {
             reject(err)


### PR DESCRIPTION
### Related issues

(put links to related issues here)

### Short description and why it's useful

(describe in a few words what is this Pull Request changing and why it's useful)

### Screenshots of visual changes before/after (if there are any)

(if you made any changes in the UI layer please provide before/after screenshots)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

(run `yarn tests:e2e` and paste the results. If you are not using our standard backend setup or demo.vuestorefront.io you can ommit this step) 

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and curently important rules acceptance

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and [refactoring plan for them](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/refactoring-to-modules.md)
