### PR TITLE
Update/Fix URL's in FAQ and Recipes

### DIFF
--- a/docs/guide/basics/recipes.md
+++ b/docs/guide/basics/recipes.md
@@ -53,7 +53,7 @@ In a case of
 ```
 
 See the discussion in [#137](https://github.com/DivanteLtd/vue-storefront/issues/137).
-Please also check the [Database tool](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/Database%20tool.md)
+Please also check the [Database tool](https://github.com/DivanteLtd/vue-storefront/blob/master/docs/guide/data/database-tool.md)
 
 ## What's the recommended way to use git on custom development
 
@@ -195,7 +195,7 @@ Yes, I believe it could. You should expose the API accordingly to our [spec](../
 
 ## Is there any documentation on integrating payment gateways?
 
-We're working on kind of boilerplate for payment modules. Right now please just take a look at a [live example](https://github.com/develodesign/vue-storefront-stripe) and try to follow the design patterns from there. The task where boilerplate + docs will show up is [https://github.com/DivanteLtd/vue-storefront/issues/923](https://github.com/DivanteLtd/vue-storefront/issues/923).
+We're working on kind of boilerplate for payment modules. Right now please just take a look at a [live example](https://github.com/develodesign/vsf-payment-stripe) and try to follow the design patterns from there. The task where boilerplate + docs will show up is [https://github.com/DivanteLtd/vue-storefront/issues/923](https://github.com/DivanteLtd/vue-storefront/issues/923).
 
 ## Is there any internationalization support?
 


### PR DESCRIPTION
### Related issues
No related issues.

### Short description and why it's useful
Noticed the dead links when reading the FAQ

### Screenshots of visual changes before/after (if there are any)
--

### Which environment this relates to

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
