### PR TITLE
Bugfix/2438 cannot edit previous steps on checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved docs at contributing.md and configuration.md (spelling etc.) - @ruthgeridema (#2421, #2422, #2423, #2425, #2426)
 - Fixed design issue of Country label on Edge 17 & Firefox - @ananth-iyer (#2390,#2399)
 - Country field is filled by first counry from the list in cart in paymen section - @RakowskiPrzemyslaw (#2428)
-- Fix cannot edit previous steps in checkout @filrak (#2457)
+- Fix cannot edit previous steps in checkout - @filrak (#2457)
 
 ## [1.8.2] - 2019.02.11
 - Fixed docker-compose configuration for network_mode and TS build config - @lukeromanowicz (#2415)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved docs at contributing.md and configuration.md (spelling etc.) - @ruthgeridema (#2421, #2422, #2423, #2425, #2426)
 - Fixed design issue of Country label on Edge 17 & Firefox - @ananth-iyer (#2390,#2399)
 - Country field is filled by first counry from the list in cart in paymen section - @RakowskiPrzemyslaw (#2428)
+- Fix cannot edit previous steps in checkout @filrak (#2457)
 
 ## [1.8.2] - 2019.02.11
 - Fixed docker-compose configuration for network_mode and TS build config - @lukeromanowicz (#2415)

--- a/core/modules/checkout/components/PersonalDetails.ts
+++ b/core/modules/checkout/components/PersonalDetails.ts
@@ -54,7 +54,6 @@ export const PersonalDetails = {
     edit () {
       if (this.isFilled) {
         this.$bus.$emit('checkout-before-edit', 'personalDetails')
-        this.isFilled = false
       }
     },
     gotoAccount () {


### PR DESCRIPTION
### Related issues

closes #2438

### Short description and why it's useful

When we were entered the step again `isFilled` has been set to `false`. It's set to `true` only after step submission so switching to another step without submission was ending up with `isFilled`blocked  to `false`