### PR TITLE
Bugfix/remove compare from mobile view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ElasticSearch fuzzy search, scoring, boosting + other improvements - @qbo-tech (#2340)
 - Improved user account menu UX on desktop - @vue-kacper (#2363)
 - Improved paddings on select fields - @patzick (#2361)
-- Improved fetching customAttributes - @afirlejczyk
+- Improved fetching customAttributes - @afirlejczyk (#2107)
+- Removed compare button from product mobile view - @patzick (#2370)
 
 ## [1.7.3] - 2019.01.31
 ### Fixed

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -161,7 +161,7 @@
               <div class="col-xs-6 col-sm-3 col-md-6">
                 <wishlist-button :product="product" />
               </div>
-              <div class="col-xs-6 col-sm-3 col-md-6">
+              <div class="col-xs-6 col-sm-3 col-md-6 product__add-to-compare">
                 <button
                   @click="isOnCompare ? removeFromList('compare') : addToList('compare')"
                   class="
@@ -305,6 +305,15 @@ $color-tertiary: color(tertiary);
 $color-secondary: color(secondary);
 $color-white: color(white);
 $bg-secondary: color(secondary, $colors-background);
+
+.product {
+  &__add-to-compare {
+    display: none;
+    @media (min-width: 767px) {
+      display: block;
+    }
+  }
+}
 
 .breadcrumbs {
   @media (max-width: 767px) {


### PR DESCRIPTION
### Related issues

#2370 

### Short description and why it's useful

Compare button is no longer displayed on mobile.

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature
