### PR TITLE
Bugfix/product gallery carousel select variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 
 
 ### Changed / Improved
--
+- Improved ProductGalleryCarousel component to handle nonnumeric options id’s - @danieldomurad (#2586)
 
 ## [1.9.0-rc.1] - 2019.03.07
 
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit tests in Karma are now removed in favor of jest - @lukeromanowicz (#2305)
 - Material Icons are loaded asynchronously - @JKrupinski, @filrak (#2060)
 - Update to babel 7 - @lukeromanowicz (#2554)
-- Improved ProductGalleryCarousel component to handle nonnumeric options id’s - @danieldomurad
 
 ## [1.8.3] - 2019.03.03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit tests in Karma are now removed in favor of jest - @lukeromanowicz (#2305)
 - Material Icons are loaded asynchronously - @JKrupinski, @filrak (#2060)
 - Update to babel 7 - @lukeromanowicz (#2554)
+- Improved ProductGalleryCarousel component to handle nonnumeric options id’s - @danieldomurad
 
 ## [1.8.3] - 2019.03.03
 

--- a/src/themes/default/components/core/ProductGalleryCarousel.vue
+++ b/src/themes/default/components/core/ProductGalleryCarousel.vue
@@ -106,7 +106,7 @@ export default {
       if (store.state.config.products.gallery.mergeConfigurableChildren) {
         let option = this.configuration[store.state.config.products.gallery.variantsGroupAttribute]
         if (typeof option !== 'undefined' && option !== null) {
-          let index = this.gallery.findIndex(obj => obj.id && Number(obj.id) === Number(option.id))
+          let index = this.gallery.findIndex(obj => obj.id && String(obj.id) === String(option.id))
           this.navigate(index)
         }
       }


### PR DESCRIPTION
### Short description and why it's useful
This is a simple fix to a problem with ProductGalleryCarousel. When attribute options values (attribute.options.value) have a text value, the carousel does not work properly. 

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
