### PR TITLE
Fixed bug with empty product collection after scroll down and sort by…

### DIFF
--- a/core/pages/Category.js
+++ b/core/pages/Category.js
@@ -181,13 +181,13 @@ export default {
 
       let filterQr = buildFilterProductsQuery(this.category, this.filters.chosen)
 
-      const fsC = Object.assign({}, this.filters.chosen) // create a copy because it will be used asynchronously (take a look below)
+      const filtersConfig = Object.assign({}, this.filters.chosen) // create a copy because it will be used asynchronously (take a look below)
       this.$store.state.category.current_product_query = Object.assign(this.$store.state.category.current_product_query, {
         populateAggregations: false,
         searchProductQuery: filterQr,
         current: this.pagination.current,
         perPage: this.pagination.perPage,
-        configuration: fsC,
+        configuration: filtersConfig,
         append: false,
         includeFields: null,
         excludeFields: null
@@ -196,12 +196,19 @@ export default {
       }) // because already aggregated
     },
     onSortOrderChanged (param) {
+      this.pagination.current = 0
       if (param.attribute) {
+        const filtersConfig = Object.assign({}, this.filters.chosen) // create a copy because it will be used asynchronously (take a look below)
         let filterQr = buildFilterProductsQuery(this.category, this.filters.chosen)
         this.$store.state.category.current_product_query = Object.assign(this.$store.state.category.current_product_query, {
           sort: param.attribute + ':' + param.direction,
           searchProductQuery: filterQr,
-          append: false
+          current: this.pagination.current,
+          perPage: this.pagination.perPage,
+          configuration: filtersConfig,
+          append: false,
+          includeFields: null,
+          excludeFields: null
         })
         this.$store.dispatch('category/products', this.$store.state.category.current_product_query).then((res) => {
         })


### PR DESCRIPTION
… select change (lazy loading bug)

### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/1806

### Short description and why it's useful

There was a bug connected with lazy loading pagination - when site was scrolled down pagination position has changed but and in sort order change method it was not reseted, so product collection was empty.

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
