### PR TITLE
Add information on what to do for images to work when you put vue-storefront-api on a different server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]
-- Update recipes.md to add information on what to do for images to work when you put vue-storefront-api on a different 
-server
-- Update recipes.md to add information on how to avoid and fix JWT token invalidation error
-- Update `prod.vuestorefront.io` nginx config in docs to remove text/html from gzipped types and avoid `duplicate MIME 
-type "text/html"` Warning in nginx logs
-
-
 ## [1.8.3] - 2019.03.03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+- Update recipes.md to add information on what to do for images to work when you put vue-storefront-api on a different 
+server
+- Update recipes.md to add information on how to avoid and fix JWT token invalidation error
+- Update `prod.vuestorefront.io` nginx config in docs to remove text/html from gzipped types and avoid `duplicate MIME 
+type "text/html"` Warning in nginx logs
+
+
 ## [1.8.3] - 2019.03.03
 
 ### Added

--- a/docs/guide/basics/recipes.md
+++ b/docs/guide/basics/recipes.md
@@ -267,3 +267,10 @@ Execute the following line on your project's root folder:
 
 The code basically looks into all project files for all ```i18n.t('some string')``` and ```$t('some string') ``` occurrences, parses an extracts the quoted text of each occurrence, and saves it into a pipe-separated CSV file, which you might help you to get your missing translations.
 
+## Running vue-storefront-api on a different machine than magento / images not working
+When you separate vue-storefront-api and magento2 by putting them on different servers, it is necessary to link the vue-storefront-api machine with magento media folder via network folder. `sshsfs` is suggested for this.
+Once the network connection is established, the correct folder needs to be pointed in the vue-storefront-api config
+```
+"assetPath": "/../var/magento2-sample-data/pub/media", 
+```
+It is necessary for the correct product image creation by the vue-storefront-api. If this is not set corectly, images will just be placeholders regardless the fact the rest of the setup works and you can see products and categories correctly synced.


### PR DESCRIPTION
Add information on what to do for images to work when you put vue-storefront-api on a different server

### Related issues

none

### Short description and why it's useful

it helps to avoid the problem with the missing images, when you put vue-storefront-api separately from magento

### Screenshots of visual changes before/after (if there are any)
none

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)
none, this is just doc update

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
