### PR TITLE
#2605 - Remove childSku parameter in url for non-configurable products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0-rc.2] - UNRELEASED
+
+### Fixed
+- Removed childSku parameter in url for non-configurable products when using urlDispatcher - @Aekal (#2605)
+
 ## [1.9.0-rc.1] - 2019.03.07
 
 ### Added

--- a/core/modules/url/helpers/index.ts
+++ b/core/modules/url/helpers/index.ts
@@ -50,20 +50,33 @@ export function normalizeUrlPath(url: string): string {
     const queryPos = url.indexOf('?')
     if (queryPos > 0) url = url.slice(0, queryPos)
   }
-  return url  
+  return url
 }
 
 export function formatCategoryLink(category: { url_path: string, slug: string }): string {
-  return rootStore.state.config.seo.useUrlDispatcher ? ('/' + category.url_path) : ((rootStore.state.config.products.useShortCatalogUrls ? '/' : '/c/') + category.slug)  
+  return rootStore.state.config.seo.useUrlDispatcher ? ('/' + category.url_path) : ((rootStore.state.config.products.useShortCatalogUrls ? '/' : '/c/') + category.slug)
 }
 
-export function formatProductLink(product: { parentSku?: string, sku: string, url_path?: string, type_id: string , slug: string}, storeCode): string | LocalizedRoute {
-  if(rootStore.state.config.seo.useUrlDispatcher && product.url_path) {
-    const routeData: LocalizedRoute = {
-      fullPath: product.url_path,
-      params: {
-        childSku: product.sku === product.parentSku ? null : product.sku
+export function formatProductLink(
+  product: {
+    parentSku?: string,
+    sku: string,
+    url_path?: string,
+    type_id: string,
+    slug: string,
+    configurable_children: []
+  },
+  storeCode
+): string | LocalizedRoute {
+  if (rootStore.state.config.seo.useUrlDispatcher && product.url_path) {
+    let routeData: LocalizedRoute;
+    if (product.configurable_children && product.configurable_children.length > 0) {
+      routeData = {
+        fullPath: product.url_path,
+        params: { childSku: product.sku }
       }
+    } else {
+      routeData = { fullPath: product.url_path }
     }
     return localizedDispatcherRoute(routeData, storeCode)
   } else {

--- a/src/themes/default/router/index.js
+++ b/src/themes/default/router/index.js
@@ -44,7 +44,8 @@ let routes = [
   { name: 'cms-page-sync', path: '/cms-page-sync', component: CmsData, props: {identifier: 'about-us', type: 'Page', sync: true} }
 ]
 if (!config.products.useShortCatalogUrls) {
-  routes = routes.concat([{ name: 'virtual-product', path: '/p/:parentSku/:slug', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
+  routes = routes.concat([
+    { name: 'virtual-product', path: '/p/:parentSku/:slug', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
     { name: 'bundle-product', path: '/p/:parentSku/:slug', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
     { name: 'simple-product', path: '/p/:parentSku/:slug', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
     { name: 'downloadable-product', path: '/p/:parentSku/:slug', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
@@ -52,9 +53,11 @@ if (!config.products.useShortCatalogUrls) {
     { name: 'configurable-product', path: '/p/:parentSku/:slug/:childSku', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
     { name: 'product', path: '/p/:parentSku/:slug/:childSku', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
     { name: 'category', path: '/c/:slug', component: Category },
-    { name: 'cms-page', path: '/i/:slug', component: CmsPage }])
+    { name: 'cms-page', path: '/i/:slug', component: CmsPage }
+  ])
 } else {
-  routes = routes.concat([{ name: 'virtual-product', path: '/:parentSku/:slug', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
+  routes = routes.concat([
+    { name: 'virtual-product', path: '/:parentSku/:slug', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
     { name: 'bundle-product', path: '/:parentSku/:slug', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
     { name: 'simple-product', path: '/:parentSku/:slug', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
     { name: 'downloadable-product', path: '/:parentSku/:slug', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
@@ -62,7 +65,8 @@ if (!config.products.useShortCatalogUrls) {
     { name: 'configurable-product', path: '/:parentSku/:slug/:childSku', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
     { name: 'product', path: '/:parentSku/:slug/:childSku', component: Product }, // :sku param can be marked as optional with ":sku?" (https://github.com/vuejs/vue-router/blob/dev/examples/route-matching/app.js#L16), but it requires a lot of work to adjust the rest of the site
     { name: 'cms-page', path: '/i/:slug', component: CmsPage },
-    { name: 'category', path: '/:slug', component: Category }])
+    { name: 'category', path: '/:slug', component: Category }
+  ])
 }
 
 export default routes


### PR DESCRIPTION
### Related issues

#2605 

### Short description and why it's useful

Removed childSku parameter in url for non-configurable products when using urlDispatcher

Before:
`/gear/gear-3/luma-analog-watch-41.html?childSku`

After:
`/gear/gear-3/luma-analog-watch-41.html`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
