### PR TITLE
#2124 only parse values of select and multiselect attributes

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -123,7 +123,7 @@
         "categoriesDynamicPrefetch": true
       },
       "attribute": {
-        "includeFields": [ "attribute_code", "id", "entity_type_id", "options", "default_value", "is_user_defined", "frontend_label", "attribute_id", "default_frontend_label", "is_visible_on_front", "is_visible", "is_comparable", "tier_prices" ]
+        "includeFields": [ "attribute_code", "id", "entity_type_id", "options", "default_value", "is_user_defined", "frontend_label", "attribute_id", "default_frontend_label", "is_visible_on_front", "is_visible", "is_comparable", "tier_prices", "frontend_input" ]
       },
       "productList": {
         "sort": "",

--- a/core/modules/catalog/components/ProductAttribute.ts
+++ b/core/modules/catalog/components/ProductAttribute.ts
@@ -23,6 +23,8 @@ export const ProductAttribute = {
 
       if (!parsedValues) {
         return this.emptyPlaceholder
+      } else if (this.attribute.frontend_input !== 'multiselect' && this.attribute.frontend_input !== 'select') {
+          return parsedValues
       } else {
         parsedValues = typeof parsedValues === 'string' ? parsedValues.split(',') : parsedValues
         let results = []


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/2124

### Short description and why it's useful

Removes extra space after every comma for non-(multi)select product attributes.

### Visual changes before/after

Output for attributes of type text:

| Output before | Output after |
| --- | --- |
| 1, 6 | 1,6 |
| Haken Zamak pulverbeschichtet,  weiß glänzend  ø 1, 6 cm,  h 8, 7 cm | Haken Zamak pulverbeschichtet, weiß glänzend  ø 1,6 cm, h 8,7 cm |

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
