### PR TITLE
bugfix/Service worker loads gz and js files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use localized routes for redirects to home page and account page — @grimasod #2157
 - ProductLinks fixed in Related products component — @pkarw #2168
 - Fix Cart Configurable Item pulled from Magento loaded as Simple — @pkarw @valeriish #2169 #2181
+- service worker prefetch now only compressed js files — @patzick #2254
 
 ### Depreciated
 - extendStore depreciation - @filrak #2143

--- a/core/build/webpack.prod.client.config.ts
+++ b/core/build/webpack.prod.client.config.ts
@@ -9,7 +9,10 @@ const extendedConfig = require(path.join(themeRoot, '/webpack.config.js'))
 const prodClientConfig = merge(baseClientConfig, {
   mode: 'production',
   plugins: [
-    new CompressionPlugin()
+    new CompressionPlugin({
+      test: /\.js(\?.*)?$/i,
+      deleteOriginalAssets: true
+    })
   ]
 })
 


### PR DESCRIPTION
### Related issues

#2254 

### Short description and why it's useful

Compression plugin process now only js files and leaves only compressed files to prefetch.

### Screenshots of visual changes before/after (if there are any)

Before:

![screen shot 2019-02-05 at 20 10 09](https://user-images.githubusercontent.com/13100280/52300576-7bc04500-2988-11e9-9e95-cdebf03bb4c8.png)

After:

![screen shot 2019-02-05 at 20 44 43](https://user-images.githubusercontent.com/13100280/52300595-8f6bab80-2988-11e9-9287-bc5665d203ef.png)

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature