### PR TITLE
#2610 - 'Product added to cart' popup appears only once per product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.10.0-rc.1] - UNRELEASED
 
 ### Added
-- 
+-
 
 ### Fixed
-- 
+- Confirmation popup 'Product has beed added to cart' is displayed only once - @JKrupinski (#2610)
 
 ### Changed / Improved
 - Improved ProductGalleryCarousel component to handle nonnumeric options id’s - @danieldomurad (#2586)

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -704,21 +704,18 @@ const actions: ActionTree<CartState, RootState> = {
         rootStore.commit('cart/' + types.CART_DEL_NON_CONFIRMED_ITEM, { product: originalCartItem }, {root: true})
       }
     } else {
-      const isThisNewItemAddedToTheCart = (!originalCartItem || !originalCartItem.item_id)
-      if (isThisNewItemAddedToTheCart) {
-        let notificationData = {
-          type: 'success',
-          message: i18n.t('Product has been added to the cart!'),
-          action1: { label: i18n.t('OK') },
-          action2: null
-        }
-        if (!config.externalCheckout) { // if there is externalCheckout enabled we don't offer action to go to checkout as it can generate cart desync
-          notificationData.action2 = { label: i18n.t('Proceed to checkout'), action: () => {
-            context.dispatch('goToCheckout')
-          }}
-        }
-        rootStore.dispatch('notification/spawnNotification', notificationData)
+      let notificationData = {
+        type: 'success',
+        message: i18n.t('Product has been added to the cart!'),
+        action1: { label: i18n.t('OK') },
+        action2: null
       }
+      if (!config.externalCheckout) { // if there is externalCheckout enabled we don't offer action to go to checkout as it can generate cart desync
+        notificationData.action2 = { label: i18n.t('Proceed to checkout'), action: () => {
+          context.dispatch('goToCheckout')
+        }}
+      }
+      rootStore.dispatch('notification/spawnNotification', notificationData)
     }
   },
   toggleMicrocart ({ commit }) {


### PR DESCRIPTION
### Related issues

#2610

### Short description and why it's useful

I've removed isThisNewItemAddedToTheCart variable because notification is displayed only once for the same product. Now notification should appear everytime when new notification message is different than last message (this is checked in spawnNotification action)

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
