### PR TITLE
Invalidate output cache using POST

### DIFF
--- a/core/scripts/server.js
+++ b/core/scripts/server.js
@@ -65,6 +65,48 @@ function createRenderer (bundle, clientManifest, template) {
   })
 }
 
+function invalidateCache (req, res) {
+  if (config.server.useOutputCache) {
+    if (req.query.tag && req.query.key) { // clear cache pages for specific query tag
+      if (req.query.key !== config.server.invalidateCacheKey) {
+        console.error('Invalid cache invalidation key')
+        utils.apiStatus(res, 'Invalid cache invalidation key', 500)
+        return
+      }
+      console.log(`Clear cache request for [${req.query.tag}]`)
+      let tags = []
+      if (req.query.tag === '*') {
+        tags = config.server.availableCacheTags
+      } else {
+        tags = req.query.tag.split(',')
+      }
+      const subPromises = []
+      tags.forEach(tag => {
+        if (config.server.availableCacheTags.indexOf(tag) >= 0 || config.server.availableCacheTags.find(t => {
+          return tag.indexOf(t) === 0
+        })) {
+          subPromises.push(cache.invalidate(tag).then(() => {
+            console.log(`Tags invalidated successfully for [${tag}]`)
+          }))
+        } else {
+          console.error(`Invalid tag name ${tag}`)
+        }
+      })
+      Promise.all(subPromises).then(r => {
+        utils.apiStatus(res, `Tags invalidated successfully [${req.query.tag}]`, 200)
+      }).catch(error => {
+        utils.apiStatus(res, error, 500)
+        console.error(error)
+      })
+    } else {
+      utils.apiStatus(res, 'Invalid parameters for Clear cache request', 500)
+      console.error('Invalid parameters for Clear cache request')
+    }
+  } else {
+    utils.apiStatus(res, 'Cache invalidation is not required, output cache is disabled', 200)
+  }
+}
+
 const serve = (path, cache, options) => express.static(resolve(path), Object.assign({
   maxAge: cache && isProd ? 60 * 60 * 24 * 30 : 0
 }, options))
@@ -81,87 +123,11 @@ const serverExtensions = require(resolve('src/server'))
 serverExtensions.registerUserServerRoutes(app)
 
 app.post('/invalidate', (req, res) => {
-  if (config.server.useOutputCache) {
-    if (req.query.tag && req.query.key) { // clear cache pages for specific query tag
-      if (req.query.key !== config.server.invalidateCacheKey) {
-        console.error('Invalid cache invalidation key')
-        utils.apiStatus(res, 'Invalid cache invalidation key', 500)
-        return
-      }
-      console.log(`Clear cache request for [${req.query.tag}]`)
-      let tags = []
-      if (req.query.tag === '*') {
-        tags = config.server.availableCacheTags
-      } else {
-        tags = req.query.tag.split(',')
-      }
-      const subPromises = []
-      tags.forEach(tag => {
-        if (config.server.availableCacheTags.indexOf(tag) >= 0 || config.server.availableCacheTags.find(t => {
-          return tag.indexOf(t) === 0
-        })) {
-          subPromises.push(cache.invalidate(tag).then(() => {
-            console.log(`Tags invalidated successfully for [${tag}]`)
-          }))
-        } else {
-          console.error(`Invalid tag name ${tag}`)
-        }
-      })
-      Promise.all(subPromises).then(r => {
-        utils.apiStatus(res, `Tags invalidated successfully [${req.query.tag}]`, 200)
-      }).catch(error => {
-        utils.apiStatus(res, error, 500)
-        console.error(error)
-      })
-    } else {
-      utils.apiStatus(res, 'Invalid parameters for Clear cache request', 500)
-      console.error('Invalid parameters for Clear cache request')
-    }
-  } else {
-    utils.apiStatus(res, 'Cache invalidation is not required, output cache is disabled', 200)
-  }
+  invalidateCache(req, res)
 })
 
 app.get('/invalidate', (req, res) => {
-  if (config.server.useOutputCache) {
-    if (req.query.tag && req.query.key) { // clear cache pages for specific query tag
-      if (req.query.key !== config.server.invalidateCacheKey) {
-        console.error('Invalid cache invalidation key')
-        utils.apiStatus(res, 'Invalid cache invalidation key', 500)
-        return
-      }
-      console.log(`Clear cache request for [${req.query.tag}]`)
-      let tags = []
-      if (req.query.tag === '*') {
-        tags = config.server.availableCacheTags
-      } else {
-        tags = req.query.tag.split(',')
-      }
-      const subPromises = []
-      tags.forEach(tag => {
-        if (config.server.availableCacheTags.indexOf(tag) >= 0 || config.server.availableCacheTags.find(t => {
-          return tag.indexOf(t) === 0
-        })) {
-          subPromises.push(cache.invalidate(tag).then(() => {
-            console.log(`Tags invalidated successfully for [${tag}]`)
-          }))
-        } else {
-          console.error(`Invalid tag name ${tag}`)
-        }
-      })
-      Promise.all(subPromises).then(r => {
-        utils.apiStatus(res, `Tags invalidated successfully [${req.query.tag}]`, 200)
-      }).catch(error => {
-        utils.apiStatus(res, error, 500)
-        console.error(error)
-      })
-    } else {
-      utils.apiStatus(res, 'Invalid parameters for Clear cache request', 500)
-      console.error('Invalid parameters for Clear cache request')
-    }
-  } else {
-    utils.apiStatus(res, 'Cache invalidation is not required, output cache is disabled', 200)
-  }
+  invalidateCache(req, res)
 })
 
 app.get('*', (req, res, next) => {

--- a/core/scripts/server.js
+++ b/core/scripts/server.js
@@ -122,13 +122,9 @@ app.use('/service-worker.js', serve('dist/service-worker.js', {
 const serverExtensions = require(resolve('src/server'))
 serverExtensions.registerUserServerRoutes(app)
 
-app.post('/invalidate', (req, res) => {
-  invalidateCache(req, res)
-})
+app.post('/invalidate', invalidateCache)
 
-app.get('/invalidate', (req, res) => {
-  invalidateCache(req, res)
-})
+app.get('/invalidate', invalidateCache)
 
 app.get('*', (req, res, next) => {
   const s = Date.now()


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/2083

### Short description and why it's useful

As described in the feature request, clearing the output cache should be supported by using either POST or GET requests. Since both GET and POST request now clears the cache in the same way it might be better to move the clear cache thing into a separate function?

### Screenshots of visual changes before/after (if there are any)

(if you made any changes in the UI layer please provide before/after screenshots)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

(run `yarn test:e2e` and paste the results. If you are not using our standard backend setup or demo.vuestorefront.io you can ommit this step) 

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
