### PR TITLE
Bugfix/2438 checkout steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved product quantity change component in product and cart - @patzick (#2398, #2437)
 - Updated to Vue 2.6.6 - @filrak (#2456)
 - Null sidebar menu data on static page fixed - @filrak (#2456)
-- Fix cannot edit previous steps in checkout - @filrak (#2457)
+- Fix cannot edit previous steps in checkout - @filrak, @patzick (#2438)
 - Fixed route guard ssr problem - @vue-kacper (#2364)
 - Fix links in footer to static pages bug - @filrak (#2464)
 - Fix links at docs, Basics/Configuration file explained - @daksamit (#2490)

--- a/core/modules/checkout/components/Payment.ts
+++ b/core/modules/checkout/components/Payment.ts
@@ -53,7 +53,6 @@ export const Payment = {
     edit () {
       if (this.isFilled) {
         this.$bus.$emit('checkout-before-edit', 'payment')
-        this.isFilled = false
       }
     },
     hasBillingData () {

--- a/core/modules/checkout/components/Shipping.ts
+++ b/core/modules/checkout/components/Shipping.ts
@@ -79,7 +79,6 @@ export const Shipping = {
     edit () {
       if (this.isFilled) {
         this.$bus.$emit('checkout-before-edit', 'shipping')
-        this.isFilled = false
       }
     },
     hasShippingDetails () {


### PR DESCRIPTION
### Related issues

closes #2438

### Short description and why it's useful

It's the same fix as in #2457 but with other steps too.
I tried many combinations between changing steps and i believe this covers issue.

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature
