### PR TITLE
revert theme-path to js to run it on server

### DIFF
--- a/core/build/theme-path.js
+++ b/core/build/theme-path.js
@@ -1,5 +1,5 @@
-import path from 'path'
-import detectInstalled from 'detect-installed'
+const path = require('path')
+const detectInstalled = require('detect-installed')
 const config = require('./config.json')
 
 let themePath = ''
@@ -12,7 +12,5 @@ else {
   themeName = themeName.replace('@vue-storefront/theme-', '')
   themePath = path.resolve(__dirname, '../../src/themes/' + themeName)
 }
-
-export default themePath
 
 module.exports = themePath

--- a/core/scripts/server.js
+++ b/core/scripts/server.js
@@ -106,7 +106,7 @@ const serve = (path, cache, options) => express.static(resolve(path), Object.ass
   maxAge: cache && isProd ? 60 * 60 * 24 * 30 : 0
 }, options))
 
-const themeRoot = require('../build/theme-path.ts')
+const themeRoot = require('../build/theme-path')
 
 app.use('/dist', serve('dist', true))
 app.use('/assets', serve(themeRoot + '/assets', true))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
     "core/**/*.ts",
     "core/**/*.vue",
     "tests/**/*.ts",
-    "module/**/*.ts"
+    "module/**/*.ts",
+    "core/build/theme-path.js"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
### Related issues

#2324 

### Short description and why it's useful

Theme path was reverted to because this file is running directly on node server in `server.js` script.