### PR TITLE
Feature/product gallery image blinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve images loading on category page, corrected alt view and blinking problem - @patzick (#2465)
 - Improve tsconfig for better IDE paths support - @patzick, @filrak (#2474)
 - fix breadcrumbs changing too early - @filrak (#2469)
+- improved product gallery load view, shows correct image on reload - @patzick (#2481)
 
 ### Deprecated / Removed
 - `@vue-storefront/store` package deprecated - @filrak

--- a/core/compatibility/components/Breadcrumbs.js
+++ b/core/compatibility/components/Breadcrumbs.js
@@ -8,7 +8,7 @@ export default {
     },
     activeRoute: {
       type: String,
-      required: true
+      default: ''
     }
   }
 }

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -535,7 +535,7 @@ export function getMediaGallery (product) {
           if (mediaItem.image) {
               mediaGallery.push({
                 'src': getThumbnailPath(mediaItem.image, rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
-                'loading': getThumbnailPath(product.image, 310, 300),
+                'loading': getThumbnailPath(mediaItem.image, 310, 300),
                 'video': mediaItem.vid
               })
           }
@@ -560,7 +560,7 @@ export function configurableChildrenImages(product) {
             if (groupedByAttribute[confChild][0].image) {
                 configurableChildrenImages.push({
                     'src': getThumbnailPath(groupedByAttribute[confChild][0].image, rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
-                    'loading': getThumbnailPath(product.image, 310, 300),
+                    'loading': getThumbnailPath(groupedByAttribute[confChild][0].image, 310, 300),
                     'id': confChild
                 })
             }

--- a/src/themes/default/components/core/ProductGalleryCarousel.vue
+++ b/src/themes/default/components/core/ProductGalleryCarousel.vue
@@ -66,7 +66,7 @@ export default {
     return {
       carouselTransitionSpeed: 300,
       currentPage: 0,
-      hideImageAtIndexAtIndex: null
+      hideImageAtIndex: null
     }
   },
   components: {

--- a/src/themes/default/components/core/ProductGalleryCarousel.vue
+++ b/src/themes/default/components/core/ProductGalleryCarousel.vue
@@ -64,7 +64,7 @@ export default {
   },
   data () {
     return {
-      carouselTransitionSpeed: 300,
+      carouselTransitionSpeed: 0,
       currentPage: 0,
       hideImageAtIndex: null
     }
@@ -140,11 +140,11 @@ export default {
   right: 0;
 }
 img {
-  opacity: 0.9;
+  opacity: 1;
   mix-blend-mode: multiply;
   vertical-align: top;
   &:hover {
-    opacity: 1;
+    opacity: 0.9;
   }
 }
 img[lazy=error] {
@@ -152,6 +152,10 @@ img[lazy=error] {
 }
 img[lazy=loading] {
   width: 100%;
+}
+img[lazy=loaded] {
+  -webkit-animation: none;
+  animation: none;
 }
 
 .video-container {


### PR DESCRIPTION
### Related issues

-

### Short description and why it's useful

Corrects product gallery thumbnails, reduces first gallery slide when specific product color is chosen and turns off default lazy animation which causes blinking on gallery.

### Screenshots of visual changes before/after (if there are any)

Gifs below are converted from mov files and for some reason are slowed down. Animations are faster, but generally shows the difference.

#### Before
![before_1](https://user-images.githubusercontent.com/13100280/53205501-c6032080-362e-11e9-9849-7e064f1859ee.gif)

#### After
![after_1](https://user-images.githubusercontent.com/13100280/53205509-cd2a2e80-362e-11e9-8114-7f9477b94a93.gif)

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature
