### PR TITLE
Always add magento2 api configuration

### DIFF
--- a/core/scripts/installer.js
+++ b/core/scripts/installer.js
@@ -264,11 +264,12 @@ class Backend extends Abstract {
         config.imageable.whitelist.allowedHosts.push(host)
 
         config.magento2.url = urlParser(this.answers.m2_url).href
-        config.magento2.api.url = urlParser(this.answers.m2_api_url).href
-        config.magento2.api.consumerKey = this.answers.m2_api_consumer_key
-        config.magento2.api.consumerSecret = this.answers.m2_api_consumer_secret
-        config.magento2.api.accessToken = this.answers.m2_api_access_token
-        config.magento2.api.accessTokenSecret = this.answers.m2_api_access_token_secret
+        config.magento2.imgUrl = urlParser(this.answers.images_endpoint).href
+        config.magento2.api.url = urlParser(this.answers.m2_api_url).href || config.magento2.api.url
+        config.magento2.api.consumerKey = this.answers.m2_api_consumer_key || config.magento2.api.consumerKey
+        config.magento2.api.consumerSecret = this.answers.m2_api_consumer_secret || config.magento2.api.consumerSecret
+        config.magento2.api.accessToken = this.answers.m2_api_access_token || config.magento2.api.accessToken
+        config.magento2.api.accessTokenSecret = this.answers.m2_api_access_token_secret || config.magento2.api.accessTokenSecret
 
         jsonFile.writeFileSync(TARGET_BACKEND_CONFIG_FILE, config, {spaces: 2})
       } catch (e) {
@@ -732,21 +733,21 @@ let questions = [
     }
   },
   {
+    type: 'input',
+    name: 'm2_url',
+    message: 'Please provide your magento url',
+    default: 'http://demo-magento2.vuestorefront.io',
+    when: function (answers) {
+      return answers.is_remote_backend === false
+    }
+  },
+  {
     type: 'confirm',
     name: 'm2_api_oauth2',
     message: `Would You like to perform initial data import from Magento2 instance?`,
     default: false,
     when: function (answers) {
       return answers.is_remote_backend === false
-    }
-  },
-  {
-    type: 'input',
-    name: 'm2_url',
-    message: 'Please provide your magento url',
-    default: 'http://demo-magento2.vuestorefront.io',
-    when: function (answers) {
-      return answers.m2_api_oauth2 === true
     }
   },
   {


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/pull/1847
https://github.com/DivanteLtd/vue-storefront/issues/1842
DivanteLtd/mage2vuestorefront#29 (comment)

### Short description and why it's useful

The magento2.imgUrl and also the magento2.api.* should always be stored in configuration.
If not the default backend (https://demo.vuestorefront.io) is used, then the user will be asked to supply the magento2 url and also choose to setup credentials and import data to elasticsearch. If the user does not choose to setup credentials, then the defaults from `vue-storefront/config/default.json` file will be used.

### Screenshots of visual changes before/after (if there are any)

(if you made any changes in the UI layer please provide before/after screenshots)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

(run `yarn test:e2e` and paste the results. If you are not using our standard backend setup or demo.vuestorefront.io you can ommit this step) 

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
