### PR TITLE
Fix javascript polyfils for unit tests - closes #2851

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Product image load after comming back to online - @patzick (#2573)
 - Insufficent validation for city field in checkout address - @lromanowicz (#2653) 
 - Incorrect hover activity on the 'filter by categories' in the search view on mobile - @idodidodi (#2783)
+- Unit tests written in JavaScript now support async/await functions and dynamic import - @michaelKurowski, @lukeromanowicz (#2851)
 
 ## [1.9.0-rc.2] - 2019.04.10
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,7 @@ module.exports = {
   plugins: ['@babel/plugin-syntax-dynamic-import'],
   env: {
     test: {
-      plugins: ['transform-es2015-modules-commonjs'],
+      plugins: ['transform-es2015-modules-commonjs', 'babel-plugin-dynamic-import-node'],
       ignore: [/node_modules\/(?!lodash-es|@vue\/test-utils)/]
     }
   }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "babel-eslint": "^9.0.0",
     "babel-jest": "^24.1.0",
     "babel-loader": "^8.0.5",
+    "babel-plugin-dynamic-import-node": "^2.2.0",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "command-exists": "^1.2.2",
     "commander": "^2.18.0",

--- a/test/unit/jest.conf.js
+++ b/test/unit/jest.conf.js
@@ -25,5 +25,8 @@ module.exports = {
   ],
   transformIgnorePatterns: [
     '<rootDir>/node_modules/(?!lodash)'
+  ],
+  setupFiles: [
+    '<rootDir>/test/unit/setupTestEnvironment.js'
   ]
 }

--- a/test/unit/setupTestEnvironment.js
+++ b/test/unit/setupTestEnvironment.js
@@ -1,0 +1,1 @@
+import '@babel/polyfill'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3346,6 +3346,13 @@ babel-plugin-dynamic-import-node@^1.2.0:
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
 
+babel-plugin-dynamic-import-node@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz#c0adfb07d95f4a4495e9aaac6ec386c4d7c2524e"
+  integrity sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==
+  dependencies:
+    object.assign "^4.1.0"
+
 babel-plugin-istanbul@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz#7981590f1956d75d67630ba46f0c22493588c893"


### PR DESCRIPTION
### Related issues

closes #2851 

### Short description and why it's useful
Fixes polyfils for unit tests written in javascript

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
