### PR TITLE
ProductAttribute.ts - check if values are an array or not.

### DIFF
--- a/core/modules/catalog/components/ProductAttribute.ts
+++ b/core/modules/catalog/components/ProductAttribute.ts
@@ -26,7 +26,12 @@ export const ProductAttribute = {
       } else if (this.attribute.frontend_input !== 'multiselect' && this.attribute.frontend_input !== 'select') {
           return parsedValues.toString()
       } else {
-        parsedValues = typeof parsedValues === 'string' ? parsedValues.split(',') : [ parsedValues ]
+        parsedValues = typeof parsedValues === 'string' ? parsedValues.split(',') : parsedValues
+
+        if (!Array.isArray(parsedValues)) {
+          parsedValues = [parsedValues]
+        }
+
         let results = []
         for (let parsedVal of parsedValues) {
           if (this.attribute.options) {


### PR DESCRIPTION
### Short description and why it's useful
Small fix for showing attribute values (customAttributes) on Product Page.
Check if `parsedValues` is already an array.

Before:
![attribute-before](https://user-images.githubusercontent.com/4245592/52353747-6eaa6100-2a2f-11e9-992c-a7c25867eea6.png)

After:
![attribute-after](https://user-images.githubusercontent.com/4245592/52353755-71a55180-2a2f-11e9-9dab-27d8de78aacd.png)



### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
