### PR TITLE
Issue: 2399. Country* field name is missplaced in shipping details - Edge 17 and Firefox

### DIFF
--- a/src/themes/default/components/core/blocks/Form/BaseSelect.vue
+++ b/src/themes/default/components/core/blocks/Form/BaseSelect.vue
@@ -133,6 +133,7 @@ export default {
     position: absolute;
     pointer-events: none;
     user-select: none;
+    left: 0;
     top: 10px;
     transition: 0.2s ease all;
     -moz-transition: 0.2s ease all;


### PR DESCRIPTION
### Related issues

Issue: https://github.com/DivanteLtd/vue-storefront/issues/2399

### Short description and why it's useful

I added a CSS line to fix the position of Country label in My shipping details page. This pull request fixes design in Chrome, Firefox & Edge 17.

### Screenshots of visual changes before/after (if there are any)
Before
![country](https://user-images.githubusercontent.com/47415585/52479859-514dd200-2baa-11e9-8cff-15ef4fdf6ca3.png)

After
![vs_after_2399_fixed](https://user-images.githubusercontent.com/24892273/52517070-36876600-2c5b-11e9-901c-66e078e66125.jpg)

(if you made any changes in the UI layer please provide before/after screenshots)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

(run `yarn test:e2e` and paste the results. If you are not using our standard backend setup or demo.vuestorefront.io you can ommit this step) 

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
