### PR TITLE
Fixed wishlist store module to not be lazy loaded

### DIFF
--- a/core/modules/wishlist/components/Wishlist.ts
+++ b/core/modules/wishlist/components/Wishlist.ts
@@ -3,7 +3,6 @@ import { Wishlist as WishlistModule } from '../'
 export const Wishlist = {
   name: 'Wishlist',
   created () {
-    WishlistModule.register()
     this.$store.dispatch('wishlist/load')
   },
   computed: {

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -6,6 +6,7 @@ import { Checkout } from '@vue-storefront/core/modules/checkout'
 import { Compare } from '@vue-storefront/core/modules/compare'
 import { Review } from '@vue-storefront/core/modules/review'
 import { Mailer } from '@vue-storefront/core/modules/mailer'
+import { Wishlist } from '@vue-storefront/core/modules/wishlist'
 import { Mailchimp } from '../modules/mailchimp'
 import { Notification } from '@vue-storefront/core/modules/notification'
 import { RecentlyViewed } from '@vue-storefront/core/modules/recently-viewed'
@@ -54,6 +55,7 @@ export const registerModules: VueStorefrontModule[] = [
   Compare,
   Review,
   Mailer,
+  Wishlist,
   Mailchimp,
   Notification,
   Ui,


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/2249

### Short description and why it's useful

Wishlist store module is no longer lazy loaded

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature