### PR TITLE
#2307 added possibility to have sticky notifications (without timeout)

### DIFF
--- a/core/modules/notification/store/index.ts
+++ b/core/modules/notification/store/index.ts
@@ -26,9 +26,11 @@ export const module: Module<NotificationState, any> = {
         return
       }
       commit('add', notification)
-      setTimeout(() => {
-        dispatch('removeNotification')
-      }, notification.timeToLive || 5000)
+      if (!notification.hasNoTimeout) {
+        setTimeout(() => {
+          dispatch('removeNotification')
+        }, notification.timeToLive || 5000)
+      }
     },
     removeNotification ({ commit, state }, index?: number) {
       if (!index) {

--- a/core/modules/notification/types/NotificationItem.ts
+++ b/core/modules/notification/types/NotificationItem.ts
@@ -8,5 +8,6 @@ export default interface NotificationItem {
   message: string,
   timeToLive?: number,
   action1: ActionItem,
-  action2?: ActionItem
+  action2?: ActionItem,
+  hasNoTimeout?: boolean
 }


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/2307

### Short description and why it's useful

This pull request resurrects *hasNoTimeout* property which is used already in micro cart (but was not functioning (anymore?)). Setting this property to true will keep the notification displayed until the user chooses one of the options.

### Usage example
As in core/compatibility/components/blocks/Microcart/Product.js:
```
        this.$store.dispatch('notification/spawnNotification', {
          type: 'warning',
          item: this.product,
          message: i18n.t('Are you sure you would like to remove this item from the shopping cart?'),
          action2: { label: i18n.t('OK'), action: this.removeFromCart },
          action1: { label: i18n.t('Cancel'), action: 'close' },
          hasNoTimeout: true
        })
```
### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
