### PR TITLE
StoreId other than 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Product video - retrieve video id from 'video_id' field (if set) instead of 'id' - @afirlejczyk
 - Fixed static file handler to immediately return 404 status for missing files - @grimason (#2685)
 - Fixed maxAge Response Header for static files and Content-Type for Service Worker - @grimason (#2686)
+- The default storeId is taken from the configurations - @nuovecode (#2718)
 
 ## [1.9.0] - UNRELEASED
 
 ### Fixed
 - 
-
-### Changed / Improved
-- The default storeId is taken from the configurations - @nuovecode (#2718)
 
 ## [1.9.0-rc.2] - 2019.04.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - 
 
+### Changed / Improved
+- The default storeId is taken from the configurations - @nuovecode (#2718)
+
 ## [1.9.0-rc.2] - 2019.04.10
 
 ### Fixed

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -54,7 +54,7 @@ export function prepareStoreView (storeCode: string) : StoreView {
     i18n: config.i18n,
     elasticsearch: config.elasticsearch,
     storeCode: '',
-    storeId: 1
+    storeId: config.defaultStoreCode && config.defaultStoreCode !== '' ? config.storeViews[config.defaultStoreCode].storeId : 1
   }
   const storeViewHasChanged = !rootStore.state.storeView || rootStore.state.storeView.storeCode !== storeCode
   if (storeCode) { // current store code


### PR DESCRIPTION
### Related issues
Related to https://github.com/DivanteLtd/vue-storefront/commit/5032eb9cb64ce0f4c38d37a752d68513867d14c2#diff-53eb0dcbb2c62c8af0204c3f9aaf84fc

### Short description and why it's useful
It's just a proposal. I'm working on a store where 1 is not the default store. I think it might be a good idea to take the store id from the config rather than hard-coded it. I'm not sure this is the best solution what do you think of?

### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
