### PR TITLE
Feature/add items minicart count type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve tsconfig for better IDE paths support - @patzick, @filrak (#2474)
 - fix breadcrumbs changing too early - @filrak (#2469)
 - improved product gallery load view, shows correct image on reload - @patzick (#2481)
+- add cart count config, allows you to display the item count instead of a sum of the item quantities - @pauluse
 
 ### Deprecated / Removed
 - `@vue-storefront/store` package deprecated - @filrak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve images loading on category page, corrected alt view and blinking problem - @patzick (#2465)
 - Improve tsconfig for better IDE paths support - @patzick, @filrak (#2474)
 - fix breadcrumbs changing too early - @filrak (#2469)
-- improved product gallery load view, shows correct image on reload - @patzick (#2481)
 - add cart count config, allows you to display the item count instead of a sum of the item quantities - @pauluse (#2483)
 - improved product gallery load view, shows correct image on reload - @patzick (#2481, #2382)
 

--- a/config/default.json
+++ b/config/default.json
@@ -235,6 +235,7 @@
       "setConfigurableProductOptions": true,
       "askBeforeRemoveProduct": true,
       "displayItemDiscounts": true,
+      "minicartCountType": "quantities",
       "create_endpoint": "http://localhost:8080/api/cart/create?token={{token}}",
       "updateitem_endpoint": "http://localhost:8080/api/cart/update?token={{token}}&cartId={{cartId}}",
       "deleteitem_endpoint": "http://localhost:8080/api/cart/delete?token={{token}}&cartId={{cartId}}",

--- a/core/modules/cart/store/getters.ts
+++ b/core/modules/cart/store/getters.ts
@@ -45,7 +45,11 @@ const getters: GetterTree<CartState, RootState> = {
       return totalsArray
     }
   },
-  totalQuantity (state) {
+  totalQuantity (state, getters, rootStore) {
+    if (rootStore.config.cart.minicartCountType === 'items') {
+      return state.cartItems.length
+    }
+
     return sumBy(state.cartItems, (p) => {
       return p.qty
     })

--- a/docs/guide/basics/configuration.md
+++ b/docs/guide/basics/configuration.md
@@ -303,6 +303,12 @@ If this option is set to `true`, in case of configurable products, Vue Storefron
 If this option is set to `true`, Vue Storefront will add use price item with a discount to the shopping cart. Otherwise, the product price and special will be added to the shopping cart instead.
 
 ```json
+  "minicartCountType": "quantities",
+```
+
+If this option is set to `items`, Vue Storefront will calculate the cart count based on items instead of the item quantities.
+
+```json
   "create_endpoint": "http://localhost:8080/api/cart/create?token={{token}}",
   "updateitem_endpoint": "http://localhost:8080/api/cart/update?token={{token}}&cartId={{cartId}}",
   "deleteitem_endpoint": "http://localhost:8080/api/cart/delete?token={{token}}&cartId={{cartId}}",


### PR DESCRIPTION
### Short description and why it's useful

Some people prefer to show the total items in the cart, instead of the sum of the cart item quantities. This PR adds a config settings which makes you able to modify the cart count based on it's value.

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
