### PR TITLE
add gallery placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve images loading on category page, corrected alt view and blinking problem - @patzick (#2465)
 - Improve tsconfig for better IDE paths support - @patzick, @filrak (#2474)
 - fix breadcrumbs changing too early - @filrak (#2469)
-- improved product gallery load view, shows correct image on reload - @patzick (#2481)
+- improved product gallery load view, shows correct image on reload - @patzick (#2481, #2382)
 
 ### Deprecated / Removed
 - `@vue-storefront/store` package deprecated - @filrak

--- a/src/themes/default/components/core/ProductGallery.vue
+++ b/src/themes/default/components/core/ProductGallery.vue
@@ -21,7 +21,8 @@
             :current-slide="currentSlide"
             :product-name="product.name"
             :gallery="gallery"
-            @close="toggleZoom"/>
+            @close="toggleZoom"
+          />
           <no-ssr>
             <product-gallery-carousel
               v-if="showProductGalleryCarousel"
@@ -92,6 +93,10 @@ export default {
 .media-gallery {
   text-align: center;
   height: 100%;
+  background-image: url('/assets/placeholder.svg');
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 40% auto;
 }
 .offline-image {
   width: 100%;


### PR DESCRIPTION
### Related issues

Followup for #2481 

### Short description and why it's useful

Added placeholder before gallery load.

@pkarw answering to comment - there is placeholder earlier in gallery - it's small image of gallery. It was by default first image from gallery, so we've seen:
1. Nothing
2. First image
3. Slide to specific color
4. placeholder, which was small first image
5. Actual image

Now it is:
1. Placeholder (this PR)
2. Placeholder of actual image (smaller image so it's blurred)
3. Actual image

### Screenshots of visual changes before/after (if there are any)

![aft2](https://user-images.githubusercontent.com/13100280/53236513-b6b6be00-3694-11e9-8f3a-b46d34246629.gif)

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature
