### PR TITLE
Share TS build config reported missing in #2415, fix network mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.8.2] - 2019.02.11
-- Fixed docker-compose configuration for network_mode and TS build config
+- Fixed docker-compose configuration for network_mode and TS build config - @lukeromanowicz (#2415)
 
 ## [1.8.1] - 2019.02.10
 This is hot-fix release for fixing the payment methods switching issue when both: `payments-cash-on-delivery` and `payments-backend-methods` modules enabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2019.02.11
+- Fixed docker-compose configuration for network_mode and TS build config
+
 ## [1.8.1] - 2019.02.10
 This is hot-fix release for fixing the payment methods switching issue when both: `payments-cash-on-delivery` and `payments-backend-methods` modules enabled.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     env_file: docker/vue-storefront/default.env
     environment:
       VS_ENV: dev
-    network_mode: bridge
+    network_mode: host
     volumes:
       - '.babelrc:/var/www/.babelrc'
       - './config:/var/www/config'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     env_file: docker/vue-storefront/default.env
     environment:
       VS_ENV: dev
-    network_mode: host
+    network_mode: bridge
     volumes:
       - '.babelrc:/var/www/.babelrc'
       - './config:/var/www/config'
@@ -18,6 +18,7 @@ services:
       - './.eslintrc.js:/var/www/.eslintrc.js'
       - './lerna.json:/var/www/lerna.json'
       - './tsconfig.json:/var/www/tsconfig.json'
+      - './tsconfig-build.json:/var/www/tsconfig-build.json'
       - './shims.d.ts:/var/www/shims.d.ts'
       - './package.json:/var/www/package.json'
       - './src:/var/www/src'


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/2415

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
