### PR TITLE
WIP: PWA module with Workbox 4.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 core/build/*.js
 node_modules
 core/modules/**/tests
+**/service-worker.js
+**/workbox-config.js

--- a/core/build/webpack.base.config.ts
+++ b/core/build/webpack.base.config.ts
@@ -7,7 +7,8 @@ import autoprefixer from 'autoprefixer';
 import HTMLPlugin from 'html-webpack-plugin';
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 import webpack from 'webpack';
-
+// temporary
+import WorkboxPlugin from '@vue-storefront/core/modules/pwa/webpack-plugin'
 fs.writeFileSync(
   path.resolve(__dirname, './config.json'),
   JSON.stringify(config)
@@ -16,6 +17,7 @@ fs.writeFileSync(
 const themesRoot = '../../src/themes'
 
 import themeRoot from './theme-path';
+import webpackPlugin from '@vue-storefront/core/modules/pwa/webpack-plugin';
 const themeResources = themeRoot + '/resource'
 const themeCSS = themeRoot + '/css'
 const themeApp = themeRoot + '/App.vue'
@@ -46,6 +48,7 @@ const isProd = process.env.NODE_ENV === 'production'
 // todo: usemultipage-webpack-plugin for multistore
 export default {
   plugins: [
+    webpackPlugin,
     new webpack.ProgressPlugin(),
     // new BundleAnalyzerPlugin({
     //   generateStatsFile: true

--- a/core/modules/pwa/service-worker.js
+++ b/core/modules/pwa/service-worker.js
@@ -1,0 +1,9 @@
+
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/4.0.0/workbox-sw.js')
+
+workbox.setConfig({debug: true})
+
+workbox.core.skipWaiting()
+workbox.core.clientsClaim()
+
+workbox.precaching.precacheAndRoute([])

--- a/core/modules/pwa/webpack-plugin.ts
+++ b/core/modules/pwa/webpack-plugin.ts
@@ -1,0 +1,14 @@
+import { InjectManifest } from 'workbox-webpack-plugin'
+
+export default new InjectManifest({
+  swDest: "sw.js",
+  swSrc: "core/modules/pwa/service-worker.js",
+  globDirectory: "dist/",
+  globPatterns: [
+    '**/*.js',
+    'assets/**.*',
+    'assets/ig/**.*',
+    'index.html',
+  ],
+  globIgnores: ['**/*..map']
+})

--- a/core/modules/pwa/webpack-plugin.ts
+++ b/core/modules/pwa/webpack-plugin.ts
@@ -2,13 +2,5 @@ import { InjectManifest } from 'workbox-webpack-plugin'
 
 export default new InjectManifest({
   swDest: "sw.js",
-  swSrc: "core/modules/pwa/service-worker.js",
-  globDirectory: "dist/",
-  globPatterns: [
-    '**/*.js',
-    'assets/**.*',
-    'assets/ig/**.*',
-    'index.html',
-  ],
-  globIgnores: ['**/*..map']
+  swSrc: "core/modules/pwa/service-worker.js"
 })

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dev:sw": "cross-env TS_NODE_PROJECT=\"tsconfig-build.json\" yarn build:sw && ts-node ./core/scripts/entry",
     "dev:inspect": "cross-env TS_NODE_PROJECT=\"tsconfig-build.json\" node --inspect -r ts-node/register ./core/scripts/entry",
     "build:sw": "cross-env NODE_ENV=production TS_NODE_PROJECT=\"tsconfig-build.json\" webpack --config ./core/build/webpack.prod.sw.config.ts --mode production --progress --hide-modules",
+    "build:sw:new": "cross-env NODE_ENV=production TS_NODE_PROJECT=\"tsconfig-build.json\" workbox injectManifest core/modules/pwa/workbox-config.js",
     "build:client": "cross-env NODE_ENV=production TS_NODE_PROJECT=\"tsconfig-build.json\" webpack --config ./core/build/webpack.prod.client.config.ts --mode production --progress --hide-modules",
     "build:server": "cross-env NODE_ENV=production TS_NODE_PROJECT=\"tsconfig-build.json\" webpack --config ./core/build/webpack.prod.server.config.ts --mode production --progress --hide-modules",
     "build": "rimraf dist && yarn build:client && yarn build:server && yarn build:sw",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "dev:sw": "cross-env TS_NODE_PROJECT=\"tsconfig-build.json\" yarn build:sw && ts-node ./core/scripts/entry",
     "dev:inspect": "cross-env TS_NODE_PROJECT=\"tsconfig-build.json\" node --inspect -r ts-node/register ./core/scripts/entry",
     "build:sw": "cross-env NODE_ENV=production TS_NODE_PROJECT=\"tsconfig-build.json\" webpack --config ./core/build/webpack.prod.sw.config.ts --mode production --progress --hide-modules",
-    "build:sw:new": "cross-env NODE_ENV=production TS_NODE_PROJECT=\"tsconfig-build.json\" workbox injectManifest core/modules/pwa/workbox-config.js",
     "build:client": "cross-env NODE_ENV=production TS_NODE_PROJECT=\"tsconfig-build.json\" webpack --config ./core/build/webpack.prod.client.config.ts --mode production --progress --hide-modules",
     "build:server": "cross-env NODE_ENV=production TS_NODE_PROJECT=\"tsconfig-build.json\" webpack --config ./core/build/webpack.prod.server.config.ts --mode production --progress --hide-modules",
     "build": "rimraf dist && yarn build:client && yarn build:server && yarn build:sw",

--- a/yarn.lock
+++ b/yarn.lock
@@ -654,6 +654,12 @@
     core-js "^2.5.3"
     regenerator-runtime "^0.11.1"
 
+"@babel/runtime@^7.0.0":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -906,7 +912,6 @@
 "@types/sinon-chai@3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@types/sinon-chai/-/sinon-chai-3.2.2.tgz#5cfdbda70bae30f79a9423334af9e490e4cce793"
-  integrity sha512-5zSs2AslzyPZdOsbm2NRtuSNAI2aTWzNKOHa/GRecKo7a5efYD7qGcPxMZXQDayVXT2Vnd5waXxBvV31eCZqiA==
   dependencies:
     "@types/chai" "*"
     "@types/sinon" "*"
@@ -918,7 +923,6 @@
 "@types/sinon@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.0.0.tgz#84e707e157ec17d3e4c2a137f41fc3f416c0551e"
-  integrity sha512-kcYoPw0uKioFVC/oOqafk2yizSceIQXCYnkYts9vJIwQklFRsMubTObTDrjQamUyBRd47332s85074cd/hCwxg==
 
 "@types/sizzle@*":
   version "2.3.2"
@@ -3605,7 +3609,6 @@ cyclist@~0.2.2:
 cypress@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.1.5.tgz#5227b2ce9306c47236d29e703bad9055d7218042"
-  integrity sha512-jzYGKJqU1CHoNocPndinf/vbG28SeU+hg+4qhousT/HDBMJxYgjecXOmSgBX/ga9/TakhqSrIrSP2r6gW/OLtg==
   dependencies:
     "@cypress/listr-verbose-renderer" "0.4.1"
     "@cypress/xvfb" "1.2.3"
@@ -6154,6 +6157,12 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@^5.0, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -6185,6 +6194,10 @@ jsonfile@^4.0.0:
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -8759,6 +8772,10 @@ regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
@@ -10955,11 +10972,23 @@ workbox-background-sync@^3.6.3:
   dependencies:
     workbox-core "^3.6.3"
 
+workbox-background-sync@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-background-sync/-/workbox-background-sync-4.0.0.tgz#231988ea3813a06825e887860b2e702e1db824e7"
+  dependencies:
+    workbox-core "^4.0.0"
+
 workbox-broadcast-cache-update@^3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.6.3.tgz#3f5dff22ada8c93e397fb38c1dc100606a7b92da"
   dependencies:
     workbox-core "^3.6.3"
+
+workbox-broadcast-update@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-broadcast-update/-/workbox-broadcast-update-4.0.0.tgz#2ff32dcdbba16a5bf44d1312527363e19b7749d1"
+  dependencies:
+    workbox-core "^4.0.0"
 
 workbox-build@^3.1.0:
   version "3.6.3"
@@ -10988,6 +11017,34 @@ workbox-build@^3.1.0:
     workbox-streams "^3.6.3"
     workbox-sw "^3.6.3"
 
+workbox-build@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-4.0.0.tgz#60747daf8831f82c0e3da6124dda854971049637"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    common-tags "^1.4.0"
+    fs-extra "^4.0.2"
+    glob "^7.1.2"
+    joi "^11.1.1"
+    lodash.template "^4.4.0"
+    pretty-bytes "^4.0.2"
+    stringify-object "^3.2.2"
+    strip-comments "^1.0.2"
+    workbox-background-sync "^4.0.0"
+    workbox-broadcast-update "^4.0.0"
+    workbox-cacheable-response "^4.0.0"
+    workbox-core "^4.0.0"
+    workbox-expiration "^4.0.0"
+    workbox-google-analytics "^4.0.0"
+    workbox-navigation-preload "^4.0.0"
+    workbox-precaching "^4.0.0"
+    workbox-range-requests "^4.0.0"
+    workbox-routing "^4.0.0"
+    workbox-strategies "^4.0.0"
+    workbox-streams "^4.0.0"
+    workbox-sw "^4.0.0"
+    workbox-window "^4.0.0"
+
 workbox-cache-expiration@^3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/workbox-cache-expiration/-/workbox-cache-expiration-3.6.3.tgz#4819697254a72098a13f94b594325a28a1e90372"
@@ -11000,9 +11057,25 @@ workbox-cacheable-response@^3.6.3:
   dependencies:
     workbox-core "^3.6.3"
 
+workbox-cacheable-response@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-4.0.0.tgz#3ac3e5a01d29a0005cf6ff9560cfe0502c8358a8"
+  dependencies:
+    workbox-core "^4.0.0"
+
 workbox-core@^3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-3.6.3.tgz#69abba70a4f3f2a5c059295a6f3b7c62bd00e15c"
+
+workbox-core@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-4.0.0.tgz#3b4aa11c9d739361ed8916b7611abc3b6fefed8b"
+
+workbox-expiration@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-expiration/-/workbox-expiration-4.0.0.tgz#098f804df178b6212e1e208be072e6f54026eec0"
+  dependencies:
+    workbox-core "^4.0.0"
 
 workbox-google-analytics@^3.6.3:
   version "3.6.3"
@@ -11013,11 +11086,26 @@ workbox-google-analytics@^3.6.3:
     workbox-routing "^3.6.3"
     workbox-strategies "^3.6.3"
 
+workbox-google-analytics@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-google-analytics/-/workbox-google-analytics-4.0.0.tgz#51c98cc471e5b35c7f86b3aff1d74a28036707e2"
+  dependencies:
+    workbox-background-sync "^4.0.0"
+    workbox-core "^4.0.0"
+    workbox-routing "^4.0.0"
+    workbox-strategies "^4.0.0"
+
 workbox-navigation-preload@^3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-3.6.3.tgz#a2c34eb7c17e7485b795125091215f757b3c4964"
   dependencies:
     workbox-core "^3.6.3"
+
+workbox-navigation-preload@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-4.0.0.tgz#96255fb2f060f0b1306755cce87ca27202e830ba"
+  dependencies:
+    workbox-core "^4.0.0"
 
 workbox-precaching@^3.6.3:
   version "3.6.3"
@@ -11025,11 +11113,23 @@ workbox-precaching@^3.6.3:
   dependencies:
     workbox-core "^3.6.3"
 
+workbox-precaching@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-4.0.0.tgz#941624d0135d9df3d88929a9de7e20bda0e8d771"
+  dependencies:
+    workbox-core "^4.0.0"
+
 workbox-range-requests@^3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-3.6.3.tgz#3cc21cba31f2dd8c43c52a196bcc8f6cdbcde803"
   dependencies:
     workbox-core "^3.6.3"
+
+workbox-range-requests@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-4.0.0.tgz#9fffba4a7a070c747ed766cbf3063978a855e749"
+  dependencies:
+    workbox-core "^4.0.0"
 
 workbox-routing@^3.6.3:
   version "3.6.3"
@@ -11037,11 +11137,23 @@ workbox-routing@^3.6.3:
   dependencies:
     workbox-core "^3.6.3"
 
+workbox-routing@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-4.0.0.tgz#96c078287494b9d279afd44739da97d3d4d782cb"
+  dependencies:
+    workbox-core "^4.0.0"
+
 workbox-strategies@^3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-3.6.3.tgz#11a0dc249a7bc23d3465ec1322d28fa6643d64a0"
   dependencies:
     workbox-core "^3.6.3"
+
+workbox-strategies@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-4.0.0.tgz#4837dece455dfbb64830c3adbdc93816d22c9ca0"
+  dependencies:
+    workbox-core "^4.0.0"
 
 workbox-streams@^3.6.3:
   version "3.6.3"
@@ -11049,9 +11161,33 @@ workbox-streams@^3.6.3:
   dependencies:
     workbox-core "^3.6.3"
 
+workbox-streams@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-streams/-/workbox-streams-4.0.0.tgz#64c92874a2a27fc37230a15c220f7c61ea04775a"
+  dependencies:
+    workbox-core "^4.0.0"
+
 workbox-sw@^3.6.3:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-3.6.3.tgz#278ea4c1831b92bbe2d420da8399176c4b2789ff"
+
+workbox-sw@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-4.0.0.tgz#7cd07470ee79d4caaf829c2ee97c29651d508027"
+
+workbox-webpack-plugin@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-webpack-plugin/-/workbox-webpack-plugin-4.0.0.tgz#8c976e7569392ac810c5115d5131ba029b311caf"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    json-stable-stringify "^1.0.1"
+    workbox-build "^4.0.0"
+
+workbox-window@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/workbox-window/-/workbox-window-4.0.0.tgz#a4d6404c96cc65d4882f79331d4e812c10f912a6"
+  dependencies:
+    workbox-core "^4.0.0"
 
 worker-farm@^1.5.2:
   version "1.6.0"


### PR DESCRIPTION
### Related issues

closes https://github.com/DivanteLtd/vue-storefront/issues/2492

### Short description and why it's useful

Workbox allows us to make use of latest PWA features and manage them in more maintainable and easier way. It also provides a unified ecosystem of PWA modules.

Progress of migration from sw-precache to Workbox with it's newly released version 4.0. Please don't do any kind of review yet. It's opened just to see the progress ;)

TODO:
- [x] Move precache capabilities to Workbox plugin
- [ ] Move runtime caching capabilities to workbox routes
- [ ] Remove SW build step from `/build` folder
- [ ] Add possibility to modify SW config from the project `src`
- [ ] Use workbox-window to notify about updates