### PR TITLE
Use localized routes for redirects to home page and account page

### DIFF
--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -10,7 +10,7 @@ import buildTimeConfig from 'config'
 import { execute } from '@vue-storefront/core/lib/sync/task'
 import UniversalStorage from '@vue-storefront/store/lib/storage'
 import i18n from '@vue-storefront/i18n'
-import { prepareStoreView, storeCodeFromRoute, currentStoreView } from '@vue-storefront/store/lib/multistore'
+import { prepareStoreView, storeCodeFromRoute, currentStoreView, localizedRoute } from '@vue-storefront/store/lib/multistore'
 import { onNetworkStatusChange } from '@vue-storefront/core/modules/offline-order/helpers/onNetworkStatusChange'
 import '@vue-storefront/core/service-worker/registration' // register the service worker
 
@@ -36,7 +36,7 @@ function _commonErrorHandler (err, reject) {
       message: i18n.t('The product, category or CMS page is not available in Offline mode. Redirecting to Home.'),
       action1: { label: i18n.t('OK') }
     })
-    router.push('/')
+    router.push(localizedRoute('/', currentStoreView().storeCode))
   } else {
     rootStore.dispatch('notification/spawnNotification', {
       type: 'error',

--- a/core/modules/user/components/AccountButton.ts
+++ b/core/modules/user/components/AccountButton.ts
@@ -12,14 +12,14 @@ export const AccountButton = {
   methods: {
     goToAccount () {
       if (this.currentUser) {
-        this.$router.push('/my-account')
+        this.$router.push(this.localizedRoute('/my-account'))
       } else {
         this.$bus.$emit('modal-show', 'modal-signup')
       }
     },
     logout () {
       this.$bus.$emit('user-before-logout')
-      this.$router.push('/')
+      this.$router.push(this.localizedRoute('/'))
     }
   }
 }

--- a/core/pages/Category.js
+++ b/core/pages/Category.js
@@ -222,7 +222,7 @@ export default {
 
       this.$store.dispatch('category/single', { key: this.$store.state.config.products.useMagentoUrlKeys ? 'url_key' : 'slug', value: this.$route.params.slug }).then(category => {
         if (!category) {
-          this.$router.push('/')
+          this.$router.push(this.localizedRoute('/'))
         } else {
           this.pagination.current = 0
           let searchProductQuery = baseFilterProductsQuery(this.$store.state.category.current, store.state.config.products.defaultFilters)

--- a/core/pages/Checkout.js
+++ b/core/pages/Checkout.js
@@ -55,7 +55,7 @@ export default {
     this.$store.dispatch('cart/load').then(() => {
       if (this.$store.state.cart.cartItems.length === 0) {
         this.notifyEmptyCart()
-        this.$router.push('/')
+        this.$router.push(this.localizedRoute('/'))
       } else {
         this.stockCheckCompleted = false
         const checkPromises = []
@@ -118,7 +118,7 @@ export default {
     onCartAfterUpdate (payload) {
       if (this.$store.state.cart.cartItems.length === 0) {
         this.notifyEmptyCart()
-        this.$router.push('/')
+        this.$router.push(this.localizedRoute('/'))
       }
     },
     onAfterShippingMethodChanged (payload) {
@@ -153,7 +153,7 @@ export default {
     onDoPlaceOrder (additionalPayload) {
       if (this.$store.state.cart.cartItems.length === 0) {
         this.notifyEmptyCart()
-        this.$router.push('/')
+        this.$router.push(this.localizedRoute('/'))
       } else {
         this.payment.paymentMethodAdditional = additionalPayload
         this.placeOrder()

--- a/core/pages/CmsPage.js
+++ b/core/pages/CmsPage.js
@@ -30,7 +30,7 @@ export default {
     validateRoute () {
       this.$store.dispatch('cmsPage/single', { value: this.$route.params.slug, setCurrent: true }).then(cmsPage => {
         if (!cmsPage) {
-          this.$router.push('/')
+          this.$router.push(this.localizedRoute('/'))
         }
       })
     }


### PR DESCRIPTION
### Related issues

-

### Short description and why it's useful

Some redirects were not using localized routes, which causes customers to be redirected to the default store. This commit fixes several of these cases. Specifically: (1) client-entry commonErrorHandler empty result error handler redirect to home page. (2) Account button redirect to home page on logout and account page on login. (3) Category page no result handler redirect to home page. (4) Checkout empty cart handler redirect to home page (5) CMS page no result handler redirect to home page.

### Screenshots of visual changes before/after (if there are any)

-

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

not e2e tested 

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
