### PR TITLE
[WIP] Lazy vs modules

### DIFF
--- a/core/app.ts
+++ b/core/app.ts
@@ -60,9 +60,9 @@ function createRouter (): VueRouter {
   })
 }
 
-function registerModules (modules: VueStorefrontModule[], store: Store<RootState>, router: VueRouter, context): void {
+function registerModules (modules: VueStorefrontModule[], context): void {
   let registeredModules = []
-  modules.forEach(m => registeredModules.push(m.register(store, router)))
+  modules.forEach(m => registeredModules.push(m.register()))
   Logger.info('VS Modules registration finished.', 'module', {
       succesfulyRegistered: registeredModules.length + ' / ' + modules.length,
       registrationOrder: registeredModules
@@ -176,7 +176,7 @@ function createApp (ssrContext, config): { app: Vue, router: VueRouter, store: S
     ssrContext
   }
 
-  registerModules(enabledModules, store, router, appContext)
+  registerModules(enabledModules, appContext)
   registerExtensions(extensions, app, router, store, config, ssrContext)
   registerTheme(buildTimeConfig.theme, app, router, store, store.state.config, ssrContext)
 

--- a/core/lib/module.ts
+++ b/core/lib/module.ts
@@ -6,6 +6,7 @@ import RootState from '@vue-storefront/store/types/RootState'
 import rootStore from '@vue-storefront/store'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import { setupMultistoreRoutes } from '@vue-storefront/store/lib/multistore'
+import { router } from '@vue-storefront/core/app'
 
 export interface VueStorefrontModuleConfig {
   key: string;
@@ -15,7 +16,14 @@ export interface VueStorefrontModuleConfig {
   afterRegistration?: (Vue?: VueConstructor, config?: Object, store?: Store<RootState>, isServer?: boolean) => void,
 }
 
+const moduleExtendings = []
+
+export function extendModule(moduleConfig) {
+  moduleExtendings.push(moduleConfig)
+}
+
 export class VueStorefrontModule {
+  private _isRegistered = false
   constructor (
     private _c: VueStorefrontModuleConfig,
   ) { }
@@ -49,32 +57,40 @@ export class VueStorefrontModule {
     if (beforeEach) routerInstance.beforeEach(beforeEach)
     if (afterEach) routerInstance.afterEach(afterEach)
   }
-
-  public extend (extendedConfig: VueStorefrontModule) {
+  
+  private _extend (extendedConfig: VueStorefrontModule) {
     const key = this._c.key
     this._c = merge(this._c, extendedConfig.config)
     Logger.info('Module "' + key + '" has been succesfully extended.', 'module')()
   }
 
-  public register (storeInstance, routerInstance): VueStorefrontModuleConfig | void {
-    let isUnique = true
-    if ( this._c.store) {
-      this._c.store.modules.forEach(store => {
-        if (VueStorefrontModule._doesStoreAlreadyExists(store.key)) {
-          Logger.error('Error during "' + this._c.key + '" module registration! Store with key "' + store.key + '" already exists!', 'module')()
-          isUnique = false
-        }
+  public register (): VueStorefrontModuleConfig | void {
+    if (!this._isRegistered) {
+      
+      moduleExtendings.forEach(extending => {
+        if (extending.key === this._c.key) this._extend(extending)
       })
-    }
 
-    if (isUnique) {
-      const isServer = typeof window === undefined
-      if (this._c.beforeRegistration) this._c.beforeRegistration(Vue, storeInstance.state.config, storeInstance, isServer)
-      if (this._c.store) VueStorefrontModule._extendStore(storeInstance, this._c.store.modules, this._c.store.plugin)
-      if (this._c.router) VueStorefrontModule._extendRouter(routerInstance, this._c.router.routes, this._c.router.beforeEach, this._c.router.afterEach)
-      VueStorefrontModule._registeredModules.push(this._c)
-      if (this._c.afterRegistration) this._c.afterRegistration(Vue, storeInstance.state.config, storeInstance, isServer)
-      return this._c
+      let isUnique = true
+      if ( this._c.store) {
+        this._c.store.modules.forEach(store => {
+          if (VueStorefrontModule._doesStoreAlreadyExists(store.key)) {
+            Logger.error('Error during "' + this._c.key + '" module registration! Store with key "' + store.key + '" already exists!', 'module')()
+            isUnique = false
+          }
+        })
+      }
+  
+      if (isUnique) {
+        const isServer = typeof window === undefined
+        if (this._c.beforeRegistration) this._c.beforeRegistration(Vue, rootStore.state.config, rootStore, isServer)
+        if (this._c.store) VueStorefrontModule._extendStore(rootStore, this._c.store.modules, this._c.store.plugin)
+        if (this._c.router) VueStorefrontModule._extendRouter(router, this._c.router.routes, this._c.router.beforeEach, this._c.router.afterEach)
+        VueStorefrontModule._registeredModules.push(this._c)
+        this._isRegistered = true
+        if (this._c.afterRegistration) this._c.afterRegistration(Vue, rootStore.state.config, rootStore, isServer)
+        return this._c
+      }
     }
   }
 }

--- a/core/lib/module.ts
+++ b/core/lib/module.ts
@@ -66,7 +66,6 @@ export class VueStorefrontModule {
 
   public register (): VueStorefrontModuleConfig | void {
     if (!this._isRegistered) {
-      
       moduleExtendings.forEach(extending => {
         if (extending.key === this._c.key) this._extend(extending)
       })

--- a/core/modules-entry.ts
+++ b/core/modules-entry.ts
@@ -1,6 +1,5 @@
 
 import { VueStorefrontModule } from '@vue-storefront/core/lib/module'
-import { Wishlist } from './modules/wishlist'
 import { Cms } from './modules/cms'
 import { Order } from './modules/order'
 import { User } from './modules/user'
@@ -8,7 +7,6 @@ import { registerModules } from 'src/modules'
 import { Breadcrumbs } from './modules/breadcrumbs'
 export const enabledModules: VueStorefrontModule[] = [
   Breadcrumbs,
-  Wishlist,
   Cms,
   Order,
   User,

--- a/core/modules/wishlist/components/AddToWishlist.ts
+++ b/core/modules/wishlist/components/AddToWishlist.ts
@@ -1,7 +1,8 @@
 import Product from '@vue-storefront/core/modules/catalog/types/Product'
+import { Wishlist as WishlistModule } from '../'
 
 export const AddToWishlist = {
-  name: 'AddToCart',
+  name: 'AddToWishlist',
   props: {
     product: {
       required: true,
@@ -10,6 +11,7 @@ export const AddToWishlist = {
   },
   methods: {
     addToWishlist (product: Product) {
+      WishlistModule.register()
       return this.$store.state['wishlist'] ? this.$store.dispatch('wishlist/addItem', product) : false
     }
   }

--- a/core/modules/wishlist/components/IsOnWishlist.ts
+++ b/core/modules/wishlist/components/IsOnWishlist.ts
@@ -2,6 +2,12 @@ import { Wishlist as WishlistModule } from '../'
 
 export const IsOnWishlist = {
   name: 'isOnWishlist',
+  props: {
+    product: {
+      required: true,
+      type: Object
+    }
+  },
   created () {
     WishlistModule.register()
   },

--- a/core/modules/wishlist/components/IsOnWishlist.ts
+++ b/core/modules/wishlist/components/IsOnWishlist.ts
@@ -1,0 +1,13 @@
+import { Wishlist as WishlistModule } from '../'
+
+export const IsOnWishlist = {
+  name: 'isOnWishlist',
+  created () {
+    WishlistModule.register()
+  },
+  computed: {
+    isOnWishlist (): boolean {
+      return !!this.$store.state.wishlist.items.find(p => p.sku === this.product.sku) || false
+    }
+  },
+}

--- a/core/modules/wishlist/components/RemoveFromWishlist.ts
+++ b/core/modules/wishlist/components/RemoveFromWishlist.ts
@@ -1,0 +1,18 @@
+import Product from '@vue-storefront/core/modules/catalog/types/Product'
+import { Wishlist as WishlistModule } from '../'
+
+export const RemoveFromWishlist = {
+  name: 'RemoveFromWishlist',
+  props: {
+    product: {
+      required: true,
+      type: Object
+    }
+  },
+  methods: {
+    removeFromWishlist (product: Product) {
+      WishlistModule.register()
+      this.$store.dispatch('wishlist/removeItem', product)
+    }
+  }
+}

--- a/core/modules/wishlist/components/Wishlist.ts
+++ b/core/modules/wishlist/components/Wishlist.ts
@@ -16,7 +16,7 @@ export const Wishlist = {
   },
   methods: {
     closeWishlist () {
-      this.$store.commit('ui/setWishlist', false)
+      this.$store.dispatch('ui/toggleWishlist')
     }
   }
 }

--- a/core/modules/wishlist/components/Wishlist.ts
+++ b/core/modules/wishlist/components/Wishlist.ts
@@ -1,6 +1,9 @@
+import { Wishlist as WishlistModule } from '../'
+
 export const Wishlist = {
   name: 'Wishlist',
   created () {
+    WishlistModule.register()
     this.$store.dispatch('wishlist/load')
   },
   computed: {

--- a/core/modules/wishlist/store/index.ts
+++ b/core/modules/wishlist/store/index.ts
@@ -3,6 +3,7 @@ import actions from './actions'
 import mutations from './mutations'
 import RootState from '@vue-storefront/store/types/RootState'
 import WishlistState from '../types/WishlistState'
+console.warn('regisetring')
 
 export const module:Module<WishlistState, RootState> = {
   namespaced: true,

--- a/core/pages/Product.js
+++ b/core/pages/Product.js
@@ -8,7 +8,6 @@ import { CompareProduct } from '@vue-storefront/core/modules/compare/components/
 import { AddToCompare } from '@vue-storefront/core/modules/compare/components/AddToCompare.ts'
 import { isOptionAvailableAsync } from '@vue-storefront/core/modules/catalog/helpers/index'
 import omit from 'lodash-es/omit'
-
 import Composite from '@vue-storefront/core/mixins/composite'
 
 export default {
@@ -53,9 +52,6 @@ export default {
       return Object.values(this.attributesByCode).filter(a => {
         return a.is_visible && a.is_user_defined && parseInt(a.is_visible_on_front) && this.product[a.attribute_code]
       })
-    },
-    isOnWishlist () {
-      return !!this.$store.state.wishlist.items.find(p => p.sku === this.product.sku)
     },
     currentStore () {
       return currentStoreView()

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,4 +1,4 @@
-import { isServer } from '@vue-storefront/core/helpers'
+// import { extendModule } from '@vue-storefront/core/lib/module'
 import { VueStorefrontModule } from '@vue-storefront/core/lib/module'
 import { Catalog } from "@vue-storefront/core/modules/catalog"
 import { Cart } from '@vue-storefront/core/modules/cart'
@@ -22,15 +22,20 @@ import { Magento2CMS } from './magento-2-cms'
 
 // Some modules  that still needs API refactoring are  temporary registered in core
 // This is how you can adjust any module with application-specific behavior
-const extendedExample = new VueStorefrontModule({
-  key: 'extend',
-  afterRegistration: function(isServer, config) {
-    console.info('Hello, im extended now!')
-  }
-})
+// const extendedExample = {
+//   key: 'example',
+//   afterRegistration: function(isServer, config) {
+//     console.info('Hello, im extended now!')
+//   }
+// }
 
-Example.extend(extendedExample)
+// extendModule(extendedExample)
 
+/**
+ * Some of the modules are registered lazily only when components from module are appearing on current page. 
+ * If you want to use this modules in pages without it's components you need to remember about registering module first
+ * - Wishlist
+ */
 export const registerModules: VueStorefrontModule[] = [
   Checkout,
   Catalog,
@@ -49,6 +54,6 @@ export const registerModules: VueStorefrontModule[] = [
   GoogleAnalytics,
   PaymentBackendMethods,
   RawOutputExample,
-  AmpRenderer
-  // Example
+  AmpRenderer,
+  Example
 ]

--- a/src/modules/ui-store/index.ts
+++ b/src/modules/ui-store/index.ts
@@ -68,7 +68,7 @@ const store = {
       commit('setMicrocart', !state.microcart)
     },
     toggleWishlist ({ commit, state }) {
-      commit('setWishlist', !state.microcart)
+      commit('setWishlist', !state.wishlist)
     }
   }
 }

--- a/src/themes/default-amp/pages/Product.vue
+++ b/src/themes/default-amp/pages/Product.vue
@@ -163,11 +163,6 @@ export default {
     }
   },
   directives: { focusClean },
-  computed: {
-    favoriteIcon () {
-      return this.isOnWishlist ? 'favorite' : 'favorite_border'
-    }
-  },
   methods: {
     showDetails (event) {
       this.detailsOpen = true

--- a/src/themes/default/components/core/blocks/Wishlist/AddToWishlist.vue
+++ b/src/themes/default/components/core/blocks/Wishlist/AddToWishlist.vue
@@ -12,9 +12,11 @@
 
 <script>
 import { IsOnWishlist } from '@vue-storefront/core/modules/wishlist/components/IsOnWishlist'
+import { AddToWishlist } from '@vue-storefront/core/modules/wishlist/components/AddToWishlist'
+import { RemoveFromWishlist } from '@vue-storefront/core/modules/wishlist/components/RemoveFromWishlist'
 
 export default {
-  mixins: [ IsOnWishlist ],
+  mixins: [ IsOnWishlist, AddToWishlist, RemoveFromWishlist ],
   computed: {
     favoriteIcon () {
       return this.isOnWishlist ? 'favorite' : 'favorite_border'

--- a/src/themes/default/components/core/blocks/Wishlist/IsOnWishlist.vue
+++ b/src/themes/default/components/core/blocks/Wishlist/IsOnWishlist.vue
@@ -1,0 +1,24 @@
+<template>
+  <button @click="isOnWishlist ? removeFromWishlist(product) : addToWishlist(product)" class="p0 inline-flex middle-xs bg-cl-transparent brdr-none action h5 pointer cl-secondary" type="button" data-testid="addToWishlist">
+    <i class="pr5 material-icons">{{ favoriteIcon }}</i>
+    <template v-if="!isOnWishlist">
+      {{ $t('Add to favorite') }}
+    </template>
+    <template v-else>
+      {{ $t('Remove') }}
+    </template>
+  </button>
+</template>
+
+<script>
+import { IsOnWishlist } from '@vue-storefront/core/modules/wishlist/components/IsOnWishlist'
+
+export default {
+  mixins: [ IsOnWishlist ],
+  computed: {
+    favoriteIcon () {
+      return this.isOnWishlist ? 'favorite' : 'favorite_border'
+    }
+  }
+}
+</script>

--- a/src/themes/default/components/core/blocks/Wishlist/Wishlist.vue
+++ b/src/themes/default/components/core/blocks/Wishlist/Wishlist.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="wishlist fixed mw-100 bg-cl-primary cl-accent" :class="{ active: isWishlistOpen }">
+  <div class="wishlist fixed mw-100 bg-cl-primary cl-accent">
     <div class="row">
       <div class="col-md-12 end-xs">
         <i class="material-icons p15 pointer cl-accent" @click="closeWishlist">close</i>
@@ -51,14 +51,10 @@ export default {
     top: 0;
     right: 0;
     z-index: 3;
-    transform: translateX(100%);
-    transition: transform 300ms $motion-main;
+    // transform: translateX(100%);
+    // transition: transform 300ms $motion-main;
     overflow-y: auto;
     overflow-x: hidden;
-
-    &.active {
-      transform: translateX(0)
-    }
   }
   i {
     opacity: 0.6;

--- a/src/themes/default/layouts/Default.vue
+++ b/src/themes/default/layouts/Default.vue
@@ -5,7 +5,11 @@
     <div id="viewport" class="w-100 relative">
       <microcart/>
       <search-panel/>
-      <wishlist/>
+      <no-ssr>
+        <transition name="slide-right">
+          <wishlist v-if="wishlistActive"/>
+        </transition>
+      </no-ssr>
       <sidebar-menu/>
       <main-header/>
       <router-view/>
@@ -23,13 +27,13 @@
 </template>
 
 <script>
+import NoSSR from 'vue-no-ssr'
 import { mapState } from 'vuex'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 
 import MainHeader from 'theme/components/core/blocks/Header/Header.vue'
 import MainFooter from 'theme/components/core/blocks/Footer/Footer.vue'
 
-import Wishlist from 'theme/components/core/blocks/Wishlist/Wishlist.vue'
 import Microcart from 'theme/components/core/blocks/Microcart/Microcart.vue'
 import SidebarMenu from 'theme/components/core/blocks/SidebarMenu/SidebarMenu.vue'
 import SearchPanel from 'theme/components/core/blocks/SearchPanel/SearchPanel.vue'
@@ -55,7 +59,8 @@ export default {
   },
   computed: {
     ...mapState({
-      overlayActive: state => state.ui.overlay
+      overlayActive: state => state.ui.overlay,
+      wishlistActive: state => state.ui.wishlist
     })
   },
   methods: {
@@ -84,7 +89,7 @@ export default {
     MainHeader,
     MainFooter,
     Microcart,
-    Wishlist,
+    'Wishlist': () => import(/* webpackChunkName: "wishlist" */'theme/components/core/blocks/Wishlist/Wishlist.vue'),
     SearchPanel,
     SidebarMenu,
     Overlay,
@@ -96,11 +101,22 @@ export default {
     CookieNotification,
     OfflineBadge,
     ModalSwitcher,
-    OrderConfirmation
+    OrderConfirmation,
+    'no-ssr': NoSSR
   }
 }
 </script>
 
 <style lang="scss" src="theme/css/main.scss">
 
+</style>
+<style lang="scss">
+.slide-right-enter, .slide-right-leave-to  {
+  transform: translateX(100%);
+  transition: transform 300ms;
+}
+.slide-right-enter-to, .slide-right-leave {
+  transform: translateX(0);
+  transition: transform 300ms;
+}
 </style>

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -158,23 +158,7 @@
             </div>
             <div class="row py40 add-to-buttons">
               <div class="col-xs-6 col-sm-3 col-md-6">
-                <button
-                  @click="isOnWishlist ? removeFromWishlist(product) : addToWishlist(product)"
-                  class="
-                    p0 inline-flex middle-xs bg-cl-transparent brdr-none
-                    action h5 pointer cl-secondary
-                  "
-                  type="button"
-                  data-testid="addToWishlist"
-                >
-                  <i class="pr5 material-icons">{{ favoriteIcon }}</i>
-                  <template v-if="!isOnWishlist">
-                    {{ $t('Add to favorite') }}
-                  </template>
-                  <template v-else>
-                    {{ $t('Remove') }}
-                  </template>
-                </button>
+                <is-on-wishlist :product="product" />
               </div>
               <div class="col-xs-6 col-sm-3 col-md-6">
                 <button
@@ -262,9 +246,11 @@ import ProductBundleOptions from 'theme/components/core/ProductBundleOptions.vue
 import ProductGallery from 'theme/components/core/ProductGallery'
 import PromotedOffers from 'theme/components/theme/blocks/PromotedOffers/PromotedOffers'
 import focusClean from 'theme/components/theme/directives/focusClean'
+import IsOnWishlist from 'theme/components/core/blocks/Wishlist/IsOnWishlist'
 
 export default {
   components: {
+    IsOnWishlist,
     AddToCart,
     Breadcrumbs,
     ColorSelector,
@@ -287,11 +273,6 @@ export default {
     }
   },
   directives: { focusClean },
-  computed: {
-    favoriteIcon () {
-      return this.isOnWishlist ? 'favorite' : 'favorite_border'
-    }
-  },
   methods: {
     showDetails (event) {
       this.detailsOpen = true

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -158,7 +158,7 @@
             </div>
             <div class="row py40 add-to-buttons">
               <div class="col-xs-6 col-sm-3 col-md-6">
-                <is-on-wishlist :product="product" />
+                <wishlist-button :product="product" />
               </div>
               <div class="col-xs-6 col-sm-3 col-md-6">
                 <button
@@ -246,11 +246,10 @@ import ProductBundleOptions from 'theme/components/core/ProductBundleOptions.vue
 import ProductGallery from 'theme/components/core/ProductGallery'
 import PromotedOffers from 'theme/components/theme/blocks/PromotedOffers/PromotedOffers'
 import focusClean from 'theme/components/theme/directives/focusClean'
-import IsOnWishlist from 'theme/components/core/blocks/Wishlist/IsOnWishlist'
 
 export default {
   components: {
-    IsOnWishlist,
+    'WishlistButton': () => import(/* webpackChunkName: "wishlist" */'theme/components/core/blocks/Wishlist/AddToWishlist'),
     AddToCart,
     Breadcrumbs,
     ColorSelector,


### PR DESCRIPTION
### Short description and why it's useful

This is a PoC of lazy loaded VS module. Some of non-critical modules will be written following the same pattern. It allows us to lazily load whole VS module and component for a given module (in this case wishlist)

Avoiding global registration of VS modules and putting this registration into components themeselves will also allow us to properly split VS modules into route chunks. 

How it works:
1. Module registration is removed
2. Module registers itself if any on it's components (except the ones responsible for opening it like WishlistButton) is visible on current view (it registers itself on created hook) so if we have Product page with AddToWishlist component (lazily loaded) it will be loaded with whole module and it's created hook will register it
3. If you want to use lazy vs modules store (like wishlist) without components you just need to register it before.


Example:
While we entering Home Page there are no components using Wishlist module therefore it's not downloaded:
![image](https://user-images.githubusercontent.com/15185752/49654924-689d0180-fa39-11e8-82e6-0fe364227d15.png)
When we click on WIshlistIcon the Wishlist component (along with module) will be lazily downloaded 
![image](https://user-images.githubusercontent.com/15185752/49654966-8ec2a180-fa39-11e8-8d9a-13c2a9b2649b.png)

I have plans to make most of VS modules work like this. This does not imply that all of them will be lazy loadable but moving registration to components ensures that if they are not lazy loaded directly - they'll be properly distributed into route chunks.