### PR TITLE
Missing no-ssr wrapper in acount icon component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- cache key used to store output chache in redis
+- Cache key used to store output chache in redis - @igloczek (#2309)
+
+### Fixed
+- Missing `no-ssr` wrapper around user specific content, which leads to broken app in production mode - @igloczek (#2314)
 
 ## [1.7.2] - 2019.01.28
 ### Fixed

--- a/src/themes/default/components/core/blocks/Header/AccountIcon.vue
+++ b/src/themes/default/components/core/blocks/Header/AccountIcon.vue
@@ -1,7 +1,9 @@
 <template>
-  <div class="inline-flex relative dropdown"
-       data-testid="accountButton"
-       @click.self="goToAccount">
+  <div
+    class="inline-flex relative dropdown"
+    data-testid="accountButton"
+    @click.self="goToAccount"
+  >
     <button
       type="button"
       class="bg-cl-transparent brdr-none p0"

--- a/src/themes/default/components/core/blocks/Header/AccountIcon.vue
+++ b/src/themes/default/components/core/blocks/Header/AccountIcon.vue
@@ -9,28 +9,35 @@
     >
       <i class="material-icons block">account_circle</i>
     </button>
-    <div v-if="currentUser" class="dropdown-content bg-cl-primary align-left sans-serif lh20 weight-400">
-      <div class="py5">
-        <div v-for="(page, index) in navigation" :key="index" @click="notify(page.title)">
-          <router-link class="no-underline block py10 px15" :to="localizedRoute(page.link)">
-            {{ page.title }}
-          </router-link>
+
+    <no-ssr>
+      <div v-if="currentUser" class="dropdown-content bg-cl-primary align-left sans-serif lh20 weight-400">
+        <div class="py5">
+          <div v-for="(page, index) in navigation" :key="index" @click="notify(page.title)">
+            <router-link class="no-underline block py10 px15" :to="localizedRoute(page.link)">
+              {{ page.title }}
+            </router-link>
+          </div>
+        </div>
+        <div class="py5 brdr-top-1 brdr-cl-bg-secondary">
+          <a href="#" class="no-underline block py10 px15" @click.prevent="logout">
+            {{ $t('Logout') }}
+          </a>
         </div>
       </div>
-      <div class="py5 brdr-top-1 brdr-cl-bg-secondary">
-        <a href="#" class="no-underline block py10 px15" @click.prevent="logout">
-          {{ $t('Logout') }}
-        </a>
-      </div>
-    </div>
+    </no-ssr>
   </div>
 </template>
 
 <script>
+import NoSSR from 'vue-no-ssr'
 import AccountIcon from '@vue-storefront/core/compatibility/components/blocks/Header/AccountIcon'
 
 export default {
   mixins: [AccountIcon],
+  components: {
+    'no-ssr': NoSSR
+  },
   data () {
     return {
       navigation: [


### PR DESCRIPTION
### Related issues
#2216

### Short description and why it's useful
Missing `no-ssr` wrapper around user-specific content, which leads to the broken app in production mode, after refreshing the page.
