### PR TITLE
fix running process on pm2 server

### DIFF
--- a/core/scripts/server.js
+++ b/core/scripts/server.js
@@ -117,7 +117,7 @@ const serve = (path, cache, options) => express.static(resolve(path), Object.ass
   maxAge: cache && isProd ? 60 * 60 * 24 * 30 : 0
 }, options))
 
-const themeRoot = require('../build/theme-path')
+const themeRoot = require('../build/theme-path.ts')
 
 app.use('/dist', serve('dist', true))
 app.use('/assets', serve(themeRoot + '/assets', true))

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/DivanteLtd/vue-storefront/README.md",
   "scripts": {
-    "start": "cross-env NODE_ENV=production pm2 start ecosystem.json $PM2_ARGS",
+    "start": "cross-env NODE_ENV=production TS_NODE_PROJECT=\"tsconfig-build.json\" pm2 start ecosystem.json $PM2_ARGS",
     "installer": "node ./core/scripts/installer",
     "installer:ci": "yarn installer --default-config",
     "all": "cross-env NODE_ENV=development node ./core/scripts/all",


### PR DESCRIPTION
### Related issues

#2260 

### Short description and why it's useful

After server deployment pm2 logs shows, that file in `const themeRoot = require('../build/theme-path.ts')` cannot be found.
