### PR TITLE
Bugfix/#2450 show prices after adding product to cart in offline mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.8.3] - 2019.02.27
+### Added
+- New reactive helper to check online state. Usage: `import { onlineHelper } from '@vue-storefront/core/helpers'` and then `onlineHelper.isOnline` - @patzick (#2510)
+
 ### Fixed
 - Problem with placing second order (unbinding payment methods after first order) - @patzick (#2195, #2503)
 
@@ -34,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inconsistent filters behaviour - clear filters on page load - @patzick (#2435)
 - fix price is never below 0 and user can't add 0 or below 0 products to cart @RakowskiPrzemyslaw (#2437)
 - Check for placing single order in case of error in any payment module - @patzick (#2409)
+- Display prices in products added in offline mode. - @patzick (#2450)
 
 ### Deprecated / Removed
 - `@vue-storefront/store` package deprecated - @filrak

--- a/core/helpers/index.ts
+++ b/core/helpers/index.ts
@@ -2,6 +2,7 @@ import rootStore from '@vue-storefront/core/store'
 import SearchQuery from '@vue-storefront/core/lib/search/searchQuery'
 import { remove as removeAccents } from 'remove-accents'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import Vue from 'vue'
 
 /**
  * Create slugify -> "create-slugify" permalink  of text
@@ -159,3 +160,10 @@ export function once (key, fn) {
 }
 
 export const isServer: boolean = typeof window === 'undefined'
+
+// Online/Offline helper
+export const onlineHelper = Vue.observable({ 
+  isOnline: isServer || navigator.onLine 
+})
+!isServer && window.addEventListener('online',  () => onlineHelper.isOnline = true)
+!isServer && window.addEventListener('offline', () => onlineHelper.isOnline = false)

--- a/core/modules/cart/store/getters.ts
+++ b/core/modules/cart/store/getters.ts
@@ -4,10 +4,11 @@ import i18n from '@vue-storefront/i18n'
 import CartState from '../types/CartState'
 import RootState from '@vue-storefront/core/types/RootState'
 import AppliedCoupon from '../types/AppliedCoupon'
+import { onlineHelper } from '@vue-storefront/core/helpers'
 
 const getters: GetterTree<CartState, RootState> = {
   totals (state) {
-    if (state.platformTotalSegments) {
+    if (state.platformTotalSegments && onlineHelper.isOnline) {
       return state.platformTotalSegments
     } else {
       let shipping = state.shipping instanceof Array ? state.shipping[0] : state.shipping

--- a/src/themes/default/components/core/blocks/Microcart/Product.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Product.vue
@@ -53,7 +53,7 @@
           {{ product.priceInclTax * product.qty | price }}
         </span>
       </div>
-      <div class="prices" v-if="product.totals && displayItemDiscounts">
+      <div class="prices" v-else-if="product.totals">
         <span class="h4 serif cl-error price-special" v-if="product.totals.discount_amount">
           {{ product.totals.row_total_incl_tax - product.totals.discount_amount | price }}&nbsp;
         </span>
@@ -62,6 +62,11 @@
         </span>
         <span class="h4 serif price-regular" v-if="!product.totals.discount_amount">
           {{ product.totals.row_total_incl_tax | price }}
+        </span>
+      </div>
+      <div class="prices" v-else>
+        <span class="h4 serif price-regular">
+          {{ product.regular_price * product.qty | price }}
         </span>
       </div>
       <div class="links">


### PR DESCRIPTION
### Related issues

closes #2450 

### Short description and why it's useful

Shows regular price when there is no totals from server.

I also discovered, that cart summary is in `cart.state.platformTotalSegments` which is updated after response from server, so after adding new product summary still was not updated. So i made a reactive online helper and used it in getter which returns cart summary.

New Vue.observable is pretty cool! :boom:  :)

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature
