### PR TITLE
Bugfix/offline images

### DIFF
--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -474,12 +474,6 @@ export function configureProductAsync (context, { product, configuration, select
       desiredProductFound = true
     }
 
-    if (typeof navigator !== 'undefined') {
-      if (selectedVariant && !navigator.onLine && context.state.offlineImage) { // this is fix for not preloaded images for offline
-        selectedVariant.image = context.state.offlineImage
-        Logger.debug('Image offline fallback to ', context.state.offlineImage)()
-      }
-    }
     if (selectedVariant) {
       if (!desiredProductFound) { // update the configuration
         populateProductConfigurationAsync(context, { product: product, selectedVariant: selectedVariant })

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -531,6 +531,7 @@ export function getMediaGallery (product) {
               mediaGallery.push({
                 'src': getThumbnailPath(mediaItem.image, rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
                 'loading': getThumbnailPath(mediaItem.image, 310, 300),
+                'error': getThumbnailPath(mediaItem.image, 310, 300),
                 'video': mediaItem.vid
               })
           }
@@ -556,6 +557,7 @@ export function configurableChildrenImages(product) {
                 configurableChildrenImages.push({
                     'src': getThumbnailPath(groupedByAttribute[confChild][0].image, rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
                     'loading': getThumbnailPath(groupedByAttribute[confChild][0].image, 310, 300),
+                    'error': getThumbnailPath(groupedByAttribute[confChild][0].image, 310, 300),
                     'id': confChild
                 })
             }
@@ -577,7 +579,8 @@ export function attributeImages(product) {
             if(product[attribute]) {
                 attributeImages.push({
                     'src': getThumbnailPath(product[attribute], rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
-                    'loading': getThumbnailPath(product[attribute], 310, 300)
+                    'loading': getThumbnailPath(product[attribute], 310, 300),
+                    'error': getThumbnailPath(product[attribute], 310, 300)
                 })
             }
         }

--- a/core/modules/catalog/store/product/actions.ts
+++ b/core/modules/catalog/store/product/actions.ts
@@ -578,10 +578,6 @@ const actions: ActionTree<ProductState, RootState> = {
       // get original product
       const productOriginal = context.getters.productOriginal
 
-      if (!context.state.offlineImage) {
-        context.state.offlineImage = productThumbnailPath(productOriginal ? productOriginal /** in case if it's not yet set */ : productVariant, true)
-        Logger.debug('Image offline fallback set to ' + context.state.offlineImage, 'product')()
-      }
       // check if passed variant is the same as original
       const productUpdated = Object.assign({}, productOriginal, productVariant)
       populateProductConfigurationAsync(context, { product: productUpdated, selectedVariant: productVariant })

--- a/src/themes/default/components/core/ProductGallery.vue
+++ b/src/themes/default/components/core/ProductGallery.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="media-gallery" :class="{'media-gallery--loaded': carouselLoaded}">
-    <div class="relative">
+    <div class="relative w-100">
       <product-gallery-overlay
         v-if="isZoomOpen"
         :current-slide="currentSlide"
@@ -78,6 +78,8 @@ export default {
   text-align: center;
   width: 100%;
   height: 100%;
+  display: flex;
+  align-items: center;
   min-height: calc(90vw * 1.1);
   background-image: url('/assets/placeholder.svg');
   background-repeat: no-repeat;

--- a/src/themes/default/components/core/ProductGalleryCarousel.vue
+++ b/src/themes/default/components/core/ProductGalleryCarousel.vue
@@ -15,9 +15,48 @@
       <slide
         v-for="(images, index) in gallery"
         :key="images.src">
-        <div class="bg-cl-secondary" :class="{'video-container h-100 flex relative': images.video}">
+        <div class="product-image-container bg-cl-secondary" :class="{'video-container w-100 h-100 flex relative': images.video}">
+          <!-- <transition-group name="fade" mode="out-in"> -->
+          <!-- <div class="aaaclass">
+            TEST
+          </div> -->
+          <!-- <transition-group name="fade" mode="out-in"> -->
           <img
-            v-show="hideImageAtIndex !== index"
+            v-show="!lowerQualityLoaded && !highQualityLoaded"
+            key="placeholderImage"
+            class="inline-flex mw-100"
+            src="/assets/placeholder.svg"
+            ref="images"
+            :alt="productName | htmlDecode"
+            @load="placeholderLoaded=true"
+          >
+          <img
+            v-show="lowerQualityLoaded && !highQualityLoaded && hideImageAtIndex !== index"
+            key="lowQualityImage"
+            class="product-image inline-flex mw-100"
+            :src="images.loading"
+            @load="lowerQualityLoaded=true"
+            ref="images"
+            :alt="productName | htmlDecode"
+            data-testid="productGalleryImage"
+            itemprop="image"
+          >
+          <img
+            v-show="highQualityLoaded && hideImageAtIndex !== index"
+            key="highQualityImage"
+            class="product-image inline-flex mw-100"
+            :src="images.src"
+            @load="highQualityLoaded=true"
+            ref="images"
+            @dblclick="openOverlay"
+            :alt="productName | htmlDecode"
+            data-testid="productGalleryImage"
+            itemprop="image"
+          >
+          <!-- </transition-group> -->
+          <!-- </transition-group> -->
+          <!-- <img
+            v-show="placeholderLoaded && hideImageAtIndex !== index"
             class="product-image inline-flex pointer mw-100"
             v-lazy="images"
             ref="images"
@@ -25,7 +64,7 @@
             :alt="productName | htmlDecode"
             data-testid="productGalleryImage"
             itemprop="image"
-          >
+          > -->
           <product-video
             v-if="images.video && (index === currentPage)"
             v-bind="images.video"
@@ -66,7 +105,10 @@ export default {
     return {
       carouselTransitionSpeed: 0,
       currentPage: 0,
-      hideImageAtIndex: null
+      hideImageAtIndex: null,
+      placeholderLoaded: false,
+      lowerQualityLoaded: false,
+      highQualityLoaded: false
     }
   },
   components: {
@@ -130,6 +172,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+// @import "~theme/css/animations/transitions";
+.fade-enter-active {
+  transition: opacity 2s;
+}
+.fade-enter, .fade-leave-to /* .fade-leave-active below version 2.1.8 */ {
+  opacity: 0;
+}
 .media-gallery-carousel {
   position: relative;
   text-align: center;
@@ -139,6 +188,20 @@ export default {
   position: absolute;
   bottom: 0;
   right: 0;
+}
+.product-image-container {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: center;
+  align-items: center;
+  // min-height: 200px;
+  width: 100%;
+}
+.product-image {
+  // height: 100%;
+  width: 100%;
+  height: auto;
 }
 img {
   opacity: 1;

--- a/src/themes/default/components/core/ProductGalleryCarousel.vue
+++ b/src/themes/default/components/core/ProductGalleryCarousel.vue
@@ -37,6 +37,7 @@
           >
           <img
             v-show="highQualityImagesLoadedMap[index]"
+            key="highQualityImage"
             :src="images.src"
             @load="highQualityImageLoaded(index)"
             class="product-image inline-flex pointer mw-100"
@@ -181,13 +182,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-// @import "~theme/css/animations/transitions";
-.fade-enter-active {
-  transition: opacity 2s;
-}
-.fade-enter, .fade-leave-to /* .fade-leave-active below version 2.1.8 */ {
-  opacity: 0;
-}
 .media-gallery-carousel {
   position: relative;
   text-align: center;


### PR DESCRIPTION
### Related issues

closes #2573 

### Short description and why it's useful

Fixes problems with gallery in offline mode:
- problem that when you get back to category page, all images are the same product
- problem that when gallery is loaded, but with no high quality image, then nothing is shown
- problem with styles when displaying placeholder
- problem when only single high quality image is shown, rest of it still can be low quality or placeholder

Overall - there were many edge cases. I've tried to catch all of them, hope this covers it.

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature