### PR TITLE
Fix AMP naming and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You can find some tutorials and explanations on our [YouTube channel](https://ww
 - [TypeScript Action Plan](https://divanteltd.github.io/vue-storefront/guide/basics/typescript.html)
 - [GraphQL Action Plan](https://divanteltd.github.io/vue-storefront/guide/basics/graphql.html)
 - [SSR Cache](https://divanteltd.github.io/vue-storefront/guide/basics/ssr-cache.html)
-- [Google Advanced Mobile Pages](https://divanteltd.github.io/vue-storefront/guide/basics/amp.html)
+- [Google Accelerated Mobile Pages](https://divanteltd.github.io/vue-storefront/guide/basics/amp.html)
 
 ### Vue Storefront core and themes
 

--- a/docs/guide/basics/amp.md
+++ b/docs/guide/basics/amp.md
@@ -1,11 +1,12 @@
-# Google Advanced Mobile Pages
+# Google Accelerated Mobile Pages
 
-Google Advanced Mobile pages are available with Vue Storefront 1.6. By default, the Product and Category pages do support AMP. To get the AMP page You should use the following URL:
+Google Accelerated Mobile pages are available with Vue Storefront 1.6. By default, the Product and Category pages do support AMP. To get the AMP page You should use the following URL:
 `http://localhost:3000/c/hoodies-and-sweatshirts-24` -> `http://localhost:3000/amp/c/hoodies-and-sweatshirts-24`.
 The discovery links are added as `<link rel="amphtml" ...`. The landing pages then distribute the traffic to canonical Vue Storefront links to enable all the features to work (by definition AMP doesn't support any additional JavaScript).
 
 :::warning Important notice
-AMP renderer works ONLY IN PRODUCTION MODE as the [Advanced Content Output Options](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Layouts%20and%20advanced%20output%20operations.md) - specifically `index.html` template switching works only in production. In development mode, there can be CSR/SSR issues so don't even test it in development mode :-)
+AMP renderer works ONLY IN PRODUCTION MODE as the [Layouts and advanced output operations
+](../core-themes/layouts.md) - specifically `index.html` template switching works only in production. In development mode, there can be CSR/SSR issues so don't even test it in development mode :-)
 :::
 
 AMPHTML templates are provided by the `src/themes/default-amp` special purpose theme which inherits some parts from `default` theme


### PR DESCRIPTION
### Related issues

(put links to related issues here)

### Short description and why it's useful

The proper name for AMP is Accelerated Mobile Pages. I also fixed a link to `layouts.md`

### Screenshots of visual changes before/after (if there are any)

(if you made any changes in the UI layer please provide before/after screenshots)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

(run `yarn test:e2e` and paste the results. If you are not using our standard backend setup or demo.vuestorefront.io you can omit this step) 

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
