### PR TITLE
Bugfix/#2480 remake order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Problem with placing second order (unbinding payment methods after first order) - @patzick (#2195, #2503)
+- Remaking order on user orders page - @patzick (#2480)
 
 ### Changed / Improved
 - Fixed an issue where the correct image for a product configuration wasn't set on the product page image carousel. Also added the fix on the productcarousel in the zoom component - @DaanKouters (#2419)

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -399,7 +399,7 @@ const actions: ActionTree<CartState, RootState> = {
           country: country,
           method_code: shipping ? shipping.method_code : null,
           carrier_code: shipping ? shipping.carrier_code : null,
-          payment_method: payment.code
+          payment_method: payment ? payment.code : null
         }
       }
       if (methodsData.country && methodsData.carrier_code) {

--- a/core/modules/order/components/UserOrders.ts
+++ b/core/modules/order/components/UserOrders.ts
@@ -13,7 +13,7 @@ export const UserOrders = {
     }
   },
   methods: {
-    reorder (products) {
+    remakeOrder (products) {
       products.forEach(item => {
         this.$store.dispatch('product/single', { options: { sku: item.sku }, setCurrentProduct: false, selectDefaultVariant: false }).then((product) => {
           product.qty = item.qty_ordered


### PR DESCRIPTION
### Related issues

closes #2480 

### Short description and why it's useful

Fixes remake order feature
### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature
