### PR TITLE
[BUGFIX] Move 'Clear cart' button to the upper part of the window

### DIFF
--- a/src/themes/default/components/core/blocks/Microcart/ClearCartButton.vue
+++ b/src/themes/default/components/core/blocks/Microcart/ClearCartButton.vue
@@ -4,7 +4,7 @@
       <i class="material-icons cl-accent mr5">
         cancel
       </i>
-      Clear cart
+      {{ $t('Clear cart') }}
     </span>
   </button>
 </template>

--- a/src/themes/default/components/core/blocks/Microcart/ClearCartButton.vue
+++ b/src/themes/default/components/core/blocks/Microcart/ClearCartButton.vue
@@ -1,0 +1,19 @@
+<template>
+  <button class="brdr-none bg-cl-transparent p0 middle-xs inline-flex cl-secondary weight-400 h4 sans-serif fs-medium">
+    <span class="clearcart-btn cl-accent">
+      <i class="material-icons cl-accent mr5">
+        cancel
+      </i>
+      Clear cart
+    </span>
+  </button>
+</template>
+
+<style lang="scss" scoped>
+  .clearcart {
+    &-btn {
+      display: flex;
+      align-items: center;
+    }
+  }
+</style>

--- a/src/themes/default/components/core/blocks/Microcart/Microcart.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Microcart.vue
@@ -4,26 +4,36 @@
     :class="[productsInCart.length ? 'bg-cl-secondary' : 'bg-cl-primary']"
     data-testid="microcart"
   >
-    <div class="row middle-xs bg-cl-primary top-sm">
-      <div class="col-xs-10">
-        <h2
-          v-if="productsInCart.length"
-          class="cl-accent mt60 mb35 ml40 heading"
-        >
-          {{ $t('Shopping cart') }}
-        </h2>
-      </div>
-      <div class="col-xs-2 end-xs">
+    <div class="row bg-cl-primary px40 actions">
+      <div class="col-xs end-xs">
         <button
           type="button"
           class="p0 brdr-none bg-cl-transparent close"
           @click="closeMicrocartExtend"
           data-testid="closeMicrocart"
         >
-          <i class="material-icons p15 cl-accent">
+          <i class="material-icons py20 cl-accent">
             close
           </i>
         </button>
+      </div>
+    </div>
+    <div class="row middle-xs bg-cl-primary top-sm px40 actions">
+      <div class="col-xs-12 col-sm">
+        <h2
+          v-if="productsInCart.length"
+          class="cl-accent mt35 mb35"
+        >
+          {{ $t('Shopping cart') }}
+        </h2>
+      </div>
+      <div class="col-xs-12 col-sm mt35 mb35 mt0">
+        <button-full
+          v-if="productsInCart.length"
+          @click.native="clearCart"
+        >
+          Clear cart
+        </button-full>
       </div>
     </div>
 
@@ -105,11 +115,6 @@
           {{ $t('Go to checkout') }}
         </button-full>
         <instant-checkout v-if="isInstantCheckoutRegistered" class="no-outline button-full block brdr-none w-100 px10 py20 bg-cl-mine-shaft :bg-cl-th-secondary ripple weight-400 h4 cl-white sans-serif fs-medium mt20" />
-        <button-full
-          @click.native="clearCart"
-        >
-          Clear cart
-        </button-full>
       </div>
     </div>
   </div>
@@ -222,13 +227,11 @@ export default {
     }
   }
 
-  .heading {
+  .mt0 {
     @media (max-width: 767px) {
-      margin: 12px 0 12px 15px;
-      font-size: 24px;
+      margin-top: 0;
     }
   }
-
   .products {
     @media (max-width: 767px) {
       padding: 30px 15px;

--- a/src/themes/default/components/core/blocks/Microcart/Microcart.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Microcart.vue
@@ -27,13 +27,11 @@
           {{ $t('Shopping cart') }}
         </h2>
       </div>
-      <div class="col-xs-12 col-sm mt35 mb35 mt0">
-        <button-full
+      <div class="col-xs-12 col-sm mt35 mb35 mt0 end-sm clearcart-col">
+        <clear-cart-button
           v-if="productsInCart.length"
           @click.native="clearCart"
-        >
-          Clear cart
-        </button-full>
+        />
       </div>
     </div>
 
@@ -130,6 +128,7 @@ import onEscapePress from '@vue-storefront/core/mixins/onEscapePress'
 import InstantCheckout from 'src/modules/instant-checkout/components/InstantCheckout.vue'
 
 import BaseInput from 'theme/components/core/blocks/Form/BaseInput'
+import ClearCartButton from 'theme/components/core/blocks/Microcart/ClearCartButton'
 import ButtonFull from 'theme/components/theme/ButtonFull'
 import ButtonOutline from 'theme/components/theme/ButtonOutline'
 import Product from 'theme/components/core/blocks/Microcart/Product'
@@ -137,6 +136,7 @@ import Product from 'theme/components/core/blocks/Microcart/Product'
 export default {
   components: {
     Product,
+    ClearCartButton,
     ButtonFull,
     ButtonOutline,
     BaseInput,
@@ -232,6 +232,14 @@ export default {
       margin-top: 0;
     }
   }
+
+  .clearcart {
+    &-col {
+      display: flex;
+      align-self: center;
+    }
+  }
+
   .products {
     @media (max-width: 767px) {
       padding: 30px 15px;

--- a/src/themes/default/resource/i18n/en-US.csv
+++ b/src/themes/default/resource/i18n/en-US.csv
@@ -84,6 +84,7 @@
 "You are logged in as","You are logged in as"
 "Edit","Edit"
 "Shopping cart","Shopping cart"
+"Clear cart","Clear cart"
 "Your shopping cart is empty.","Your shopping cart is empty."
 "Don't hesitate and","Don't hesitate and"
 "browse our catalog","browse our catalog"


### PR DESCRIPTION
### Related issues
#2697

### Short description and why it's useful
Move "clear cart" button to the top of the cart. Additionaly, I've added conditional to clear cart button because it was displaying when there was no products in the cart.

### Screenshots of visual changes before/after (if there are any)
<img alt="before" src="https://user-images.githubusercontent.com/23217487/56528893-32779e80-6550-11e9-934d-3b9c638fe90a.png">
<img alt="after" src="https://user-images.githubusercontent.com/23217487/56528885-2f7cae00-6550-11e9-9829-6007fec81860.png">


### Which environment this relates to

Test version (bugfix to new feature).