### PR TITLE
Feature/ clicking on product name navigates to product and closes sidebar.

### DIFF
--- a/src/themes/default/components/core/blocks/Microcart/Microcart.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Microcart.vue
@@ -38,7 +38,7 @@
       {{ $t('to find something beautiful for You!') }}
     </div>
     <ul v-if="productsInCart.length" class="bg-cl-primary m0 px40 pb40 products">
-      <product v-for="product in productsInCart" :key="product.sku" :product="product" @product-navigate="closeMicrocartExtend" />
+      <product v-for="product in productsInCart" :key="product.sku" :product="product" />
     </ul>
     <div v-if="productsInCart.length" class="summary px40 cl-accent serif">
       <h3 class="m0 pt40 mb30 weight-400 summary-heading">

--- a/src/themes/default/components/core/blocks/Microcart/Microcart.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Microcart.vue
@@ -38,7 +38,7 @@
       {{ $t('to find something beautiful for You!') }}
     </div>
     <ul v-if="productsInCart.length" class="bg-cl-primary m0 px40 pb40 products">
-      <product v-for="product in productsInCart" :key="product.sku" :product="product" />
+      <product v-for="product in productsInCart" :key="product.sku" :product="product" @product-navigate="closeMicrocartExtend" />
     </ul>
     <div v-if="productsInCart.length" class="summary px40 cl-accent serif">
       <h3 class="m0 pt40 mb30 weight-400 summary-heading">

--- a/src/themes/default/components/core/blocks/Microcart/Product.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Product.vue
@@ -7,9 +7,21 @@
     </div>
     <div class="col-xs flex pl35 py15 start-xs between-sm details">
       <div>
-        <div class="serif h4 name">
+        <router-link
+          class="serif h4 name"
+          :to="localizedRoute({
+            name: product.type_id + '-product',
+            params: {
+              parentSku: product.parentSku ? product.parentSku : product.sku,
+              slug: product.slug,
+              childSku: product.sku
+            }
+          })"
+          data-testid="productLink"
+          @click.native="$emit('product-navigate')"
+        >
           {{ product.name | htmlDecode }}
-        </div>
+        </router-link>
         <div class="h6 cl-bg-tertiary pt5 sku" data-testid="productSku">
           {{ product.sku }}
         </div>

--- a/src/themes/default/components/core/blocks/Microcart/Product.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Product.vue
@@ -18,7 +18,7 @@
             }
           })"
           data-testid="productLink"
-          @click.native="$emit('product-navigate')"
+          @click.native="$store.commit('ui/setMicrocart', false)"
         >
           {{ product.name | htmlDecode }}
         </router-link>


### PR DESCRIPTION
### Related issues

closes (https://github.com/DivanteLtd/vue-storefront/issues/2588)

### Short description and why it's useful

Previously you were not able to click on a product name to visit a product you had already added to your cart. This made it difficult to make changes to a product as you would have to manually find it.

### Screenshots of visual changes before/after (if there are any)

![](https://media.giphy.com/media/xW5mY1P12UOBhCYkoj/giphy.gif)

### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

(run `yarn test:e2e` and paste the results. If you are not using our standard backend setup or demo.vuestorefront.io you can ommit this step) 

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [X] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [X] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
