### PR TITLE
fix wrong paddings on select fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Magento 2.3 MSI work-around (it's still not supported fully) (#2366)
 - ElasticSearch fuzzy search, scoring, boosting + other improvements - @qbo-tech (#2340)
 - Improved user account menu UX on desktop - @vue-kacper (#2363)
+- Improved paddings on select fields - @patzick (#2361)
 
 ## [1.7.3] - 2019.01.31
 ### Fixed

--- a/src/themes/default/components/core/SortBy.vue
+++ b/src/themes/default/components/core/SortBy.vue
@@ -28,7 +28,6 @@ export default {
         border-bottom: 1px solid $color-tertiary;
         select {
             @extend .h4;
-            padding: 10px 0;
             font-size: 14px;
             border: none;
             width: 100%;

--- a/src/themes/default/components/core/blocks/Form/BaseSelect.vue
+++ b/src/themes/default/components/core/blocks/Form/BaseSelect.vue
@@ -107,7 +107,6 @@ export default {
 
   select {
     @extend .h4;
-    padding: 10px 0;
     border: none;
     border-bottom: 1px solid $color-tertiary;
     width: 100%;
@@ -134,7 +133,6 @@ export default {
     position: absolute;
     pointer-events: none;
     user-select: none;
-    left: 13px;
     top: 10px;
     transition: 0.2s ease all;
     -moz-transition: 0.2s ease all;


### PR DESCRIPTION
### Related issues

#2361 

### Short description and why it's useful

Fixes padding on select fields.

### Screenshots of visual changes before/after (if there are any)

Before
![image](https://user-images.githubusercontent.com/13100280/52326586-7e06bb80-29e9-11e9-8ff1-6e4f5242a03f.png)


After
![image](https://user-images.githubusercontent.com/13100280/52326598-8959e700-29e9-11e9-802e-33e21cb70ca2.png)


### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature