### PR TITLE
remove single image on product page, always show a gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve tsconfig for better IDE paths support - @patzick, @filrak (#2474)
 - fix breadcrumbs changing too early - @filrak (#2469)
 - add cart count config, allows you to display the item count instead of a sum of the item quantities - @pauluse (#2483)
-- improved product gallery load view, shows correct image on reload - @patzick (#2481, #2382)
+- improved product gallery load view, shows correct image on reload - @patzick (#2481, #2482, #2488)
 
 ### Deprecated / Removed
 - `@vue-storefront/store` package deprecated - @filrak

--- a/core/modules/catalog/components/ProductGallery.ts
+++ b/core/modules/catalog/components/ProductGallery.ts
@@ -24,8 +24,5 @@ export const ProductGallery = {
     }
   },
   computed: {
-    defaultImage () {
-      return this.gallery.length ? this.gallery[0] : false
-    }
   }
 }

--- a/src/themes/default/components/core/ProductGallery.vue
+++ b/src/themes/default/components/core/ProductGallery.vue
@@ -5,33 +5,21 @@
     </div>
     <div v-show="OnlineOnly">
       <div class="relative">
-        <div v-if="gallery.length === 1">
-          <img
-            :src="defaultImage.src"
-            v-lazy="defaultImage"
-            class="mw-100 pointer"
-            ref="defaultImage"
-            :alt="product.name | htmlDecode"
-            itemprop="image"
-          >
-        </div>
-        <div v-else>
-          <product-gallery-overlay
-            v-if="isZoomOpen"
-            :current-slide="currentSlide"
-            :product-name="product.name"
+        <product-gallery-overlay
+          v-if="isZoomOpen"
+          :current-slide="currentSlide"
+          :product-name="product.name"
+          :gallery="gallery"
+          @close="toggleZoom"
+        />
+        <no-ssr>
+          <product-gallery-carousel
+            v-if="showProductGalleryCarousel"
             :gallery="gallery"
-            @close="toggleZoom"
-          />
-          <no-ssr>
-            <product-gallery-carousel
-              v-if="showProductGalleryCarousel"
-              :gallery="gallery"
-              :configuration="configuration"
-              :product-name="product.name"
-              @toggle="openOverlay"/>
-          </no-ssr>
-        </div>
+            :configuration="configuration"
+            :product-name="product.name"
+            @toggle="openOverlay"/>
+        </no-ssr>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Related issues

#2481 

### Short description and why it's useful

Always display a gallery, even if there is only one image.
There was no option to zoom single image, and loading caused a jump effect. Now gallery will be consistent.

### Screenshots of visual changes before/after (if there are any)

#### Before
![gal_before](https://user-images.githubusercontent.com/13100280/53275457-7cccd280-36fb-11e9-8cac-fc84076438f3.gif)

#### After
![gal_after](https://user-images.githubusercontent.com/13100280/53275466-835b4a00-36fb-11e9-8d76-f45b3ab3c5d2.gif)

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature