### PR TITLE
Added number of displayed items products on PLP on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit tests in Karma are now removed in favor of jest - @lukeromanowicz (#2305)
 - Material Icons are loaded asynchronously - @JKrupinski, @filrak (#2060)
 - Update to babel 7 - @lukeromanowicz (#2554)
+- Number of displayed products is now visible on PLP on desktop - @awierzbiak (#2504)
 
 ## [1.8.3] - 2019.03.03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 
 ### Changed / Improved
--
+- Number of displayed products is now visible on PLP on desktop - @awierzbiak (#2504)
 
 ## [1.9.0-rc.1] - 2019.03.07
 
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit tests in Karma are now removed in favor of jest - @lukeromanowicz (#2305)
 - Material Icons are loaded asynchronously - @JKrupinski, @filrak (#2060)
 - Update to babel 7 - @lukeromanowicz (#2554)
-- Number of displayed products is now visible on PLP on desktop - @awierzbiak (#2504)
 
 ## [1.8.3] - 2019.03.03
 

--- a/src/themes/default/pages/Category.vue
+++ b/src/themes/default/pages/Category.vue
@@ -31,8 +31,8 @@
           </div>
           <sidebar class="mobile-filters-body" :filters="filters.available"/>
         </div>
-        <p class="col-xs-12 hidden-md m0 px20 cl-secondary">{{ productsTotal }} {{ $t('items') }}</p>
-        <div class="col-md-9 pt20 px10 border-box products-list">
+        <div class="col-md-9 px10 border-box products-list">
+          <p class="col-xs-12 end-md m0 pb20 cl-secondary">{{ productsTotal }} {{ $t('items') }}</p>
           <div v-if="isCategoryEmpty" class="hidden-xs">
             <h4 data-testid="noProductsInfo">{{ $t('No products found!') }}</h4>
             <p>{{ $t('Please change Your search criteria and try again. If still not finding anything relevant, please visit the Home page and try out some of our bestsellers!') }}</p>


### PR DESCRIPTION
### Related issues

closes #2504

### Short description and why it's useful

Displays number of items on PLP on desktop

### Screenshots of visual changes before/after (if there are any)

Before
![before](https://user-images.githubusercontent.com/38215944/54030585-5c495180-41ac-11e9-83fd-ace2971a55a0.png)

After
![after](https://user-images.githubusercontent.com/38215944/54030594-64a18c80-41ac-11e9-9c7f-2c0ff9b3c187.png)

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
