### PR TITLE
#2726 - Respect store code on order/PROCESS_QUEUE for shop store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Confirmation popup 'Product has beed added to cart' is displayed only once - @JKrupinski (#2610)
 - Moved My Account options from Categories - @bartdominiak (#2612)
 - Image switching fix - @pkarw (#2709)
+- Respect store code on order/PROCESS_QUEUE for shop store - @zulcom (#2727)
 
 ### Changed / Improved
 - Improved ProductGalleryCarousel component to handle nonnumeric options id’s - @danieldomurad (#2586)

--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -128,7 +128,7 @@ const invokeClientEntry = async () => {
       const dbNamePrefix = storeView.storeCode ? storeView.storeCode + '-' : ''
 
       const ordersCollection = new UniversalStorage(localForage.createInstance({
-        name: 'shop',
+        name: dbNamePrefix + 'shop',
         storeName: 'orders',
         driver: localForage[config.localForage.defaultDrivers['orders']]
       }))


### PR DESCRIPTION
### Related issues
#2726

Closes to #2726

### Short description and why it's useful
It fixes #2726 so store code applies to shop store.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
