### PR TITLE
Bugfix/elasticsearch multistore addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - validation for UTF8 alpha and alphanumeric characters in most checkout fields - @lromanowicz (#2653)
+- helper to process config urls with default endpoint host `config.api.host` - @patzick (#2858)
 
 ### Fixed
 - ESlint throwing errors about undefined jest globals in tests - @lukeromanowicz (#2702)

--- a/config/default.json
+++ b/config/default.json
@@ -32,9 +32,12 @@
       "host": "localhost",
       "port": 8080
     },
+    "api": {
+      "url": "http://localhost:8080"
+    },
     "elasticsearch": {
       "httpAuth": "",
-      "host": "localhost:8080/api/catalog",
+      "host": "/api/catalog",
       "index": "vue_storefront_catalog",
       "min_score": 0.02,
       "csrTimeout": 5000,
@@ -92,7 +95,7 @@
         "name": "German Store",
         "url": "/de",
         "elasticsearch": {
-          "host": "localhost:8080/api/catalog",
+          "host": "/api/catalog",
           "index": "vue_storefront_catalog_de"
         },
         "tax": {
@@ -119,7 +122,7 @@
         "name": "Italian Store",
         "url": "/it",
         "elasticsearch": {
-          "host": "localhost:8080/api/catalog",
+          "host": "/api/catalog",
           "index": "vue_storefront_catalog_it"
         },
         "tax": {

--- a/core/helpers/index.ts
+++ b/core/helpers/index.ts
@@ -4,6 +4,7 @@ import { remove as removeAccents } from 'remove-accents'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import { formatCategoryLink } from '@vue-storefront/core/modules/url/helpers'
 import Vue from 'vue'
+import config from 'config'
 
 /**
  * Create slugify -> "create-slugify" permalink  of text
@@ -167,3 +168,8 @@ export const onlineHelper = Vue.observable({
 })
 !isServer && window.addEventListener('online',  () => onlineHelper.isOnline = true)
 !isServer && window.addEventListener('offline', () => onlineHelper.isOnline = false)
+
+export const processURLAddress = (url:string = '') => {
+  if (url.startsWith('/')) return `${config.api.url}${url}`
+  return url
+}

--- a/core/lib/search/adapter/api/searchAdapter.ts
+++ b/core/lib/search/adapter/api/searchAdapter.ts
@@ -2,7 +2,7 @@ import map from 'lodash-es/map'
 import rootStore from '@vue-storefront/core/store'
 import { prepareElasticsearchQueryBody } from './elasticsearchQuery'
 import fetch from 'isomorphic-fetch'
-import { slugify } from '@vue-storefront/core/helpers'
+import { slugify, processURLAddress } from '@vue-storefront/core/helpers'
 import queryString from 'query-string'
 import { currentStoreView, prepareStoreView } from '../../../multistore'
 import SearchQuery from '@vue-storefront/core/lib/search/searchQuery'
@@ -42,10 +42,7 @@ export class SearchAdapter {
 
     Request.index = storeView.elasticsearch.index
 
-    let url = storeView.elasticsearch.host
-    if (!url.startsWith('http')) {
-      url = 'http://' + url
-    }
+    let url = processURLAddress(storeView.elasticsearch.host)
 
     if (this.entities[Request.type].url) {
       url = this.entities[Request.type].url


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#2713

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Related to #2713, on next there is no products on homePage when other language is on. Added api url to default config and helper to process API urls.
Also in local env i can refresh both `/de/my-account` and `/my-account` without redirection to homepage.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change