### PR TITLE
image selection supporting multiple configurable options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for the newest node version - @gdomiciano (#2669)
 - Default storeId from `0` to `1` for multistore and cmsdata logic - @janmyszkier (#2590)
 - Used `$bus` plugin instead of EventBus import - @szafran89 (#2630)
+- Image selection supporting multiple configurable options - @mdesmet (#2599)
 
 ## [1.9.0-rc.2] - UNRELEASED
 

--- a/config/default.json
+++ b/config/default.json
@@ -277,7 +277,6 @@
         "Price: High to low":"final_price:desc"
       },
       "gallery": {
-        "variantsGroupAttribute": "color",
         "mergeConfigurableChildren": true,
         "imageAttributes": ["image","thumbnail","small_image"],
         "width": 600,

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -4,10 +4,7 @@ import { calculateProductTax } from '../helpers/tax'
 import flattenDeep from 'lodash-es/flattenDeep'
 import omit from 'lodash-es/omit'
 import remove from 'lodash-es/remove'
-import reduce from 'lodash-es/reduce'
-import map from 'lodash-es/map'
 import toString from 'lodash-es/toString'
-import forEach from 'lodash-es/forEach'
 import union from 'lodash-es/union'
 // TODO: Remove this dependency
 import { optionLabel } from './optionLabel'
@@ -555,9 +552,9 @@ export function getMediaGallery (product) {
 export function configurableChildrenImages(product) {
   let configurableChildrenImages = []
   if (product.configurable_children && product.configurable_children.length > 0) {
-    let configurableAttributes = map(product.configurable_options, 'attribute_code')
-    forEach(product.configurable_children, child => {
-      let id = reduce(configurableAttributes, (result, attribute) => {
+    let configurableAttributes = product.configurable_options.map(option => option.attribute_code)
+    product.configurable_children.forEach(child => {
+      let id = configurableAttributes.reduce((result, attribute) => {
         result[attribute] = child[attribute]
         return result
       }, {})

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -549,18 +549,16 @@ export function configurableChildrenImages(product) {
   let configurableChildrenImages = []
   if (product.configurable_children && product.configurable_children.length > 0) {
     let configurableAttributes = product.configurable_options.map(option => option.attribute_code)
-    product.configurable_children.forEach(child => {
-      let id = configurableAttributes.reduce((result, attribute) => {
-        result[attribute] = child[attribute]
-        return result
-      }, {})
-      configurableChildrenImages.push({
-        'src': getThumbnailPath(product.image, rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
+    configurableChildrenImages = product.configurable_children.map(child =>
+      ({
+        'src': getThumbnailPath(child.image, rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
         'loading': getThumbnailPath(product.image, 310, 300),
-        'error': getThumbnailPath(product.image, 310, 300),
-        'id': id
+        'id': configurableAttributes.reduce((result, attribute) => {
+          result[attribute] = child[attribute]
+          return result
+        }, {})
       })
-    })
+    )
   } else {
     configurableChildrenImages = attributeImages(product)
   }

--- a/src/themes/default/components/core/ProductGalleryCarousel.vue
+++ b/src/themes/default/components/core/ProductGalleryCarousel.vue
@@ -45,6 +45,9 @@
 import store from '@vue-storefront/core/store'
 import { Carousel, Slide } from 'vue-carousel'
 import ProductVideo from './ProductVideo'
+import reduce from 'lodash-es/reduce'
+import map from 'lodash-es/map'
+import isEqual from 'lodash-es/isEqual'
 
 export default {
   name: 'ProductGalleryCarousel',
@@ -104,9 +107,12 @@ export default {
     },
     selectVariant () {
       if (store.state.config.products.gallery.mergeConfigurableChildren) {
-        let option = this.configuration[store.state.config.products.gallery.variantsGroupAttribute]
-        if (typeof option !== 'undefined' && option !== null) {
-          let index = this.gallery.findIndex(obj => obj.id && Number(obj.id) === Number(option.id))
+        let option = reduce(map(this.configuration, 'attribute_code'), (result, attribute) => {
+          result[attribute] = this.configuration[attribute].id
+          return result
+        }, {})
+        if (option) {
+          let index = this.gallery.findIndex(obj => obj.id && isEqual(obj.id, option))
           this.navigate(index)
         }
       }

--- a/src/themes/default/components/core/ProductGalleryCarousel.vue
+++ b/src/themes/default/components/core/ProductGalleryCarousel.vue
@@ -45,9 +45,6 @@
 import store from '@vue-storefront/core/store'
 import { Carousel, Slide } from 'vue-carousel'
 import ProductVideo from './ProductVideo'
-import reduce from 'lodash-es/reduce'
-import map from 'lodash-es/map'
-import isEqual from 'lodash-es/isEqual'
 
 export default {
   name: 'ProductGalleryCarousel',
@@ -107,12 +104,14 @@ export default {
     },
     selectVariant () {
       if (store.state.config.products.gallery.mergeConfigurableChildren) {
-        let option = reduce(map(this.configuration, 'attribute_code'), (result, attribute) => {
+        let configurableAttributes = this.configuration.map(option => option.attribute_code)
+        let option = configurableAttributes.reduce((result, attribute) => {
           result[attribute] = this.configuration[attribute].id
           return result
         }, {})
         if (option) {
-          let index = this.gallery.findIndex(obj => obj.id && isEqual(obj.id, option))
+          let index = this.gallery.findIndex(
+            obj => obj.id && Object.entries(obj.id).toSTring() === Object.entries(option).toString(), option)
           this.navigate(index)
         }
       }


### PR DESCRIPTION
### Related issues

No issue

### Short description and why it's useful

If you have a shop with configurable children products having multiple configurable options that look totally different (each having different thumbnail), this code change enables showing the right product for each

### Screenshots of visual changes before/after (if there are any)



### Screenshot of passed e2e tests (if you are using our standard setup as a backend)

feature not present in demo shop

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
