### PR TITLE
Update recipes.md and add information n how to avoid JWT token invalidation

### DIFF
--- a/docs/guide/basics/recipes.md
+++ b/docs/guide/basics/recipes.md
@@ -267,3 +267,5 @@ Execute the following line on your project's root folder:
 
 The code basically looks into all project files for all ```i18n.t('some string')``` and ```$t('some string') ``` occurrences, parses an extracts the quoted text of each occurrence, and saves it into a pipe-separated CSV file, which you might help you to get your missing translations.
 
+## Syncing magento and vue-storefront-api servers / Fix for "An error occurred validating the nonce"
+There might be an issue with JWT token validation if one of the servers is more than 600 seconds behind the other. The 600 seconds limit is defined on Magento side by its `\Magento\Integration\Model\Oauth\Nonce\Generator::TIME_DEVIATION`. To fix this issue you need to make sure both severs `date` command show the same datetime  (or both at least below 10 minute difference). This can be done by utilizing `tzdata` package (sudo dpkg-reconfigure tzdata) or setting it directly with `date` package (e.g: `sudo date --set "23 Mar 2019 12:00:00"`, but providing the current datetime)


### PR DESCRIPTION
to explain how to sync magento and vue-storefront-api servers  and avoid nonce invalidation due to time difference

### Related issues

none

### Short description and why it's useful

Provided fix allows to sync both hosts and aovid JWT token invalidation due to server time difference.

### Screenshots of visual changes before/after (if there are any)
none

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)
no changes, only docs update

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
