### PR TITLE
Fix MicrocartOpen failing unit test (Tests are not enabled in general?)

### DIFF
--- a/core/modules/cart/tests/isMicrocartOpen.spec.js
+++ b/core/modules/cart/tests/isMicrocartOpen.spec.js
@@ -12,8 +12,8 @@ describe('[cart] isMicrocartOpen.ts', () => {
 
   beforeEach(() => {
     state = {
-      ui: {
-       microcart: 'microcartVal'
+      cart: {
+        isMicrocartOpen: 'microcartVal'
       }
     }
 
@@ -24,7 +24,7 @@ describe('[cart] isMicrocartOpen.ts', () => {
 
   it('returns expected value from store', () => {
     const wrapper = shallowMount(TestInstance, { store, localVue })
-    expect(wrapper.vm.isMicrocartOpen).to.equal(state.ui.microcart)
+    expect(wrapper.vm.isOpen).to.equal(state.cart.isMicrocartOpen)
   })
   // TODO: Check the returned value adter state changes
 })


### PR DESCRIPTION
Hello! First of all I wanted to say thanks for such a great job. :tada: 

 My name is Fernando Cejas (@android10) and with Fernando Garcia (@fegabe), we are working on a forked version of the repository.

The reason behind this decision is that we are using **Vue-Storefront** as our base project because of how rich is in terms or architecture/structure, but we need a lot of customization which is not enough by just adding a theme (we can discuss that further :))

Regarding this **PR**, we have seen there was some renaming on ```Microcart.ts``` but tests never updated.

https://github.com/DivanteLtd/vue-storefront/commit/3618408577e94d46f78f663715e258b932e1da7a#diff-cdd05c1b24b0c3839ff44897dcbbc144R17

We have also seen that tests are not being executed and many of them are out-of-date and its execution on Travis is commented. 

Is there any strong reason for this? And what are your plans? Re-enabling them anytime soon?



