### PR TITLE
Retrieve video id from video_id property -> changes required for mage…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Used `$bus` plugin instead of EventBus import - @szafran89 (#2630)
 - BaseCheckbox now uses v-model. @click is not needed anymore - @haukebri (#2630)
 - Image selection supporting multiple configurable options - @mdesmet (#2599)
+- Product video - retrieve video id from 'video_id' field (if set) instead of 'id' - @afirlejczyk
 
 ## [1.9.0-rc.2] - UNRELEASED
 

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -526,16 +526,23 @@ export function configureProductAsync (context, { product, configuration, select
 export function getMediaGallery (product) {
   let mediaGallery = []
   if (product.media_gallery) {
-      for (let mediaItem of product.media_gallery) {
-          if (mediaItem.image) {
-              mediaGallery.push({
-                'src': getThumbnailPath(mediaItem.image, rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
-                'loading': getThumbnailPath(mediaItem.image, 310, 300),
-                'error': getThumbnailPath(mediaItem.image, 310, 300),
-                'video': mediaItem.vid
-              })
-          }
+    for (let mediaItem of product.media_gallery) {
+      if (mediaItem.image) {
+        let video = mediaItem.vid
+
+        if (video && video.video_id) {
+          video.id = video.video_id
+          delete video.video_id
+        }
+
+        mediaGallery.push({
+          'src': getThumbnailPath(mediaItem.image, rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
+          'loading': getThumbnailPath(mediaItem.image, 310, 300),
+          'error': getThumbnailPath(mediaItem.image, 310, 300),
+          'video': video
+        })
       }
+    }
   }
   return mediaGallery
 }


### PR DESCRIPTION
I need to make a small adjustment to support video export in magento2-vsbridge-indexer
https://github.com/DivanteLtd/magento2-vsbridge-indexer/pull/36

`id` field is mapped by default as a number (in ES), but for youtube video, we have a text.
We shouldn't mix mapping for the same field in ES 5.x.
It is better to set video ID to a new field e.g: 'video_id'.
I also make a change in mage2vsf
https://github.com/DivanteLtd/mage2vuestorefront/pull/82/files