### PR TITLE
Fix - Adjusted search sidebar component #971

### DIFF
--- a/src/themes/default/components/core/blocks/SearchPanel/SearchPanel.vue
+++ b/src/themes/default/components/core/blocks/SearchPanel/SearchPanel.vue
@@ -83,10 +83,12 @@ export default {
 
 <style lang="scss" scoped>
 @import "~theme/css/animations/transitions";
+@import "~theme/css/variables/grid";
+@import "~theme/css/variables/typography";
 
 .searchpanel {
   height: 100vh;
-  width: 800px;
+  width: 928px;
   top: 0;
   right: 0;
   z-index: 3;
@@ -94,6 +96,7 @@ export default {
   transition: transform 300ms $motion-main;
   overflow-y: auto;
   overflow-x: hidden;
+
   .close-icon-row {
     display: flex;
     justify-content: flex-end;
@@ -102,16 +105,31 @@ export default {
   .container {
     padding-left: 40px;
     padding-right: 40px;
+
+    @media #{$media-xs} {
+      padding-left: 30px;
+      padding-right: 30px;
+    }
   }
 
   .row {
-    margin-left: -15px;
-    margin-right: -15px;
+    margin-left: - map-get($grid-gutter-widths, lg) / 2;
+    margin-right: - map-get($grid-gutter-widths, lg) / 2;
+
+    @media #{$media-xs} {
+      margin-right: - map-get($grid-gutter-widths, xs) / 2;
+      margin-left: - map-get($grid-gutter-widths, xs) / 2;
+    }
   }
 
   .col-md-12 {
-    padding-left: 15px;
-    padding-right: 15px;
+    padding-left: map-get($grid-gutter-widths, lg) / 2;
+    padding-right: map-get($grid-gutter-widths, lg) / 2;
+
+    @media #{$media-xs} {
+      padding-left: map-get($grid-gutter-widths, xs) / 2;
+      padding-right: map-get($grid-gutter-widths, xs) / 2;
+    }
   }
 
   .product-listing {
@@ -121,12 +139,18 @@ export default {
   .product {
     box-sizing: border-box;
     width: 33.33%;
-    padding-left: 15px;
-    padding-right: 15px;
+    padding-left: map-get($grid-gutter-widths, lg) / 2;
+    padding-right: map-get($grid-gutter-widths, lg) / 2;
+
+    @media #{$media-xs} {
+      width: 50%;
+      padding-left: map-get($grid-gutter-widths, xs) / 2;
+      padding-right: map-get($grid-gutter-widths, xs) / 2;
+    }
   }
 
   &.active {
-    transform: translateX(0)
+    transform: translateX(0);
   }
 
   .close-icon {
@@ -147,12 +171,18 @@ export default {
   }
 
   .search-panel-input {
-    border: none;
     width: 100%;
-    padding-bottom: 0px;
-    padding-top: 0px;
-    outline: 0;
     height: 60px;
+    padding-bottom: 0;
+    padding-top: 0;
+    border: none;
+    outline: 0;
+    font-size: 18px;
+    font-family: map-get($font-families, secondary);
+
+    @media #{$media-xs} {
+      font-size: 16px;
+    }
   }
 
   .no-results {
@@ -171,33 +201,9 @@ export default {
   .close-button {
     background: #fff;
   }
-}
 
-@media only screen and (max-width:575.98px) {
-  .searchpanel {
-
-     .container {
-      padding-left: 30px;
-      padding-right: 30px;
-    }
-
-    .row {
-      margin-right: -10px;
-      margin-left: -10px;
-    }
-
-    .col-md-12 {
-      padding-left: 10px;
-      padding-right: 10px;
-    }
-
-    .product {
-      width: 50%;
-      padding-left: 10px;
-      padding-right: 10px;
-    }
-
-    button {
+  button {
+    @media #{$media-xs} {
       width: 100%;
       margin-bottom: 15px;
     }

--- a/src/themes/default/css/variables/_grid.scss
+++ b/src/themes/default/css/variables/_grid.scss
@@ -1,0 +1,43 @@
+// Grid
+// ====
+// Settings for grid project
+//
+// stylelint-disable indentation, number-no-trailing-zeros
+
+// Grid breakpoints
+//
+// Define the minimum dimensions at which your layout will change,
+// adapting to different screen sizes, for use in media queries.
+
+$breakpoints: (
+        xs: 1px,
+        xsm: 400px,
+        sm: 768px,
+        md: 1025px,
+        lg: 1200px
+);
+
+// Grid columns
+// ------------
+// Set the width of the gutters.
+
+$grid-gutter-widths: (
+        xs: 10px,
+        sm: 30px,
+        md: 30px,
+        lg: 30px
+) !default;
+$test: 2;
+$screen: "only screen";
+
+// breakpoint settings look helpers/bs-variables
+$media-lg: "#{$screen} and (min-width:#{map-get($breakpoints, lg)})"; // min 1200px
+$media-md-up: "#{$screen} and (min-width:#{map-get($breakpoints, md)})"; //min 1025px
+$media-md: "#{$screen} and (min-width:#{map-get($breakpoints, md)}) and (max-width:#{map-get($breakpoints, lg) - 1})"; //min 1025px max 1199px
+$media-to-md: "#{$screen} and (max-width:#{map-get($breakpoints, lg) - 1})"; //max 1199px
+$media-sm-up: "#{$screen} and (min-width:#{map-get($breakpoints, sm)})"; // min 768px
+$media-sm: "#{$screen} and (min-width:#{map-get($breakpoints, sm)}) and (max-width:#{map-get($breakpoints, md) - 1})"; // min 768 max 1024px
+$media-to-sm: "#{$screen} and (max-width:#{map-get($breakpoints, md) - 1})"; // max 1024px
+$media-xs: "#{$screen} and (max-width:#{map-get($breakpoints, sm) - 1})"; // max 767px
+$media-xs-up: "#{$screen} and (min-width:#{map-get($breakpoints, xs)})";// min 1px
+$media-to-xxs: "#{$screen} and (max-width:#{map-get($breakpoints, xsm)})"; // max 400px

--- a/src/themes/default/css/variables/_typography.scss
+++ b/src/themes/default/css/variables/_typography.scss
@@ -1,0 +1,17 @@
+// Typography
+// ==========
+// Font sizes and families
+//
+// stylelint-disable indentation
+
+// Font Families
+// -------------
+$font-fallbacks: (
+        sans-serif: '-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
+        serif: 'Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif'
+);
+
+$font-families: (
+        primary: ("Roboto", #{(map-get($font-fallbacks, 'sans-serif'))}),
+        secondary: ("Playfair Display", map-get($font-fallbacks, 'serif'))
+) !default;

--- a/src/themes/default/css/variables/_variables.scss
+++ b/src/themes/default/css/variables/_variables.scss
@@ -3,3 +3,9 @@
 
 // Colors
 @import 'colors';
+
+// Grid
+@import 'grid';
+
+// Typography
+@import 'typography';


### PR DESCRIPTION
### Related issues

#971

### Short description and why it's useful

I adjusted search sidebar component to look like template in figma:
- change width of sidebar from 800px to 928px
- add new scss file with all media queries and grid gutters widths to use them globally
- add new scss file with variables for fonts to use them globally
- grid gutters widths on mobile from 20px to 10px
- change font size in search panel input to 18px on desktop and 16px on mobile