### PR TITLE
Bugfix/do not remove query params from route

### DIFF
--- a/core/modules/catalog/components/ProductGallery.ts
+++ b/core/modules/catalog/components/ProductGallery.ts
@@ -16,7 +16,7 @@ export const ProductGallery = {
     },
     offline: {
       type: Object,
-      required: true
+      required: false
     },
     product: {
       type: Object,

--- a/core/modules/url/router/beforeEach.ts
+++ b/core/modules/url/router/beforeEach.ts
@@ -11,12 +11,7 @@ import Vue from 'vue'
 
 export const UrlDispatchMapper = async (to) => {
   const routeData = await store.dispatch('url/mapUrl', { url: to.fullPath, query: to.query })
-  if (routeData) {
-    Object.keys(routeData.params).map(key => {
-      to.params[key] = routeData.params[key]
-    })
-    return routeData
-  }
+  return Object.assign({}, to, routeData)
 }
 export function beforeEach(to: Route, from: Route, next) {
   if (isServer) {


### PR DESCRIPTION
### Related issues

related PR: #2446 

### Short description and why it's useful

Fixes problem with removing queryParams from route path.

I've tried to change childSku queryParam on filters change, but we have too many listeners on route and too many actions is invoked then, so i resigned from that for now. It needs to be done with an architectural change.