### PR TITLE
Proper name and private set for docs package

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "@vue-storefront/docs",
+  "private": true,
+  "version": "0.1.0",
   "scripts": {
     "docs:dev": "vuepress dev",
     "docs:build": "vuepress build"


### PR DESCRIPTION
Apart of these changes, I have a question about adding `docs` directory to  `package.json` yarn `workspaces` array. 
Docs are not part of the VSF app itself, so it's not important to install their dependencies for everyone. Also, this package is not going to be published to npm, so for me, it should be separated.