### PR TITLE
Product Zoom Picture fix - now it is centered

### DIFF
--- a/src/themes/default/components/core/ProductGalleryZoom.vue
+++ b/src/themes/default/components/core/ProductGalleryZoom.vue
@@ -92,7 +92,7 @@ $z-index-gallery: map-get($z-index, overlay) + 1;
     padding: 20px;
     height: 750px;
     max-height: 100%;
-    max-width: 750px;
+    justify-content: space-evenly;
 
     @media (max-width: 767px) {
       top: 50%;
@@ -142,6 +142,7 @@ $z-index-gallery: map-get($z-index, overlay) + 1;
   }
 
   &__gallery {
+    max-width: 600px;
     height: 100%;
     flex: 1;
 


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/2178

### Short description and why it's useful

Product zoom picture is now centered

### Screenshots of visual changes before/after (if there are any)

Before
<img width="1055" alt="before" src="https://user-images.githubusercontent.com/34317830/51390716-5500b280-1b30-11e9-842c-ede77c7e0cae.png">

After
<img width="1046" alt="after" src="https://user-images.githubusercontent.com/34317830/51390715-5500b280-1b30-11e9-9b35-e07dbd84fa51.png">

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [ x ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ x ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ x ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
