### PR TITLE
improve side menu scrolling

### DIFF
--- a/src/themes/default/components/core/blocks/SidebarMenu/SidebarMenu.vue
+++ b/src/themes/default/components/core/blocks/SidebarMenu/SidebarMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sidebar-menu absolute mw-100 bg-cl-secondary" :class="{ active: isOpen }">
+  <div class="sidebar-menu absolute mw-100 bg-cl-primary" :class="{ active: isOpen }">
     <div class="row brdr-bottom-1 brdr-cl-bg-secondary">
       <div class="col-xs bg-cl-primary" v-if="submenu.depth">
         <sub-btn type="back" class="bg-cl-transparent brdr-none" />
@@ -31,23 +31,24 @@
             class="brdr-bottom-1 brdr-cl-bg-secondary bg-cl-primary flex"
             :key="category.slug"
             @click="closeMenu"
-            v-for="category in categories"
-            v-if="category.product_count > 0 || category.children_count > 0"
+            v-for="category in visibleCategories"
           >
-            <sub-btn
-              class="bg-cl-transparent brdr-none fs-medium"
-              :id="category.id"
-              :name="category.name"
-              v-if="category.children_count > 0"
-              @click.native="activeSubMenu = category.id"
-            />
-            <router-link
-              v-else
-              class="px25 py20 cl-accent no-underline col-xs"
-              :to="localizedRoute({ name: 'category', params: { id: category.id, slug: category.slug }})"
-            >
-              {{ category.name }}
-            </router-link>
+            <div v-if="isCurrentMenuShowed" class="subcategory-item">
+              <sub-btn
+                class="bg-cl-transparent brdr-none fs-medium"
+                :id="category.id"
+                :name="category.name"
+                v-if="category.children_count > 0"
+                @click.native="activeSubMenu = category.id"
+              />
+              <router-link
+                v-else
+                class="px25 py20 cl-accent no-underline col-xs"
+                :to="localizedRoute({ name: 'category', params: { id: category.id, slug: category.slug }})"
+              >
+                {{ category.name }}
+              </router-link>
+            </div>
 
             <sub-category
               v-show="activeSubMenu === category.id"
@@ -56,7 +57,7 @@
               :parent-slug="category.slug"
             />
           </li>
-          <li @click="closeMenu">
+          <li @click="closeMenu" v-if="isCurrentMenuShowed" class="bg-cl-secondary">
             <router-link
               class="block px25 py20 brdr-bottom-1 brdr-cl-secondary cl-accent no-underline fs-medium-small"
               :to="localizedRoute('/sale')"
@@ -65,7 +66,7 @@
               {{ $t('Sale') }}
             </router-link>
           </li>
-          <li @click="closeMenu">
+          <li @click="closeMenu" v-if="isCurrentMenuShowed" class="bg-cl-secondary">
             <router-link
               class="block px25 py20 brdr-bottom-1 brdr-cl-secondary cl-accent no-underline fs-medium-small"
               :to="localizedRoute('/magazine')"
@@ -74,7 +75,7 @@
               {{ $t('Magazine') }}
             </router-link>
           </li>
-          <li @click="closeMenu" v-if="compareIsActive">
+          <li @click="closeMenu" v-if="compareIsActive && isCurrentMenuShowed" class="bg-cl-secondary">
             <router-link
               class="block px25 py20 brdr-bottom-1 brdr-cl-secondary cl-accent no-underline fs-medium-small"
               :to="localizedRoute('/compare')"
@@ -83,7 +84,7 @@
               {{ $t('Compare products') }}
             </router-link>
           </li>
-          <li @click="closeMenu">
+          <li @click="closeMenu" v-if="isCurrentMenuShowed" class="bg-cl-secondary">
             <router-link
               class="block px25 py20 brdr-bottom-1 brdr-cl-secondary cl-accent no-underline fs-medium-small"
               :to="localizedRoute('/order-tracking')"
@@ -92,7 +93,7 @@
               {{ $t('Track my order') }}
             </router-link>
           </li>
-          <li @click="closeMenu" class="brdr-bottom-1 brdr-cl-secondary flex">
+          <li @click="closeMenu" class="brdr-bottom-1 brdr-cl-secondary bg-cl-secondary flex">
             <sub-btn
               v-if="currentUser"
               :name="$t('My account')"
@@ -104,7 +105,7 @@
               :id="'foo'"
             />
             <a
-              v-if="!currentUser"
+              v-if="!currentUser && isCurrentMenuShowed"
               href="#"
               @click.prevent="login"
               class="block w-100 px25 py20 cl-accent no-underline fs-medium-small"
@@ -176,7 +177,18 @@ export default {
     ...mapState({
       submenu: state => state.ui.submenu,
       currentUser: state => state.user.current
-    })
+    }),
+    getSubmenu () {
+      return this.submenu
+    },
+    visibleCategories () {
+      return this.categories.filter(category => {
+        return category.product_count > 0 || category.children_count > 0
+      })
+    },
+    isCurrentMenuShowed () {
+      return !this.getSubmenu || !this.getSubmenu.depth
+    }
   },
   methods: {
     login () {
@@ -237,6 +249,11 @@ $color-mine-shaft: color(mine-shaft);
     a {
       color: $color-mine-shaft;
     }
+  }
+
+  .subcategory-item {
+    display: flex;
+    width: 100%;
   }
 
   button {

--- a/src/themes/default/components/core/blocks/SidebarMenu/SubCategory.vue
+++ b/src/themes/default/components/core/blocks/SidebarMenu/SubCategory.vue
@@ -22,19 +22,21 @@
         :key="link.slug"
         v-for="link in children"
       >
-        <sub-btn
-          class="bg-cl-transparent brdr-none fs-medium"
-          :id="link.id"
-          :name="link.name"
-          v-if="link.children_count > 0"
-        />
-        <router-link
-          v-else
-          class="px25 py20 cl-accent no-underline col-xs"
-          :to="localizedRoute({ name: 'category', params: { id: link.id, slug: link.slug }})"
-        >
-          {{ link.name }}
-        </router-link>
+        <div v-if="isCurrentMenuShowed" class="subcategory-item">
+          <sub-btn
+            class="bg-cl-transparent brdr-none fs-medium"
+            :id="link.id"
+            :name="link.name"
+            v-if="link.children_count > 0"
+          />
+          <router-link
+            v-else
+            class="px25 py20 cl-accent no-underline col-xs"
+            :to="localizedRoute({ name: 'category', params: { id: link.id, slug: link.slug }})"
+          >
+            {{ link.name }}
+          </router-link>
+        </div>
         <sub-category
           :category-links="link.children_data"
           :id="link.id"
@@ -111,11 +113,17 @@ export default {
     ...mapState({
       submenu: state => state.ui.submenu
     }),
+    getSubmenu () {
+      return this.submenu
+    },
     styles () {
       const pos = this.submenu.path.indexOf(this.id)
       return pos !== -1 ? {
         zIndex: pos + 1
       } : false
+    },
+    isCurrentMenuShowed () {
+      return this.getSubmenu && this.getSubmenu.depth && this.getSubmenu.path[this.getSubmenu.depth - 1] === this.id
     }
   },
   methods: {
@@ -140,5 +148,10 @@ export default {
     top: 0;
     min-height: 100%;
     transform: translateX(-100%);
+  }
+
+  .subcategory-item {
+    display: flex;
+    width: 100%;
   }
 </style>


### PR DESCRIPTION
### Related issues

#2029 

### Short description and why it's useful

It fixes sidemenu problem, when some subcategories are tiny and some are huge.
I visualized id by shrinking window (screens below)
Also changed menu background color to consistent white.

### Screenshots of visual changes before/after (if there are any)
## Before:
![screen shot 2019-01-07 at 23 46 58](https://user-images.githubusercontent.com/13100280/50798431-a4e1ad00-12d8-11e9-9b5a-3e847e9046cd.png)
![screen shot 2019-01-06 at 19 06 08](https://user-images.githubusercontent.com/13100280/50798461-c2167b80-12d8-11e9-80a9-558802350511.png)
![screen shot 2019-01-06 at 19 06 29](https://user-images.githubusercontent.com/13100280/50798468-c80c5c80-12d8-11e9-9556-3f323ced3f0a.png)

## After
![screen shot 2019-01-07 at 23 47 43](https://user-images.githubusercontent.com/13100280/50798508-e5d9c180-12d8-11e9-95c7-a8c0304c4434.png)
![screen shot 2019-01-07 at 23 48 24](https://user-images.githubusercontent.com/13100280/50798513-ed996600-12d8-11e9-934b-14fb4851dcf7.png)
![screen shot 2019-01-07 at 23 49 02](https://user-images.githubusercontent.com/13100280/50798521-f38f4700-12d8-11e9-801d-15ec567c6b8e.png)
