### PR TITLE
Fix date filter

### DIFF
--- a/core/filters/date.js
+++ b/core/filters/date.js
@@ -6,6 +6,6 @@ import { currentStoreView } from '@vue-storefront/store/lib/multistore'
  * @param {String} format
  */
 export function date (date, format) {
-  const storeView = currentStoreView()
-  return new Date(date).toLocaleString(storeView.i18n.defaultLocale)
+  const { defaultLocale } = currentStoreView().i18n
+  return new Date(date.replace(/-/g, '/')).toLocaleString(defaultLocale)
 }


### PR DESCRIPTION
### Short description and why it's useful
Fix created_at data from Magento (causes bug to display data in date filter in Safari and IE)
This is used on Customer/OrderHistory/Items and single items and so on (where used created_at property)
### Screenshots of visual changes before/after (if there are any)
![screen shot 2018-12-04 at 5 52 54 pm](https://user-images.githubusercontent.com/3002735/49454297-88d88080-f7ed-11e8-82df-bfb947372fff.png)
![screen shot 2018-12-04 at 5 54 07 pm](https://user-images.githubusercontent.com/3002735/49454358-a73e7c00-f7ed-11e8-9980-ca5caa3cf842.png)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

(run `yarn test:e2e` and paste the results. If you are not using our standard backend setup or demo.vuestorefront.io you can ommit this step) 

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
