### PR TITLE
bugfix/template-paths-changed-in-1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix breadcrumbs changing too early - @filrak (#2469)
 - add cart count config, allows you to display the item count instead of a sum of the item quantities - @pauluse (#2483)
 - improved product gallery load view, shows correct image on reload - @patzick (#2481, #2382)
+- Fix an issue where the index.html template within a theme is ignored - @EnthrallRecords (#2489) 
 
 ### Deprecated / Removed
 - `@vue-storefront/store` package deprecated - @filrak

--- a/core/build/webpack.base.config.ts
+++ b/core/build/webpack.base.config.ts
@@ -19,7 +19,7 @@ import themeRoot from './theme-path';
 const themeResources = themeRoot + '/resource'
 const themeCSS = themeRoot + '/css'
 const themeApp = themeRoot + '/App.vue'
-const themedIndex = path.join(themeRoot, 'index.template.html')
+const themedIndex = path.join(themeRoot, '/templates/index.template.html')
 const themedIndexMinimal = path.join(themeRoot, '/templates/index.minimal.template.html')
 const themedIndexBasic = path.join(themeRoot, '/templates/index.basic.template.html')
 const themedIndexAmp = path.join(themeRoot, '/templates/index.amp.template.html')


### PR DESCRIPTION

### Short description and why it's useful

Per 1.8 upgrade notes `src/themes/default/index.template.html` has been moved to `src/themes/default/templates/index.template.html`. Build does not reflect the change, so index.html is not built from the template in the new location.

### Screenshots of visual changes before/after (if there are any)

**Before:**
![image](https://user-images.githubusercontent.com/47048856/53280266-243f0a80-36e6-11e9-85d5-b97bd013e3f2.png)

**After:**
![image](https://user-images.githubusercontent.com/47048856/53280068-564f6d00-36e4-11e9-9057-18de06c87a8b.png)

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
