### PR TITLE
Bugfix/Too early changed breadcrumbs

### DIFF
--- a/core/modules/catalog/store/product/actions.ts
+++ b/core/modules/catalog/store/product/actions.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import { ActionTree } from 'vuex'
 import * as types from './mutation-types'
-import { breadCrumbRoutes, productThumbnailPath } from '@vue-storefront/core/helpers'
+import { breadCrumbRoutes, productThumbnailPath, isServer } from '@vue-storefront/core/helpers'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { configureProductAsync,
   doPlatformPricesSync,
@@ -617,18 +617,20 @@ const actions: ActionTree<ProductState, RootState> = {
         const productFields = Object.keys(product).filter(fieldName => {
           return rootStore.state.config.entities.product.standardSystemFields.indexOf(fieldName) < 0 // don't load metadata info for standard fields
         })
-        subloaders.push(context.dispatch('attribute/list', { // load attributes to be shown on the product details - the request is now async
+        const attributesPromise = context.dispatch('attribute/list', { // load attributes to be shown on the product details - the request is now async
           filterValues: rootStore.state.config.entities.product.useDynamicAttributeLoader ? productFields : null,
           only_visible: rootStore.state.config.entities.product.useDynamicAttributeLoader ? true : false,
           only_user_defined: true,
           includeFields: rootStore.state.config.entities.optimize ? rootStore.state.config.entities.attribute.includeFields : null
-        }, { root: true }))
+        }, { root: true })
         if (Vue.prototype.$isServer) {
+          subloaders.push(context.dispatch('setupBreadcrumbs', { product: product }))
           subloaders.push(context.dispatch('filterUnavailableVariants', { product: product }))
         } else {
+          attributesPromise.then(() => context.dispatch('setupBreadcrumbs', { product: product })) // if this is client's side request postpone breadcrumbs setup till attributes are loaded to avoid too-early breadcrumb switch #2469
           context.dispatch('filterUnavailableVariants', { product: product }) // exec async
         }
-        subloaders.push(context.dispatch('setupBreadcrumbs', { product: product }))
+        subloaders.push(attributesPromise)
 
         // subloaders.push(context.dispatch('setupVariants', { product: product })) -- moved to "product/single"
         /* if (product.type_id === 'grouped' || product.type_id === 'bundle') { -- moved to "product/single"

--- a/core/modules/catalog/store/product/actions.ts
+++ b/core/modules/catalog/store/product/actions.ts
@@ -622,7 +622,7 @@ const actions: ActionTree<ProductState, RootState> = {
           only_visible: rootStore.state.config.entities.product.useDynamicAttributeLoader ? true : false,
           only_user_defined: true,
           includeFields: rootStore.state.config.entities.optimize ? rootStore.state.config.entities.attribute.includeFields : null
-        }, { root: true })
+        }, { root: true }) // TODO: it might be refactored to kind of: `await context.dispatch('attributes/list) - or using new Promise() .. to wait for attributes to be loaded before executing the next action. However it may decrease the performance - so for now we're just waiting with the breadcrumbs
         if (Vue.prototype.$isServer) {
           subloaders.push(context.dispatch('setupBreadcrumbs', { product: product }))
           subloaders.push(context.dispatch('filterUnavailableVariants', { product: product }))


### PR DESCRIPTION
### Related issues

Related to #2469 

### Short description and why it's useful

Breadcrumbs were changed too early because first `attributes/list` request takes some time (usually requires a server roundtrip). 

### Contribution and currently important rules acceptance

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
