### PR TITLE
Possible solution for docker-compose up hanging on Windows installation

### DIFF
--- a/docs/guide/installation/windows.md
+++ b/docs/guide/installation/windows.md
@@ -39,6 +39,8 @@ docker-compose up
 
 This step can take some minutes.
 
+Note: If it appears that docker-compose is hanging, try opening a new terminal and continue to the next step using that terminal. Allow docker-compose to continue running in the background.
+
 6. Restore products database and run latest migrations
 
 ```bash


### PR DESCRIPTION

### Related issues

docker-compose up hanging during Windows installation (though it was waiting, not hanging)

### Short description and why it's useful

I'm not too good with terminology, but this was what I did to get through the setup when it seemed like docker was hanging (which it actually wasn't; it was waiting for activity on the actual website). This may not be a real problem for developers who are familiar with Docker or developing on Windows, but I am a new developer and this was very frustrating for me to get past.