### PR TITLE
Fixed cart sync anomaly

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ If you're new and need some guidance feel free to visit out [forum](https://foru
 - `@pkarw` (integrations and backend related stuff)
 - `@ptomczyk` (frontend related stuff)
 - `@Bartek Igielski`(frontend and magento-specific related stuff)
-- `@George` (mostly backend and integration related stuff but can also help with frontend)
 
 Want to invest some time in building the future of eCommerce? we are looking for core team members willing to help us make VS even more awesome. Interested - contact `@Filip Rakowski` on slack
 

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -661,7 +661,7 @@ const actions: ActionTree<CartState, RootState> = {
         }
       }
       Vue.prototype.$bus.$emit('servercart-after-diff', { diffLog: diffLog, serverItems: serverItems, clientItems: clientItems, dryRun: event.dry_run, event: event }) // send the difflog
-        Logger.info('Client/Server cart synchronised ', 'cart', diffLog)()
+      Logger.info('Client/Server cart synchronised ', 'cart', diffLog)()
     } else {
       Logger.error(event.result, 'cart') // override with guest cart()
       if (rootStore.state.cart.bypassCount < MAX_BYPASS_COUNT) {


### PR DESCRIPTION
### Related issues

https://github.com/DivanteLtd/vue-storefront/issues/2639

### Short description and why it's useful

Added a delay between cart sync with server to reduce the possibility of a product being created multiple times with multiple item ids on the server when the add to cart button is clicked multiple times within a short interval. 

The delay is to allow for sufficient time for the first request to create the product on the cart on the server to complete and return with an item_id so that the next request that is sent to the server contains this item_id, causing an update to the quantity of the product in cart rather than creating the product as a new item in cart.

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
