### PR TITLE
correct magento order id in my orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - ESlint throwing errors about undefined jest globals in tests - @lukeromanowicz (#2702)
 - Fixed changing the country when entering shipping address in checkout not updating shipping costs - @revlis-x (#2691)
+- Correct magento order id in my orders - @mdesmet (#2763)
 
 ## [1.9.0-rc.2] - 2019.04.10
 

--- a/src/themes/default/components/core/blocks/MyAccount/MyOrders.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyOrders.vue
@@ -25,7 +25,7 @@
           </thead>
           <tbody>
             <tr class="brdr-top-1 brdr-cl-bg-secondary" v-for="order in ordersHistory" :key="order.entity_id">
-              <td class="fs-medium lh25">{{ order.entity_id }}</td>
+              <td class="fs-medium lh25">#{{ order.increment_id }}</td>
               <td class="fs-medium lh25 hide-on-xs">{{ order.created_at | date }}</td>
               <td class="fs-medium lh25 hide-on-xs">{{ order.customer_firstname }} {{ order.customer_lastname }}</td>
               <td class="fs-medium lh25 hide-on-xs">{{ order.grand_total | price }}</td>


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #2743

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Solving this issue is just a simple replacement, however there is more to this issue: The thankyou page also mentions the internal order id. This id is not returned by order api. It seems that we would have to retrieve the order and fetch the order_increment_id for the given internal id.

We would also need to:

- extend the magento 2 rest api client with support to retrieve a single order
- adapt the o2m.js module to fetch the increment id and return it


### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
