### PR TITLE
Fix #2283 - Create new cart after checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support regional characters in urls
 - `store/lib/search` has been moved to `core/lib/search` (#2225)
 - `store/lib/multistore` has been moved to `core/lib/multistore` (#2224)
-- After checkout create logged-in cart for logged-in users if using order Direct Backend Sync (#2302)
+- After checkout create logged-in cart for logged-in users if using order Direct Backend Sync - @grimasod (#2302)
 
 ## [1.7.2] - 2019.01.28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support regional characters in urls
 - `store/lib/search` has been moved to `core/lib/search` (#2225)
 - `store/lib/multistore` has been moved to `core/lib/multistore` (#2224)
+- After checkout create logged-in cart for logged-in users if using order Direct Backend Sync (#2302)
 
 ## [1.7.2] - 2019.01.28
 ### Fixed

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -49,7 +49,7 @@ const actions: ActionTree<CartState, RootState> = {
     context.commit(types.CART_LOAD_CART, [])
     context.commit(types.CART_LOAD_CART_SERVER_TOKEN, null)
     if (rootStore.state.config.cart.synchronize) {
-      rootStore.dispatch('cart/serverCreate', { guestCart: true }, {root: true}) // guest cart because when the order hasn't been passed to magento yet it will repopulate your cart
+      rootStore.dispatch('cart/serverCreate', { guestCart: !rootStore.state.config.orders.directBackendSync }, {root: true}) // guest cart when not using directBackendSync because when the order hasn't been passed to magento yet it will repopulate your cart
     }
   },
   save (context) {


### PR DESCRIPTION
### Related issues

#2283

### Short description and why it's useful

With Direct Backend Sync enabled, create a logged-in customer cart (if the user is logged in) after completing an order. A guest cart is no longer necessary.

### Screenshots of visual changes before/after (if there are any)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
