### PR TITLE
Add clear filters button on desktop and refactor available filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.9.0] - 2019.02.12
+## [1.9.0]
 ### Changed / Improved
 - Added clear filters button on desktop also and only show if filters are applied - @DaanKouters (#2342)
 - Improved configuration.md (spelling etc.) - @ruthgeridema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2019.02.12
+- Added clear filters button on desktop also and only show if filters are applied - @DaanKouters (#2342)
+
 ## [1.8.2] - 2019.02.11
 - Fixed docker-compose configuration for network_mode and TS build config - @lukeromanowicz (#2415)
 

--- a/core/compatibility/components/blocks/Category/Sidebar.js
+++ b/core/compatibility/components/blocks/Category/Sidebar.js
@@ -1,5 +1,6 @@
 import { buildFilterProductsQuery } from '@vue-storefront/core/helpers'
 import { mapGetters } from 'vuex'
+import pickBy from 'lodash-es/pickBy'
 
 export default {
   name: 'CategorySidebar',
@@ -16,6 +17,12 @@ export default {
     },
     activeFilters () {
       return this.getActiveCategoryFilters
+    },
+    availableFilters () {
+      return pickBy(this.filters, (filter) => { return (filter.length) })
+    },
+    hasActiveFilters () {
+      return Object.keys(this.activeFilters).length !== 0
     }
   },
   methods: {

--- a/src/themes/default/components/core/blocks/Category/Sidebar.vue
+++ b/src/themes/default/components/core/blocks/Category/Sidebar.vue
@@ -4,17 +4,15 @@
       {{ $t('Filter') }}
     </h4>
     <button
-      class="visible-xs no-outline brdr-none py15 px40 bg-cl-mine-shaft :bg-cl-th-secondary ripple h5 cl-white sans-serif"
+      class="no-outline brdr-none py15 px40 bg-cl-mine-shaft :bg-cl-th-secondary ripple h5 cl-white sans-serif"
       @click="resetAllFilters"
-      :class="{'button-disabled': Object.keys(activeFilters).length === 0}"
-      :disabled="Object.keys(activeFilters).length === 0"
+      v-show="hasActiveFilters"
     >
       {{ $t('Clear') }}
     </button>
     <div
-      v-for="(filter, filterIndex) in filters"
+      v-for="(filter, filterIndex) in availableFilters"
       :key="filterIndex"
-      v-if="filter.length"
     >
       <h5>
         {{ $t(filterIndex + '_filter') }}


### PR DESCRIPTION
### Related issues
https://github.com/DivanteLtd/vue-storefront/issues/2342

### Short description and why it's useful
Added the already existing clear filters button also for Desktop, now the clear filters button only shows if there any filters being applied.

I also refactored the filters loop, while there shouldn't be a condition in the v-for loop, i created a computed property in the sidebar core file to exclude filters that have no options. So only the available filters are visible (an available filter is a filter with 1 or more options)

### Screenshots of visual changes before/after (if there are any)
<img width="288" alt="schermafbeelding 2019-02-12 om 12 26 41" src="https://user-images.githubusercontent.com/26965893/52632340-8c5d4780-2ec1-11e9-9991-8ae6878e8834.png">

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility)

### Contribution and currently important rules acceptance

- [x ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)