### PR TITLE
Added posibility to extend currently existing vuex stores from modules

### DIFF
--- a/core/modules-entry.ts
+++ b/core/modules-entry.ts
@@ -1,12 +1,24 @@
 
-import { VueStorefrontModule } from './modules'
+import { VueStorefrontModule, VueStorefrontModuleConfig } from './modules'
 import { Cart } from './modules/cart'
 import { Review } from './modules/review'
 import { Wishlist } from './modules/wishlist'
 import { Mailchimp } from './modules/mailchimp'
 import { Mailer } from './modules/mailer'
-// import { Example } from './modules/module-template'
+import { Example } from './modules/module-template'
 
+
+// You can extend any module before registration like this
+const extendedExample: VueStorefrontModuleConfig = {
+  key: 'extend',
+  afterRegistration: function(Vue, config) {
+    console.info('Hello, im extended now')
+  }
+}
+
+Example.extend(extendedExample)
+
+// This modules will be registered in the app
 export const enabledModules: VueStorefrontModule[] = [
   Cart,
   Review,

--- a/core/modules/index.ts
+++ b/core/modules/index.ts
@@ -7,7 +7,7 @@ import { merge } from 'lodash-es'
 
 export interface VueStorefrontModuleConfig {
   key: string;
-  store?: { module?: Module<any, any>, plugin?: Function };
+  store?: { module?: Module<any, any>, plugin?: Function, extend?: { key: string, module: Module<any, any> }[] };
   router?: { routes?: RouteConfig[], beforeEach?: NavigationGuard, afterEach?: NavigationGuard },
   beforeRegistration?: (Vue: VueConstructor, config: Object) => void,
   afterRegistration?: (Vue: VueConstructor, config: Object) => void,
@@ -19,30 +19,49 @@ function extendRouter (routes?: RouteConfig[], beforeEach?: NavigationGuard, aft
   if (afterEach) router.afterEach(afterEach)
 }
 
-function extendStore (key: string, store: Module<any, any>, plugin: any) : void {
+function extendStore (key: string, store: Module<any, any>, plugin: any, extend: { key: string, module: Module<any, any> }[]) : void {
+  const registeredStores: any = rootStore
+  console.info(extend)
   if (store) {
-    let registeredStores: any = rootStore
-    // Merge stores with conflicting keys
+    // in case of conflicting keys throw warning 
     if (registeredStores._modules.root._children[key]) {
-      rootStore.registerModule(key, merge(store, registeredStores._modules.root._children[key]._rawModule))
+      // rootStore.registerModule(key, merge(store, registeredStores._modules.root._children[key]._rawModule))
+      throw new Error('Error during VS Module registration. Module with key "' + key + '" that you are trying to register already exists. If you are trying to extend currently existing module use store.extend property.')
     } else {
       rootStore.registerModule(key, store)
     }
   }
   if (plugin) rootStore.subscribe(plugin)
+  if (extend) {
+    extend.forEach(extendStore => {
+      console.info(extendStore)
+      if (registeredStores._modules.root._children[extendStore.key]) {
+        const newStore = merge(registeredStores._modules.root._children[extendStore.key]._rawModule, extendStore.module)
+        rootStore.unregisterModule(extendStore.key)
+        rootStore.registerModule(extendStore.key, newStore)
+        console.info(rootStore)
+      } else {
+        throw new Error('Error during VS Module registration. Module with key "' + key + '" that you are trying to extend already exists. If you want to register new Vuex store use store.module property.')
+      }
+    })
+  }
 }
 
 export class VueStorefrontModule {
   constructor (
     private _c: VueStorefrontModuleConfig
   ) { }
+
+  public extend (extendedConfig: VueStorefrontModuleConfig) {
+    this._c = merge(this._c, extendedConfig)
+  }
   /**
    * Registers module in app with before/after hooks, store and router.
    * Should be called inside an apps entry point available for both server and client.
    */
   public register (): void {
     if (this._c.beforeRegistration) this._c.beforeRegistration(Vue, rootStore.state.config)
-    if (this._c.store) extendStore(this._c.key, this._c.store.module, this._c.store.plugin)
+    if (this._c.store) extendStore(this._c.key, this._c.store.module, this._c.store.plugin, this._c.store.extend)
     if (this._c.router) extendRouter(this._c.router.routes, this._c.router.beforeEach, this._c.router.afterEach)
     if (this._c.afterRegistration) this._c.afterRegistration(Vue, rootStore.state.config)
   }

--- a/core/modules/module-template/index.ts
+++ b/core/modules/module-template/index.ts
@@ -2,6 +2,7 @@
 // Read more about modules: https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md
 import { module } from './store'
 import { plugin } from './store/plugin'
+import { extendMailchimp } from './store/mailchimp'
 import { beforeRegistration } from './hooks/beforeRegistration'
 import { afterRegistration } from './hooks/afterRegistration'
 import { VueStorefrontModule, VueStorefrontModuleConfig } from '@vue-storefront/core/modules'
@@ -17,7 +18,7 @@ export const cacheStorage = initCacheStorage(KEY)
 // Put everything that should extend the base app here so it can be later registered as VS module
 const moduleConfig: VueStorefrontModuleConfig = {
   key: KEY,
-  store: { module, plugin },
+  store: { module, plugin, extend: [{ key: 'mailchimp', module: extendMailchimp}] },
   beforeRegistration,
   afterRegistration,
   router: { routes, beforeEach, afterEach }

--- a/core/modules/module-template/store/mailchimp/index.ts
+++ b/core/modules/module-template/store/mailchimp/index.ts
@@ -1,0 +1,22 @@
+// With store.extend property you can extend currently existing VS modules. 
+// Vuex Module below will be merged with the one with the same key property.
+// You can add new properties to currently existing stores or override existing ones just by using the same name
+// In this example we will override mailchimp vuex store
+import { Module } from 'vuex'
+
+// you can use mailchimp state instead of any 
+export const extendMailchimp: Module<any, any> = {
+  state: {
+    addedproperty: 'Hello!'
+  },
+  actions: {
+    unsubscribe () {
+      // mailchimp module 'unsubscribe' action will be overwritten by this one
+      console.info('Hello from mailchimp module extension! Now this action is broken ;o')
+    },
+    logHello () {
+      // this action will be added to mailchimp vuex module
+      console.info('Hello!')
+    }
+  }
+}


### PR DESCRIPTION
### Related issues

(put links to related issues here)

### Short description and why it's useful

(describe in a few words what is this Pull Request changing and why it's useful)

### Screenshots of visual changes before/after (if there are any)

(if you made any changes in the UI layer please provide before/after screenshots)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

(run `yarn test:e2e` and paste the results. If you are not using our standard backend setup or demo.vuestorefront.io you can ommit this step) 

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
