### PR TITLE
Ref. 2304 Fix used variable for products count in category

### DIFF
--- a/docs/guide/components/category-page.md
+++ b/docs/guide/components/category-page.md
@@ -17,7 +17,7 @@ No props
 - `categoryName` - category name.
 - `categoryId` - category ID.
 - `breadcrumbs` - breadcrumbs for the current category from the Vuex store.
-- `productsCounter` - how many products are in the category.
+- `productsTotal` - how many products are in the category.
 - `lazyLoadProductsOnscroll` - allows lazy-loading more products on scroll, by default it's true
 
 ## Methods

--- a/src/themes/default/pages/Category.vue
+++ b/src/themes/default/pages/Category.vue
@@ -31,7 +31,7 @@
           </div>
           <sidebar class="mobile-filters-body" :filters="filters.available"/>
         </div>
-        <p class="col-xs-12 hidden-md m0 px20 cl-secondary">{{ productsCounter }} items</p>
+        <p class="col-xs-12 hidden-md m0 px20 cl-secondary">{{ productsTotal }} {{ $t('items') }}</p>
         <div class="col-md-9 pt20 px10 border-box products-list">
           <div v-if="isCategoryEmpty" class="hidden-xs">
             <h4 data-testid="noProductsInfo">{{ $t('No products found!') }}</h4>


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/2304

### Short description and why it's useful

The product count on mobile was referencing a variable containing the value after pagination (50 on page load, the correct one after scrolling down). In addition, the _items_ label wasn't using the translation function.

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
