### PR TITLE
#854 added confirm dialog before removing a product from cart

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -137,6 +137,7 @@
       "synchronize_totals": true,
       "setCustomProductOptions": true,
       "setConfigurableProductOptions": true,
+      "askBeforeRemoveProduct": true,
       "create_endpoint": "http://localhost:8080/api/cart/create?token={{token}}",
       "updateitem_endpoint": "http://localhost:8080/api/cart/update?token={{token}}&cartId={{cartId}}",
       "deleteitem_endpoint": "http://localhost:8080/api/cart/delete?token={{token}}&cartId={{cartId}}",

--- a/core/components/Notification.js
+++ b/core/components/Notification.js
@@ -17,9 +17,12 @@ export default {
         return
       }
       this.notifications.push(data)
-      setTimeout(() => {
-        this.action('close', this.notifications.length - 1)
-      }, data.timeToLive || 5000)
+
+      if (!data.hasNoTimeout) {
+        setTimeout(() => {
+          this.action('close', this.notifications.length - 1)
+        }, data.timeToLive || 5000)
+      }
     },
     action (action, id, notification) {
       this.$bus.$emit('notification-after-' + action, notification)

--- a/core/components/blocks/Microcart/Product.js
+++ b/core/components/blocks/Microcart/Product.js
@@ -1,3 +1,4 @@
+import rootStore from '@vue-storefront/store'
 import { MicrocartProduct } from '@vue-storefront/core/modules/cart/components/Product.ts'
 import i18n from '../../../i18n'
 
@@ -21,14 +22,18 @@ export default {
   },
   methods: {
     removeItem () {
-      this.$bus.$emit('notification', {
-        type: 'warning',
-        item: this.product,
-        message: i18n.t('Are you sure you would like to remove this item from the shopping cart?'),
-        action2: { label: i18n.t('OK'), action: 'itemremoved' },
-        action1: { label: i18n.t('Cancel'), action: 'close' },
-        hasNoTimeout: true
-      })
+      if (rootStore.state.config.cart.askBeforeRemoveProduct) {
+        this.$bus.$emit('notification', {
+          type: 'warning',
+          item: this.product,
+          message: i18n.t('Are you sure you would like to remove this item from the shopping cart?'),
+          action2: { label: i18n.t('OK'), action: 'itemremoved' },
+          action1: { label: i18n.t('Cancel'), action: 'close' },
+          hasNoTimeout: true
+        })
+      } else {
+        this.removeFromCart()
+      }
     },
     updateQuantity () {
       // additional logic will be moved to theme

--- a/core/components/blocks/Microcart/Product.js
+++ b/core/components/blocks/Microcart/Product.js
@@ -1,4 +1,5 @@
 import { MicrocartProduct } from '@vue-storefront/core/modules/cart/components/Product.ts'
+import i18n from '../../../i18n'
 
 export default {
   data () {
@@ -11,15 +12,23 @@ export default {
   beforeMount () {
     // deprecated, will be moved to theme or removed in the near future #1742
     this.$bus.$on('cart-after-itemchanged', this.onProductChanged)
+    this.$bus.$on('notification-after-itemremoved', this.onProductRemoved)
   },
   beforeDestroy () {
     // deprecated, will be moved to theme or removed in the near future #1742
     this.$bus.$off('cart-after-itemchanged', this.onProductChanged)
+    this.$bus.$off('notification-after-itemremoved', this.onProductRemoved)
   },
   methods: {
     removeItem () {
-      // renamed to removefromCart
-      this.removeFromCart()
+      this.$bus.$emit('notification', {
+        type: 'warning',
+        item: this.product,
+        message: i18n.t('Are you sure you would like to remove this item from the shopping cart?'),
+        action2: { label: i18n.t('OK'), action: 'itemremoved' },
+        action1: { label: i18n.t('Cancel'), action: 'close' },
+        hasNoTimeout: true
+      })
     },
     updateQuantity () {
       // additional logic will be moved to theme
@@ -34,6 +43,11 @@ export default {
       // deprecated, will be moved to theme or removed in the near future #1742
       if (event.item.sku === this.product.sku) {
         this.$forceUpdate()
+      }
+    },
+    onProductRemoved (event) {
+      if (event.item.sku === this.product.sku) {
+        this.removeFromCart(event.item)
       }
     },
     switchEdit () {

--- a/core/i18n/resource/i18n/de-DE.csv
+++ b/core/i18n/resource/i18n/de-DE.csv
@@ -35,3 +35,4 @@
 "404 Page Not Found","404 Seite nicht gefunden"
 "Error with response - bad content-type!","Fehler in der Antwort vom Server - Falscher content-type!"
 "Unhandled error, wrong response format!","Unbehandelter Fehler. Die Antwort vom Server ist falsch formatiert!"
+"Are you sure you would like to remove this item from the shopping cart?","Sind Sie sicher, dass sie diesen Artikel aus Ihrem Warenkorb entfernen wollen?"

--- a/core/i18n/resource/i18n/en-US.csv
+++ b/core/i18n/resource/i18n/en-US.csv
@@ -63,3 +63,4 @@
 "Summary","Summary",
 "login","login"
 "to account","to account"
+"Are you sure you would like to remove this item from the shopping cart?","Are you sure you would like to remove this item from the shopping cart?"

--- a/core/i18n/resource/i18n/es-ES.csv
+++ b/core/i18n/resource/i18n/es-ES.csv
@@ -35,3 +35,5 @@
 "404 Page Not Found","404 Pagina no encontrada"
 "Error with response - bad content-type!","Error con la respuesta - ¡tipo de contenido incorrecto!"
 "Unhandled error, wrong response format!","¡Error no controlado, formato de respuesta incorrecto!"
+"Are you sure you would like to remove this item from the shopping cart?","¿Está seguro de que desea eliminar este artículo de la cesta de la compra?"
+

--- a/core/i18n/resource/i18n/fr-FR.csv
+++ b/core/i18n/resource/i18n/fr-FR.csv
@@ -45,3 +45,4 @@
 "Please configure product custom options and fix the validation errors","Veuillez configurer les options du produit et corriger les erreurs de validation"
 "Error refreshing user token. User is not authorized to access the resource","Une erreur est survenue. L'utilisateur n'est pas autorisé à accéder à cette ressource"
 "Must be greater than 0","Doit être supérieur à 0"
+"Are you sure you would like to remove this item from the shopping cart?","Etes-vous sûr de vouloir supprimer cet objet de votre panier ?"

--- a/core/i18n/resource/i18n/it-IT.csv
+++ b/core/i18n/resource/i18n/it-IT.csv
@@ -48,3 +48,4 @@
 "No available product variants","Non ci sono varianti disponibili"
 "email","email"
 "password","password"
+"Are you sure you would like to remove this item from the shopping cart?","Sei sicuro di voler rimuovere questo articolo dal carrello?"

--- a/core/i18n/resource/i18n/jp-JP.csv
+++ b/core/i18n/resource/i18n/jp-JP.csv
@@ -35,3 +35,4 @@
 "404 Page Not Found","404ページが見つかりません"
 "Error with response - bad content-type!","エラー：無効なcontent-type!"
 "Unhandled error, wrong response format!","処理不能エラー、レスポンスのフォーマットが間違っています!"
+"Are you sure you would like to remove this item from the shopping cart?","ショッピングカートからこのアイテムを削除してもよろしいですか？"

--- a/core/i18n/resource/i18n/nl-NL.csv
+++ b/core/i18n/resource/i18n/nl-NL.csv
@@ -35,3 +35,4 @@ Compare Products,Producten vergelijken
 404 Page Not Found,404 Pagina niet gevonden
 Error with response - bad content-type!,Error with response - bad content-type!
 "Unhandled error, wrong response format!","Unhandled error, wrong response format!"
+"Are you sure you would like to remove this item from the shopping cart?","Weet u zeker dat u dit artikel uit uw mandje wilt verwijderen?"

--- a/core/i18n/resource/i18n/pl-PL.csv
+++ b/core/i18n/resource/i18n/pl-PL.csv
@@ -44,3 +44,4 @@
 "Please configure product custom options and fix the validation errors","Skonfiguruj opcje produktu i popraw będy walidacji"
 "Error refreshing user token. User is not authorized to access the resource","Błąd odświeżania tokenu użytkownika. Użytkownik nie dostępu do zasobu"
 "Must be greater than 0","Musi być większa niż 0"
+"Are you sure you would like to remove this item from the shopping cart?","Czy na pewno chcesz usunąć ten produkt z koszyka?"

--- a/core/i18n/resource/i18n/pt-BR.csv
+++ b/core/i18n/resource/i18n/pt-BR.csv
@@ -39,3 +39,4 @@
 "Internal Application error while refreshing the tokens. Please clear the storage and refresh page.","Erro Interno da Aplicação ao atualizar os tokens. Por favor limpe o cache do seu navegador e atualize a página."
 "Proceed to checkout","Ir para Finalização de Compra"
 "OK","OK"
+"Are you sure you would like to remove this item from the shopping cart?","Tem certeza de que deseja remover este item do carrinho de compras?"

--- a/core/i18n/resource/i18n/ru-RU.csv
+++ b/core/i18n/resource/i18n/ru-RU.csv
@@ -35,3 +35,4 @@
 "404 Page Not Found","404 Страница не найдена"
 "Error with response - bad content-type!","Ошибка в ответе - плохой content-type!"
 "Unhandled error, wrong response format!","Необработанная ошибка, неверный формат ответа!"
+"Are you sure you would like to remove this item from the shopping cart?","Вы уверены, что хотите удалить этот товар из корзины?"


### PR DESCRIPTION
### Related issues

Missing confirm dialog before remove product from cart #854

### Short description and why it's useful

It's useful for the user not to delete a product by accident from cart 

### Screenshots of visual changes before/after (if there are any)

Before
![before](https://user-images.githubusercontent.com/9677257/47571203-47c09700-d938-11e8-8b13-406640b06aba.png)


After
<img width="1499" alt="after" src="https://user-images.githubusercontent.com/9677257/47571230-5a3ad080-d938-11e8-88c0-91059d6517a8.png">

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

not required

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
