### PR TITLE
Fixed category filters reset functionality on mobile

### DIFF
--- a/core/compatibility/components/blocks/Category/Sidebar.js
+++ b/core/compatibility/components/blocks/Category/Sidebar.js
@@ -26,7 +26,7 @@ export default {
       this.$bus.$emit('filter-reset')
       this.$store.dispatch('category/resetFilters')
       this.$store.dispatch('category/searchProductQuery', buildFilterProductsQuery(this.category, this.activeFilters))
-      this.$store.dispatch('category/products', this.getCurrentCategoryProductQuery)
+      this.$store.dispatch('category/products', {searchProductQuery: this.getCurrentCategoryProductQuery})
     }
   }
 }

--- a/core/modules/catalog/components/CategoryFilters.ts
+++ b/core/modules/catalog/components/CategoryFilters.ts
@@ -22,7 +22,7 @@ export default {
       this.$bus.$emit('filter-reset')
       this.$store.dispatch('category/resetFilters')
       this.$store.dispatch('category/searchProductQuery', buildFilterProductsQuery(this.category, this.activeFilters))
-      this.$store.dispatch('category/products', this.getCurrentCategoryProductQuery)
+      this.$store.dispatch('category/products', {searchProductQuery: this.getCurrentCategoryProductQuery})
     }
   }
 }


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/2262

### Short description and why it's useful

Fixed filters reset button functionality (on mobile)

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature