### PR TITLE
Remove text/html from gzip_types

### DIFF
--- a/docs/guide/installation/prod.vuestorefront.io
+++ b/docs/guide/installation/prod.vuestorefront.io
@@ -40,6 +40,7 @@ server {
 		text/javascript
 		application/javascript
 		application/json
+    text/xml
 		text/json;
 
 	location / {

--- a/docs/guide/installation/prod.vuestorefront.io
+++ b/docs/guide/installation/prod.vuestorefront.io
@@ -38,7 +38,6 @@ server {
 	gzip_types
 		text/css
 		text/javascript
-    text/xml
 		application/javascript
 		application/json
     text/xml

--- a/docs/guide/installation/prod.vuestorefront.io
+++ b/docs/guide/installation/prod.vuestorefront.io
@@ -38,6 +38,7 @@ server {
 	gzip_types
 		text/css
 		text/javascript
+    text/xml
 		application/javascript
 		application/json
     text/xml

--- a/docs/guide/installation/prod.vuestorefront.io
+++ b/docs/guide/installation/prod.vuestorefront.io
@@ -38,11 +38,9 @@ server {
 	gzip_types
 		text/css
 		text/javascript
-		text/xml
 		application/javascript
 		application/json
-		text/json
-		text/html;
+		text/json;
 
 	location / {
 		proxy_pass http://localhost:3000/;


### PR DESCRIPTION
Nginx per default compress text/html and I nginx was returning a warning.

### Short description and why it's useful

Per default, Nginx compress text/html gzip_types

https://stackoverflow.com/questions/6475472/duplicate-mime-type-text-html

### Contribution and currently important rules acceptance

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [X] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [X] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
