### PR TITLE
Fix missing material icons

### DIFF
--- a/src/index.basic.template.html
+++ b/src/index.basic.template.html
@@ -5,20 +5,6 @@
 		{{{ meta.inject().meta.text() }}}
 		<meta name="generator" content="Vue Storefront">
 		{{{ meta.inject().link.text() }}}
-		<script type="text/javascript">
-			WebFontConfig = {
-				google: { families: [ 'Playfair+Display:400,700', 'Roboto:400,700', 'Material+Icons' ] }
-			};
-			(function() {
-				var wf = document.createElement('script');
-				wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
-				'://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js';
-				wf.type = 'text/javascript';
-				wf.async = 'true';
-				var s = document.getElementsByTagName('script')[0];
-				s.parentNode.insertBefore(wf, s);
-			})();
-		</script>
 		{{{ renderStyles() }}}
 		{{{ output.appendHead() }}}
 	</head>

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -5,20 +5,6 @@
 		{{{ meta.inject().meta.text() }}}
 		<meta name="generator" content="Vue Storefront">
 		{{{ meta.inject().link.text() }}}
-		<script type="text/javascript">
-			WebFontConfig = {
-				google: { families: [ 'Playfair+Display:400,700', 'Roboto:400,700', 'Material+Icons' ] }
-			};
-			(function() {
-				var wf = document.createElement('script');
-				wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
-				'://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js';
-				wf.type = 'text/javascript';
-				wf.async = 'true';
-				var s = document.getElementsByTagName('script')[0];
-				s.parentNode.insertBefore(wf, s);
-      })();
-    </script>
 		{{{ renderResourceHints() }}}
 		{{{ renderStyles() }}}
 		{{{ output.appendHead() }}}

--- a/src/themes/default/templates/index.basic.template.html
+++ b/src/themes/default/templates/index.basic.template.html
@@ -7,7 +7,7 @@
 		{{{ meta.inject().link.text() }}}
 		<script type="text/javascript">
 			WebFontConfig = {
-				google: { families: [ 'Playfair+Display:400,700', 'Roboto:400,700' ] }
+				google: { families: [ 'Playfair+Display:400,700', 'Roboto:400,700', 'Material+Icons' ] }
 			};
 			(function() {
 				var wf = document.createElement('script');

--- a/src/themes/default/templates/index.template.html
+++ b/src/themes/default/templates/index.template.html
@@ -8,7 +8,7 @@
 		{{{ meta.inject().script.text() }}}
 		<script type="text/javascript">
 			WebFontConfig = {
-				google: { families: [ 'Playfair+Display:400,700', 'Roboto:400,700' ] }
+				google: { families: [ 'Playfair+Display:400,700', 'Roboto:400,700', 'Material+Icons' ] }
 			};
 			(function() {
 				var wf = document.createElement('script');


### PR DESCRIPTION
### Related issues

closes nothing

### Short description and why it's useful

Adds material icons font to default theme templates  Rel to https://github.com/DivanteLtd/vue-storefront/pull/2257
### Screenshots of visual changes before/after (if there are any)
![image](https://user-images.githubusercontent.com/15185752/53884764-9be13380-401c-11e9-959a-40027972fec1.png)
![image](https://user-images.githubusercontent.com/15185752/53884779-a13e7e00-401c-11e9-808b-1ed120117826.png)
