### PR TITLE
core category page - fixed lint issue trailing spaces not allowed

### DIFF
--- a/core/pages/Category.js
+++ b/core/pages/Category.js
@@ -87,7 +87,7 @@ export default {
       const defaultFilters = store.state.config.products.defaultFilters
       store.dispatch('category/resetFilters')
       EventBus.$emit('filter-reset')
-      
+
       await store.dispatch('category/list', { level: store.state.config.entities.category.categoriesDynamicPrefetch && store.state.config.entities.category.categoriesDynamicPrefetchLevel ? store.state.config.entities.category.categoriesDynamicPrefetchLevel : null, includeFields: store.state.config.entities.optimize && Vue.prototype.$isServer ? store.state.config.entities.category.includeFields : null })
       await store.dispatch('attribute/list', { // load filter attributes for this specific category
         filterValues: defaultFilters, // TODO: assign specific filters/ attribute codes dynamicaly to specific categories


### PR DESCRIPTION
There was lint issue `Trailing spaces not allowed` once I run `yarn dev`