### PR TITLE
Ref. #2262 Fix merging for category filter clear

### DIFF
--- a/core/compatibility/components/blocks/Category/Sidebar.js
+++ b/core/compatibility/components/blocks/Category/Sidebar.js
@@ -25,8 +25,10 @@ export default {
     resetAllFilters () {
       this.$bus.$emit('filter-reset')
       this.$store.dispatch('category/resetFilters')
-      this.$store.dispatch('category/searchProductQuery', buildFilterProductsQuery(this.category, this.activeFilters))
-      this.$store.dispatch('category/mergeSearchOptions', {searchProductQuery: {}})
+      this.$store.dispatch('category/searchProductQuery', {})
+      this.$store.dispatch('category/mergeSearchOptions', {
+        searchProductQuery: buildFilterProductsQuery(this.category, this.activeFilters)
+      })
       this.$store.dispatch('category/products', this.getCurrentCategoryProductQuery)
     }
   }

--- a/core/modules/catalog/components/CategoryFilters.ts
+++ b/core/modules/catalog/components/CategoryFilters.ts
@@ -21,8 +21,10 @@ export default {
       // todo: get rid of this one
       this.$bus.$emit('filter-reset')
       this.$store.dispatch('category/resetFilters')
-      this.$store.dispatch('category/searchProductQuery', buildFilterProductsQuery(this.category, this.activeFilters))
-      this.$store.dispatch('category/mergeSearchOptions', {searchProductQuery: {}})
+      this.$store.dispatch('category/searchProductQuery', {})
+      this.$store.dispatch('category/mergeSearchOptions', {
+        searchProductQuery: buildFilterProductsQuery(this.category, this.activeFilters)
+      })
       this.$store.dispatch('category/products', this.getCurrentCategoryProductQuery)
     }
   }


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/2262

### Short description and why it's useful

Now on filter clear the GET has `request={}`, hence it loads the full catalog from Elasticsearch, not just the current category.

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
