### PR TITLE
Issue/add custom options to standard system fields

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -177,6 +177,7 @@
           "description",
           "configurable_options",
           "tsk",
+          "custom_options",
           "custom_attributes",
           "size_options",
           "regular_price",


### PR DESCRIPTION
Custom Options are not visible on product page by default.
I add `custom_options` to standardSystemFields and options will be now visible on product page.
![screenshot-localhost-3011-2019 04 23-12-18-09](https://user-images.githubusercontent.com/4245592/56573755-10b6ff80-65c2-11e9-8f9e-bb0b54396fe6.png)
