### PR TITLE
delay serviceWorker registration

### DIFF
--- a/core/service-worker/registration.js
+++ b/core/service-worker/registration.js
@@ -2,25 +2,29 @@ import { register } from 'register-service-worker'
 import { server } from 'config'
 
 if (process.env.NODE_ENV === 'production' || server.devServiceWorker) {
-  register(`/service-worker.js`, {
-    ready () {
-      console.log(
-        'App is being served from cache by a service worker.'
-      )
-    },
-    cached () {
-      console.log('Content has been cached for offline use.')
-    },
-    updated (registration) {
-      console.log('New content is available, please refresh.')
-    },
-    offline () {
-      console.log(
-        'No internet connection found. App is running in offline mode.'
-      )
-    },
-    error (error) {
-      console.error('Error during service worker registration:', error)
-    }
+  window.addEventListener('load', () => {
+    setTimeout(() => {
+      register(`/service-worker.js`, {
+        ready () {
+          console.log(
+            'App is being served from cache by a service worker.'
+          )
+        },
+        cached () {
+          console.log('Content has been cached for offline use.')
+        },
+        updated (registration) {
+          console.log('New content is available, please refresh.')
+        },
+        offline () {
+          console.log(
+            'No internet connection found. App is running in offline mode.'
+          )
+        },
+        error (error) {
+          console.error('Error during service worker registration:', error)
+        }
+      })
+    }, 500)
   })
 }


### PR DESCRIPTION
### Short description and why it's useful

For better first load experience and following [recommendations](https://developers.google.com/web/fundamentals/primers/service-workers/registration) i delayed service worker registration to wait for application to load.