### PR TITLE
Issue 2074: Using meta_title and meta_description fields on product a…

### DIFF
--- a/core/pages/Category.js
+++ b/core/pages/Category.js
@@ -274,8 +274,8 @@ export default {
           }, storeView.storeCode)).href
         }
       ],
-      title: htmlDecode(this.$route.meta.title || this.categoryName),
-      meta: this.$route.meta.description ? [{ vmid: 'description', description: htmlDecode(this.$route.meta.description) }] : []
+      title: htmlDecode(this.category.meta_title || this.categoryName),
+      meta: this.category.meta_description ? [{ vmid: 'description', description: htmlDecode(this.category.meta_description) }] : []
     }
   }
 }

--- a/core/pages/Product.js
+++ b/core/pages/Product.js
@@ -2,7 +2,7 @@ import { mapGetters } from 'vuex'
 
 import store from '@vue-storefront/store'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
-import { htmlDecode, stripHTML } from '@vue-storefront/core/filters'
+import { htmlDecode } from '@vue-storefront/core/filters'
 import { currentStoreView, localizedRoute } from '@vue-storefront/store/lib/multistore'
 import { CompareProduct } from '@vue-storefront/core/modules/compare/components/Product.ts'
 import { AddToCompare } from '@vue-storefront/core/modules/compare/components/AddToCompare.ts'
@@ -225,7 +225,6 @@ export default {
   metaInfo () {
     const storeView = currentStoreView()
     return {
-      title: htmlDecode(this.$route.meta.title || this.productName),
       link: [
         { rel: 'amphtml',
           href: this.$router.resolve(localizedRoute({
@@ -238,7 +237,8 @@ export default {
           }, storeView.storeCode)).href
         }
       ],
-      meta: [{ vmid: 'description', description: this.product.short_description ? stripHTML(htmlDecode(this.product.short_description)) : htmlDecode(stripHTML(this.product.description)) }]
+      title: htmlDecode(this.product.meta_title || this.productName),
+      meta: this.product.meta_description ? [{ vmid: 'description', description: htmlDecode(this.product.meta_description) }] : []
     }
   }
 }


### PR DESCRIPTION
### Related issues

#2074

### Short description and why it's useful

Meta tags (title and description) on category and product page was generated based on wrong data. I changed this and now it is possible to use meta_title and meta_description fileds from magento to generate this meta tags.

### Screenshots of visual changes before/after (if there are any)

No screenshots

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

No screenshots

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
