### PR TITLE
Bugfix/#2523

### DIFF
--- a/core/compatibility/components/blocks/Category/Sidebar.js
+++ b/core/compatibility/components/blocks/Category/Sidebar.js
@@ -33,13 +33,15 @@ export default {
       return [...filters].sort((a, b) => { return a.id - b.id })
     },
     resetAllFilters () {
-      this.$bus.$emit('filter-reset')
-      this.$store.dispatch('category/resetFilters')
-      this.$store.dispatch('category/searchProductQuery', {})
-      this.$store.dispatch('category/mergeSearchOptions', {
-        searchProductQuery: buildFilterProductsQuery(this.category, this.activeFilters)
-      })
-      this.$store.dispatch('category/products', this.getCurrentCategoryProductQuery)
+      if (this.hasActiveFilters) {
+        this.$bus.$emit('filter-reset')
+        this.$store.dispatch('category/resetFilters')
+        this.$store.dispatch('category/searchProductQuery', {})
+        this.$store.dispatch('category/mergeSearchOptions', {
+          searchProductQuery: buildFilterProductsQuery(this.category, this.activeFilters)
+        })
+        this.$store.dispatch('category/products', this.getCurrentCategoryProductQuery)
+      }
     }
   }
 }


### PR DESCRIPTION
### Related issues

Closes: #2523 

### Short description and why it's useful

We can't call `resetAllFilters` in `mounted()` as it causes secod data fetch with page refresh (first is in the SSR and it should be just called once :-))
