### PR TITLE
Output cache versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config/local.json
 var
 build/config.json
 core/build/config.json
+core/build/cache-version.json
 theme.js
 desktop.ini
 src/themes/catalog/resource/i18n.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- cache key used to store output chache in redis
+
 ## [1.7.2] - 2019.01.28
 ### Fixed
 - clear search filters on mobile - @patzick (#2282)

--- a/core/build/webpack.server.config.js
+++ b/core/build/webpack.server.config.js
@@ -3,6 +3,18 @@ const merge = require('webpack-merge')
 const base = require('./webpack.base.config')
 const VueSSRPlugin = require('vue-ssr-webpack-plugin')
 
+// when output cache is enabled generate cache version key
+const config = require('config')
+const fs = require('fs')
+const path = require('path')
+const uuid = require('uuid/v4')
+if (config.server.useOutputCache) {
+  fs.writeFileSync(
+    path.join(__dirname, 'cache-version.json'),
+    JSON.stringify(uuid())
+  )
+}
+
 module.exports = merge(base, {
   mode: 'development',
   target: 'node',

--- a/core/package.json
+++ b/core/package.json
@@ -18,6 +18,7 @@
     "lru-cache": "^4.0.1",
     "redis-tag-cache": "^1.2.1",
     "remove-accents": "^0.4.2",
+    "uuid": "^3.3.2",
     "vue": "^2.5.17",
     "vue-carousel": "^0.6.9",
     "vue-i18n": "^8.0.0",

--- a/core/scripts/server.js
+++ b/core/scripts/server.js
@@ -7,10 +7,12 @@ let config = require('config')
 const TagCache = require('redis-tag-cache').default
 const utils = require('./server/utils')
 const compile = require('lodash.template')
+
 const compileOptions = {
   escape: /{{([^{][\s\S]+?[^}])}}/g,
   interpolate: /{{{([\s\S]+?)}}}/g
 }
+
 const isProd = process.env.NODE_ENV === 'production'
 process.noDeprecation = true
 
@@ -18,11 +20,15 @@ const app = express()
 
 let cache
 if (config.server.useOutputCache) {
+  const cacheKey = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'build', 'cache-version.json')) || '')
+  const redisConfig = Object.assign(config.redis, { keyPrefix: cacheKey })
+
   cache = new TagCache({
-    redis: config.redis,
-    defaultTimeout: config.server.outputCacheDefaultTtl // Expire records after a day (even if they weren't invalidated)
+    redis: redisConfig,
+    defaultTimeout: config.server.outputCacheDefaultTtl
   })
-  console.log('Redis cache set', config.redis)
+
+  console.log('Redis cache set', redisConfig)
 }
 
 const templatesCache = {}


### PR DESCRIPTION
### Short description and why it's useful

Currently, the cache is persisted in Redis until the expiration, which can lead to issues with serving old content after deployment, if this cache will not be manually cleaned.

These changes are related to the build process and `redis-tag-cache` package setup.

In the first step during the server build, I generate the UUID and save it to `core/build/cache-version.json` file. 

Then when the server is firing up, it reads saved previously UUID and uses it to set `keyPrefix` which help us distinguish the correct version of the cache.

Why not generate UUID directly in `server.js`? We can spawn multiple instances of this server, so each of them will have on the cache, which is not efficient.

### Upgrade Notes and Changelog
There are no changes required, just under the hood magic, but if someone was currently clearing all the cache during deployment, it's not necessary anymore.

### Questions
If manual cache clearing is not so useful anymore, should be kept `yarn cache` and `core/script/cache.js`?
If we should keep it, it also needs to read the content of `cache-version.json`, so maybe will be good to abstract the logic of creating cache instance 🤔 
