### PR TITLE
Feature/2649

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed wrong price displayed in instant checkout module - @vishal-7037 (#2884)
 
 ### Changed / Improved
+- Changed the way to access the configuration. Currently the `rootStore.state.config` is deprecated. Please do use the `@vue-storefront/core/lib/config-manager.ts` > `ConfigManager.getConfig()` instead - @pkarw (#2649)
 - Changed the order number (from `entity_id` to `increment_id`) on MyOrders and MyOrder pages - @pkarw (#2743)
 - Disabled the server cart sync in case user is in the checkout - @pkarw (#2749)
 - Improved ProductGalleryCarousel component to handle nonnumeric options id’s - @danieldomurad (#2586)

--- a/config/default.json
+++ b/config/default.json
@@ -10,8 +10,8 @@
       "outputCacheDefaultTtl": 86400,
       "availableCacheTags": ["product", "category", "home", "checkout", "page-not-found", "compare", "my-account", "P", "C", "error"],
       "invalidateCacheKey": "aeSu7aip",
-      "dynamicConfigReload": false,
-      "dynamicConfigContinueOnError": false,
+      "dynamicConfigReload": true,
+      "dynamicConfigContinueOnError": true,
       "dynamicConfigExclude": ["ssr", "storeViews", "entities", "localForage", "shipping", "boost", "query"],
       "dynamicConfigInclude": [],
       "elasticCacheQuota": 3096

--- a/config/default.json
+++ b/config/default.json
@@ -10,8 +10,8 @@
       "outputCacheDefaultTtl": 86400,
       "availableCacheTags": ["product", "category", "home", "checkout", "page-not-found", "compare", "my-account", "P", "C", "error"],
       "invalidateCacheKey": "aeSu7aip",
-      "dynamicConfigReload": true,
-      "dynamicConfigContinueOnError": true,
+      "dynamicConfigReload": false,
+      "dynamicConfigContinueOnError": false,
       "dynamicConfigExclude": ["ssr", "storeViews", "entities", "localForage", "shipping", "boost", "query"],
       "dynamicConfigInclude": [],
       "elasticCacheQuota": 3096

--- a/core/app.ts
+++ b/core/app.ts
@@ -1,9 +1,7 @@
 import { Store } from 'vuex'
 import RootState from '@vue-storefront/core/types/RootState'
 import Vue from 'vue'
-import buildTimeConfig from 'config'
 import { isServer } from '@vue-storefront/core/helpers'
-import { Logger } from '@vue-storefront/core/lib/logger'
 
 // Plugins
 import i18n from '@vue-storefront/i18n'
@@ -35,6 +33,7 @@ import { enabledModules } from './modules-entry'
 // Will be deprecated in 1.8
 import { registerExtensions } from '@vue-storefront/core/compatibility/lib/extensions'
 import { registerExtensions as extensions } from 'src/extensions'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 function createRouter (): VueRouter {
   return new VueRouter({
@@ -62,15 +61,16 @@ once('__VUE_EXTEND_RR__', () => {
 })
 
 const createApp  = async (ssrContext, config, storeCode = null): Promise<{app: Vue, router: VueRouter, store: Store<RootState>}> => {
+  ConfigManager.setConfig(config)
   router = createRouter()
   // sync router with vuex 'router' store
   sync(store, router)
   // TODO: Don't mutate the state directly, use mutation instead
   store.state.version = process.env.APPVERSION
-  store.state.config = config
+  store.state.config = config // @deprecated 
   store.state.__DEMO_MODE__ = (config.demomode === true) ? true : false
   if(ssrContext) Vue.prototype.$ssrRequestContext = ssrContext
-  if (!store.state.config) store.state.config = buildTimeConfig // if provided from SSR, don't replace it
+  if (!store.state.config) store.state.config = ConfigManager.getBaseConfig() //  @deprecated - we should avoid the `ConfigManager.getConfig()`
   const storeView = prepareStoreView(storeCode) // prepare the default storeView
   store.state.storeView = storeView
   // store.state.shipping.methods = shippingMethods
@@ -115,7 +115,7 @@ const createApp  = async (ssrContext, config, storeCode = null): Promise<{app: V
 
   registerModules(enabledModules, appContext)
   registerExtensions(extensions, app, router, store, config, ssrContext)
-  registerTheme(buildTimeConfig.theme, app, router, store, store.state.config, ssrContext)
+  registerTheme(ConfigManager.getBaseConfig().theme, app, router, store, ConfigManager.getConfig(), ssrContext)
 
   Vue.prototype.$bus.$emit('application-after-init', app)
 

--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -5,8 +5,6 @@ import union from 'lodash-es/union'
 import { createApp } from '@vue-storefront/core/app'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus/index'
 import rootStore from '@vue-storefront/core/store'
-
-import buildTimeConfig from 'config'
 import { execute } from '@vue-storefront/core/lib/sync/task'
 import UniversalStorage from '@vue-storefront/core/store/lib/storage'
 import i18n from '@vue-storefront/i18n'
@@ -15,17 +13,18 @@ import { onNetworkStatusChange } from '@vue-storefront/core/modules/offline-orde
 import '@vue-storefront/core/service-worker/registration' // register the service worker
 import { AsyncDataLoader } from './lib/async-data-loader'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 declare var window: any
 
 const invokeClientEntry = async () => {
-  const config = Object.assign(buildTimeConfig, window.__INITIAL_STATE__.config ? window.__INITIAL_STATE__.config : buildTimeConfig)
+  const config = Object.assign(ConfigManager.getBaseConfig(), window.__INITIAL_STATE__.config ? window.__INITIAL_STATE__.config : ConfigManager.getBaseConfig())
 
   // Get storeCode from server (received either from cache header or env variable)
   let storeCode =  window.__INITIAL_STATE__.user.current_storecode
   const { app, router, store } = await createApp(null, config, storeCode)
 
   if (window.__INITIAL_STATE__) {
-    store.replaceState(Object.assign({}, store.state, window.__INITIAL_STATE__, { config: buildTimeConfig }))
+    store.replaceState(Object.assign({}, store.state, window.__INITIAL_STATE__, { config: ConfigManager.getBaseConfig() }))
   }
 
   store.dispatch('url/registerDynamicRoutes')

--- a/core/compatibility/components/SortBy.js
+++ b/core/compatibility/components/SortBy.js
@@ -11,7 +11,7 @@ export default {
   computed: {
     sortByAttribute () {
       // renamed to sortingOptions
-      return this.$store.state.config.products.sortByAttributes
+      return this.$config.products.sortByAttributes
     }
   },
   mixins: [CategorySort]

--- a/core/compatibility/components/blocks/Microcart/Product.js
+++ b/core/compatibility/components/blocks/Microcart/Product.js
@@ -1,6 +1,6 @@
-import rootStore from '@vue-storefront/core/store'
 import { MicrocartProduct } from '@vue-storefront/core/modules/cart/components/Product.ts'
 import i18n from '@vue-storefront/i18n'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export default {
   data () {
@@ -20,7 +20,7 @@ export default {
   },
   methods: {
     removeItem () {
-      if (rootStore.state.config.cart.askBeforeRemoveProduct) {
+      if (ConfigManager.getConfig().cart.askBeforeRemoveProduct) {
         this.$store.dispatch('notification/spawnNotification', {
           type: 'warning',
           item: this.product,

--- a/core/compatibility/components/blocks/SidebarMenu/SidebarMenu.js
+++ b/core/compatibility/components/blocks/SidebarMenu/SidebarMenu.js
@@ -10,7 +10,7 @@ export default {
     ...mapGetters('category', ['getCategories']),
     categories () {
       return this.getCategories.filter((op) => {
-        return op.level === (this.$store.state.config.entities.category.categoriesDynamicPrefetchLevel ? this.$store.state.config.entities.category.categoriesDynamicPrefetchLevel : 2) // display only the root level (level =1 => Default Category), categoriesDynamicPrefetchLevel = 2 by default
+        return op.level === (this.$config.entities.category.categoriesDynamicPrefetchLevel ? this.$config.entities.category.categoriesDynamicPrefetchLevel : 2) // display only the root level (level =1 => Default Category), categoriesDynamicPrefetchLevel = 2 by default
       })
     },
     ...mapState({

--- a/core/compatibility/plugins/config/index.js
+++ b/core/compatibility/plugins/config/index.js
@@ -1,5 +1,5 @@
-import store from '@vue-storefront/core/store'
-const config = store.state.config
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
+const config = ConfigManager.getConfig()
 // deprecated, use vuex store instead
 const ConfigPlugin = {
   install (Vue) {
@@ -7,7 +7,7 @@ const ConfigPlugin = {
       Object.defineProperties(Vue.prototype, {
         $config: {
           get: function () {
-            return config
+            return ConfigManager.getConfig()
           }
         }
       })

--- a/core/helpers/initCacheStorage.ts
+++ b/core/helpers/initCacheStorage.ts
@@ -1,13 +1,13 @@
 import * as localForage from 'localforage'
 import UniversalStorage from '@vue-storefront/core/store/lib/storage'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
-import rootStore from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 /** Inits cache storage for given module. By default via local storage */
 export function initCacheStorage(key, localised = true) {
   const storeView = currentStoreView()
   const dbNamePrefix = storeView.storeCode ? storeView.storeCode + '-' : ''
-  const config = rootStore.state.config
+  const config = ConfigManager.getConfig()
   const cacheDriver = config.localForage && config.localForage.defaultDrivers[key] ?
     config.localForage.defaultDrivers[key] :
     'LOCALSTORAGE'

--- a/core/i18n/index.ts
+++ b/core/i18n/index.ts
@@ -1,8 +1,9 @@
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
-import config from 'config'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import { once } from '@vue-storefront/core/helpers'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
+const config = ConfigManager.getConfig()
 
 once('__VUE_EXTEND_I18N__', () => {
   Vue.use(VueI18n)

--- a/core/lib/config-manager.ts
+++ b/core/lib/config-manager.ts
@@ -1,0 +1,16 @@
+import buildTimeConfig from 'config'
+
+const ConfigManager = {
+  _currentConfig: null,
+  setConfig (config: any) {
+    this._currentConfig = config
+  },
+  getBaseConfig() { // pre-bundled config - which is not supporting the `dynamicConfigReload` option
+    return buildTimeConfig    
+  },
+  getConfig () {
+    return this._currentConfig !== null ? this._currentConfig : buildTimeConfig
+  }
+}
+
+export { ConfigManager }

--- a/core/lib/module/index.ts
+++ b/core/lib/module/index.ts
@@ -10,6 +10,7 @@ import { isServer } from '@vue-storefront/core/helpers'
 import { VSF, VueStorefrontModuleConfig } from './types'
 import { doesStoreAlreadyExists, mergeStores } from './helpers'
 import { RouterManager } from '@vue-storefront/core/lib/router-manager'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 const moduleExtendings: VueStorefrontModuleConfig[] = []
 const registeredModules: VueStorefrontModuleConfig[] = []
@@ -49,7 +50,7 @@ class VueStorefrontModule {
 
   private static _extendRouter (routerInstance, routes?: RouteConfig[], beforeEach?: NavigationGuard, afterEach?: NavigationGuard): void {
     if (routes) {
-      setupMultistoreRoutes(rootStore.state.config, routerInstance, routes)
+      setupMultistoreRoutes(ConfigManager.getConfig(), routerInstance, routes)
       RouterManager.addRoutes(routes, routerInstance)
     }
     if (beforeEach) routerInstance.beforeEach(beforeEach)
@@ -83,7 +84,7 @@ class VueStorefrontModule {
       let areStoresUnique = true
       const VSF: VSF = {
         Vue, 
-        config: rootStore.state.config, 
+        config: ConfigManager.getConfig(), 
         store: rootStore, 
         isServer
       }
@@ -107,7 +108,7 @@ class VueStorefrontModule {
             this._c.beforeRegistration(VSF) 
           } else {
             Logger.warn('You are using outdated signature for beforeRegistration hook that soon will be deprecated and module will stop working properly. Please update to the new signature that can be found in our docs: https://docs.vuestorefront.io/guide/modules/introduction.html#beforeregistration', 'module', this._c.key)()
-            this._c.beforeRegistration(Vue, rootStore.state.config, rootStore, isServer)
+            this._c.beforeRegistration(Vue, ConfigManager.getConfig(), rootStore, isServer)
           }
         }
         if (this._c.store) VueStorefrontModule._extendStore(rootStore, this._c.store.modules, this._c.store.plugin)
@@ -119,7 +120,7 @@ class VueStorefrontModule {
             this._c.afterRegistration(VSF)
            } else {
             Logger.warn('You are using outdated signature for afterRegistration hook that soon will be deprecated and module will stop working properly. Please update to the new signature that can be found in our docs: https://docs.vuestorefront.io/guide/modules/introduction.html#afterregistration', 'module', this._c.key)()
-            this._c.afterRegistration(Vue, rootStore.state.config, rootStore, isServer)
+            this._c.afterRegistration(Vue, ConfigManager.getConfig(), rootStore, isServer)
            } 
         }
         return this._c

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -4,7 +4,8 @@ import { initializeSyncTaskStorage } from './sync/task'
 import Vue from 'vue'
 import queryString from 'query-string'
 import { RouterManager } from '@vue-storefront/core/lib/router-manager'
-import VueRouter, { RouteConfig, RawLocation } from 'vue-router';
+import VueRouter, { RouteConfig, RawLocation } from 'vue-router'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export interface LocalizedRoute {
   path?: string,
@@ -48,7 +49,7 @@ export function currentStoreView () : StoreView {
 }
 
 export function prepareStoreView (storeCode: string) : StoreView {
-  const config = rootStore.state.config
+  const config = ConfigManager.getConfig()
   let storeView = { // current, default store
     tax: config.tax,
     i18n: config.i18n,
@@ -82,7 +83,7 @@ export function prepareStoreView (storeCode: string) : StoreView {
 
 export function storeCodeFromRoute (matchedRouteOrUrl: LocalizedRoute | RawLocation | string) : string {
   if (matchedRouteOrUrl) {
-    for (const storeCode of rootStore.state.config.storeViews.mapStoreUrlsFor) {
+    for (const storeCode of ConfigManager.getConfig().storeViews.mapStoreUrlsFor) {
       let urlPath = typeof matchedRouteOrUrl === 'object' ? matchedRouteOrUrl.path : matchedRouteOrUrl
       if (urlPath.length > 0 && urlPath[0] !== '/') urlPath = '/' + urlPath
       if (urlPath.startsWith('/' + storeCode + '/') || urlPath === '/' + storeCode) {
@@ -113,8 +114,8 @@ export function adjustMultistoreApiUrl (url: string) : string {
 }
 
 export function localizedRoute (routeObj: LocalizedRoute | string | RouteConfig | RawLocation, storeCode: string): any {
-  if (routeObj && (<LocalizedRoute>routeObj).fullPath && rootStore.state.config.seo.useUrlDispatcher) return localizedDispatcherRoute(<LocalizedRoute>Object.assign({}, routeObj, { params: null }), storeCode)
-  if (storeCode && routeObj && rootStore.state.config.defaultStoreCode !== storeCode) {
+  if (routeObj && (<LocalizedRoute>routeObj).fullPath && ConfigManager.getConfig().seo.useUrlDispatcher) return localizedDispatcherRoute(<LocalizedRoute>Object.assign({}, routeObj, { params: null }), storeCode)
+  if (storeCode && routeObj && ConfigManager.getConfig().defaultStoreCode !== storeCode) {
     if (typeof routeObj === 'object') {
       if (routeObj.name) {
         routeObj.name = storeCode + '-' + routeObj.name
@@ -133,7 +134,7 @@ export function localizedDispatcherRoute (routeObj: LocalizedRoute | string, sto
     return '/' + storeCode + routeObj
   } 
   if (routeObj && routeObj.fullPath) { // case of using dispatcher
-    const routeCodePrefix = rootStore.state.config.defaultStoreCode !== storeCode ? `/${storeCode}` : ''
+    const routeCodePrefix = ConfigManager.getConfig().defaultStoreCode !== storeCode ? `/${storeCode}` : ''
     const qrStr = queryString.stringify(routeObj.params)
     return `${routeCodePrefix}/${routeObj.fullPath}${qrStr ? `?${qrStr}` : ''}`
   }

--- a/core/lib/search.ts
+++ b/core/lib/search.ts
@@ -7,6 +7,7 @@ import { getSearchAdapter } from './search/adapter/searchAdapterFactory'
 import { SearchRequest } from '@vue-storefront/core/types/search/SearchRequest'
 import { SearchResponse } from '@vue-storefront/core/types/search/SearchResponse'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 // TODO - use one from helpers instead
 export function isOnline () : boolean {
@@ -46,7 +47,7 @@ export const quickSearchByQuery  = async ({ query, start = 0, size = 50, entityT
     if (excludeFields) Request._sourceExclude = excludeFields
     if (includeFields) Request._sourceInclude = includeFields
 
-    if (rootStore.state.config.usePriceTiers && (entityType === 'product') && rootStore.state.user.groupId) {
+    if (ConfigManager.getConfig().usePriceTiers && (entityType === 'product') && rootStore.state.user.groupId) {
         Request.groupId = rootStore.state.user.groupId
     }
 
@@ -75,7 +76,7 @@ export const quickSearchByQuery  = async ({ query, start = 0, size = 50, entityT
       delete Request.groupId
     }
 
-    if (rootStore.state.config.usePriceTiers && rootStore.state.user.groupToken) {
+    if (ConfigManager.getConfig().usePriceTiers && rootStore.state.user.groupToken) {
         Request.groupToken = rootStore.state.user.groupToken
     }
 
@@ -87,7 +88,7 @@ export const quickSearchByQuery  = async ({ query, start = 0, size = 50, entityT
       const res = searchAdapter.entities[Request.type].resultPorcessor(resp, start, size)
 
       if (res) { // otherwise it can be just a offline mode
-        cache.setItem(cacheKey, res, null, rootStore.state.config.elasticsearch.disableLocalStorageQueriesCache).catch((err) => { console.error('Cannot store cache for ' + cacheKey + ', ' + err) })
+        cache.setItem(cacheKey, res, null, ConfigManager.getConfig().elasticsearch.disableLocalStorageQueriesCache).catch((err) => { console.error('Cannot store cache for ' + cacheKey + ', ' + err) })
         if (!servedFromCache) { // if navigator onLine == false means ES is unreachable and probably this will return false; sometimes returned false faster than indexedDb cache returns result ...
           Logger.debug('Result from ES for ' + cacheKey + ' (' + entityType + '),  ms=' + (new Date().getTime() - benchmarkTime.getTime()))()
           res.cache = false

--- a/core/lib/search/adapter/api/elasticsearch/boost.js
+++ b/core/lib/search/adapter/api/elasticsearch/boost.js
@@ -1,6 +1,6 @@
-import config from 'config'
-
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 export default function getBoosts (attribute = '') {
+  const config = ConfigManager.getConfig()
   let searchableAttributes = [
   ]
 

--- a/core/lib/search/adapter/api/elasticsearch/mapping.js
+++ b/core/lib/search/adapter/api/elasticsearch/mapping.js
@@ -1,11 +1,10 @@
-import store from '@vue-storefront/core/store'
-
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 export default function getMapping (attribute, entityType = 'products') {
   let mapping = [
   ]
 
-  if (store.state.config.hasOwnProperty(entityType) && store.state.config[entityType].hasOwnProperty('filterFieldMapping')) {
-    mapping = store.state.config[entityType].filterFieldMapping
+  if (ConfigManager.getConfig().hasOwnProperty(entityType) && ConfigManager.getConfig()[entityType].hasOwnProperty('filterFieldMapping')) {
+    mapping = ConfigManager.getConfig()[entityType].filterFieldMapping
   }
 
   if (mapping.hasOwnProperty(attribute)) {

--- a/core/lib/search/adapter/api/elasticsearch/multimatch.js
+++ b/core/lib/search/adapter/api/elasticsearch/multimatch.js
@@ -1,10 +1,10 @@
-import config from 'config'
-
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 export default function getMultiMatchConfig (queryText) {
   return getConfig(queryText)
 }
 
 function getConfig (queryText) {
+  const config = ConfigManager.getConfig()
   let scoringConfig = config.elasticsearch.hasOwnProperty('searchScoring') ? config.elasticsearch.searchScoring : {}
   let minimumShouldMatch = ''
   if (config.elasticsearch.queryMethod === 'GET') {

--- a/core/lib/search/adapter/api/elasticsearch/score.js
+++ b/core/lib/search/adapter/api/elasticsearch/score.js
@@ -1,6 +1,6 @@
-import config from 'config'
-
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 export default function getFunctionScores () {
+  const config = ConfigManager.getConfig()
   if (!config.elasticsearch.hasOwnProperty('searchScoring')) {
     return false
   }

--- a/core/lib/search/adapter/api/elasticsearchQuery.js
+++ b/core/lib/search/adapter/api/elasticsearchQuery.js
@@ -3,9 +3,10 @@ import getMultiMatchConfig from './elasticsearch/multimatch'
 import getBoosts from './elasticsearch/boost'
 import getMapping from './elasticsearch/mapping'
 import cloneDeep from 'lodash-es/cloneDeep'
-import config from 'config'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export async function prepareElasticsearchQueryBody (searchQuery) {
+  const config = ConfigManager.getConfig()
   const bodybuilder = await import(/* webpackChunkName: "bodybuilder" */ 'bodybuilder')
   const optionsPrfeix = '_options'
   const queryText = searchQuery.getSearchText()

--- a/core/lib/search/adapter/api/searchAdapter.ts
+++ b/core/lib/search/adapter/api/searchAdapter.ts
@@ -1,5 +1,4 @@
 import map from 'lodash-es/map'
-import rootStore from '@vue-storefront/core/store'
 import { prepareElasticsearchQueryBody } from './elasticsearchQuery'
 import fetch from 'isomorphic-fetch'
 import { slugify, processURLAddress } from '@vue-storefront/core/helpers'
@@ -8,6 +7,7 @@ import { currentStoreView, prepareStoreView } from '../../../multistore'
 import SearchQuery from '@vue-storefront/core/lib/search/searchQuery'
 import HttpQuery from '@vue-storefront/core/types/search/HttpQuery'
 import { SearchResponse } from '@vue-storefront/core/types/search/SearchResponse'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export class SearchAdapter {
   public entities: any
@@ -25,7 +25,7 @@ export class SearchAdapter {
     if (Request.searchQuery instanceof SearchQuery) {
       ElasticsearchQueryBody = await prepareElasticsearchQueryBody(Request.searchQuery)
       if (Request.searchQuery.getSearchText() !== '') {
-        ElasticsearchQueryBody['min_score'] = rootStore.state.config.elasticsearch.min_score
+        ElasticsearchQueryBody['min_score'] = ConfigManager.getConfig().elasticsearch.min_score
       }
     } else {
       // backward compatibility for old themes uses bodybuilder
@@ -67,18 +67,18 @@ export class SearchAdapter {
     if (!Request.index || !Request.type) {
       throw new Error('Query.index and Query.type are required arguments for executing ElasticSearch query')
     }
-    if (rootStore.state.config.elasticsearch.queryMethod === 'GET') {
+    if (ConfigManager.getConfig().elasticsearch.queryMethod === 'GET') {
       httpQuery.request = JSON.stringify(ElasticsearchQueryBody)
     }
     url = url + '/' + encodeURIComponent(Request.index) + '/' + encodeURIComponent(Request.type) + '/_search'
     url = url + '?' + queryString.stringify(httpQuery)
-    return fetch(url, { method: rootStore.state.config.elasticsearch.queryMethod,
+    return fetch(url, { method: ConfigManager.getConfig().elasticsearch.queryMethod,
       mode: 'cors',
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json'
       },
-      body: rootStore.state.config.elasticsearch.queryMethod === 'POST' ? JSON.stringify(ElasticsearchQueryBody) : null
+      body: ConfigManager.getConfig().elasticsearch.queryMethod === 'POST' ? JSON.stringify(ElasticsearchQueryBody) : null
     }).then(resp => { return resp.json() })
   }
 
@@ -89,7 +89,7 @@ export class SearchAdapter {
     if (resp.hasOwnProperty('hits')) {
       return {
         items: map(resp.hits.hits, hit => {
-          return Object.assign(hit._source, { _score: hit._score, slug: hit._source.slug ? hit._source.slug : ((hit._source.hasOwnProperty('url_key') && rootStore.state.config.products.useMagentoUrlKeys) ? hit._source.url_key : (hit._source.hasOwnProperty('name') ? slugify(hit._source.name) + '-' + hit._source.id : '')) }) // TODO: assign slugs server side
+          return Object.assign(hit._source, { _score: hit._score, slug: hit._source.slug ? hit._source.slug : ((hit._source.hasOwnProperty('url_key') && ConfigManager.getConfig().products.useMagentoUrlKeys) ? hit._source.url_key : (hit._source.hasOwnProperty('name') ? slugify(hit._source.name) + '-' + hit._source.id : '')) }) // TODO: assign slugs server side
         }), // TODO: add scoring information
         total: resp.hits.total,
         start: start,

--- a/core/lib/search/adapter/graphql/processor/processType.ts
+++ b/core/lib/search/adapter/graphql/processor/processType.ts
@@ -1,14 +1,14 @@
 import { SearchResponse } from '@vue-storefront/core/types/search/SearchResponse'
 import map from 'lodash-es/map'
 import { slugify } from '@vue-storefront/core/helpers'
-import rootStore from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export function processESResponseType (resp, start, size): SearchResponse {
   const response = {
     items: map(resp.hits.hits, hit => {
       return Object.assign(hit._source, {
         _score: hit._score,
-        slug: hit._source.slug ? hit._source.slug : ((hit._source.hasOwnProperty('url_key') && rootStore.state.config.products.useMagentoUrlKeys)
+        slug: hit._source.slug ? hit._source.slug : ((hit._source.hasOwnProperty('url_key') && ConfigManager.getConfig().products.useMagentoUrlKeys)
           ? hit._source.url_key
           : (hit._source.hasOwnProperty('name') ? slugify(hit._source.name) + '-' + hit._source.id : ''))
       }) // TODO: assign slugs server side
@@ -32,7 +32,7 @@ export function processProductsType (resp, start, size): SearchResponse {
         delete item._score
       }
       options['slug'] = item.slug ? item.slug : ((item.url_key &&
-      rootStore.state.config.products.useMagentoUrlKeys)
+      ConfigManager.getConfig().products.useMagentoUrlKeys)
         ? item.url_key : (item.name
           ? slugify(item.name) + '-' + item.id : ''))
 

--- a/core/lib/search/adapter/graphql/searchAdapter.ts
+++ b/core/lib/search/adapter/graphql/searchAdapter.ts
@@ -1,9 +1,9 @@
-import rootStore from '@vue-storefront/core/store'
 import { prepareQueryVars } from './gqlQuery'
 import { currentStoreView, prepareStoreView } from '../../../multistore'
 import fetch from 'isomorphic-fetch'
 import {processESResponseType, processProductsType, processCmsType} from './processor/processType'
 import SearchQuery from '../../searchQuery'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export class SearchAdapter {
 
@@ -45,7 +45,7 @@ export class SearchAdapter {
     if (this.entities[Request.type].url) {
       urlGql = this.entities[Request.type].url
     } else {
-      urlGql = rootStore.state.config.server.protocol + '://' + rootStore.state.config.graphql.host + ':' + rootStore.state.config.graphql.port + '/graphql'
+      urlGql = ConfigManager.getConfig().server.protocol + '://' + ConfigManager.getConfig().graphql.host + ':' + ConfigManager.getConfig().graphql.port + '/graphql'
       const urlStoreCode = (storeView.storeCode !== '') ? encodeURIComponent(storeView.storeCode) + '/' : ''
       urlGql = urlGql + '/' + urlStoreCode
     }

--- a/core/lib/sync/index.ts
+++ b/core/lib/sync/index.ts
@@ -7,6 +7,7 @@ import * as localForage from 'localforage'
 import UniversalStorage from '@vue-storefront/core/store/lib/storage'
 import { currentStoreView } from '../multistore'
 import { isServer } from '@vue-storefront/core/helpers'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 /** Syncs given task. If user is offline requiest will be sent to the server after restored connection */
 function queue (task) {
@@ -16,7 +17,7 @@ function queue (task) {
   return new Promise((resolve, reject) => {
     tasksCollection.setItem(task.task_id.toString(), task, (err, resp) => {
       if (err) Logger.error(err, 'sync')()
-      Vue.prototype.$bus.$emit('sync/PROCESS_QUEUE', { config: rootStore.state.config }) // process checkout queue
+      Vue.prototype.$bus.$emit('sync/PROCESS_QUEUE', { config: ConfigManager.getConfig() }) // process checkout queue
       resolve(task)
     }).catch((reason) => {
       Logger.error(reason, 'sync')() // it doesn't work on SSR
@@ -32,14 +33,14 @@ function execute (task) { // not offline task
   task = _prepareTask(task)
   // Logger.info('New sync task [execute] ' + task.url, 'sync', task)()
   const usersCollection = new UniversalStorage(localForage.createInstance({
-    name: (rootStore.state.config.storeViews.commonCache ? '' : dbNamePrefix) + 'shop',
+    name: (ConfigManager.getConfig().storeViews.commonCache ? '' : dbNamePrefix) + 'shop',
     storeName: 'user',
-    driver: localForage[rootStore.state.config.localForage.defaultDrivers['user']]
+    driver: localForage[ConfigManager.getConfig().localForage.defaultDrivers['user']]
   }))
   const cartsCollection = new UniversalStorage(localForage.createInstance({
-    name: (rootStore.state.config.storeViews.commonCache ? '' : dbNamePrefix) + 'shop',
+    name: (ConfigManager.getConfig().storeViews.commonCache ? '' : dbNamePrefix) + 'shop',
     storeName: 'carts',
-    driver: localForage[rootStore.state.config.localForage.defaultDrivers['carts']]
+    driver: localForage[ConfigManager.getConfig().localForage.defaultDrivers['carts']]
   }))
   return new Promise((resolve, reject) => {
     if (isServer) {

--- a/core/lib/sync/task.ts
+++ b/core/lib/sync/task.ts
@@ -12,6 +12,7 @@ import { Logger } from '@vue-storefront/core/lib/logger'
 import { TaskQueue } from '@vue-storefront/core/lib/sync'
 import * as entities from '@vue-storefront/core/store/lib/entities'
 import UniversalStorage from '@vue-storefront/core/store/lib/storage'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 const AUTO_REFRESH_MAX_ATTEMPTS = 20
 
@@ -52,7 +53,7 @@ function _internalExecute (resolve, reject, task: Task, currentToken, currentCar
     return
   }
   let url = task.url.replace('{{token}}', (currentToken == null) ? '' : currentToken).replace('{{cartId}}', (currentCartId == null) ? '' : currentCartId)
-  if (rootStore.state.config.storeViews.multistore) {
+  if (ConfigManager.getConfig().storeViews.multistore) {
     url = adjustMultistoreApiUrl(url)
   }
   let silentMode = false
@@ -76,7 +77,7 @@ function _internalExecute (resolve, reject, task: Task, currentToken, currentCar
           if (isNaN(rootStore.state.userTokenInvalidateLock) || isUndefined(rootStore.state.userTokenInvalidateLock)) rootStore.state.userTokenInvalidateLock = 0
 
           silentMode = true
-          if (rootStore.state.config.users.autoRefreshTokens) {
+          if (ConfigManager.getConfig().users.autoRefreshTokens) {
             if (!rootStore.state.userTokenInvalidateLock) {
               rootStore.state.userTokenInvalidateLock++
               if (rootStore.state.userTokenInvalidateAttemptsCount >= AUTO_REFRESH_MAX_ATTEMPTS) {
@@ -178,6 +179,6 @@ export function initializeSyncTaskStorage () {
   Vue.prototype.$db.syncTaskCollection = new UniversalStorage(localForage.createInstance({
     name: dbNamePrefix + 'shop',
     storeName: 'syncTasks',
-    driver: localForage[rootStore.state.config.localForage.defaultDrivers['syncTasks']]
+    driver: localForage[ConfigManager.getConfig().localForage.defaultDrivers['syncTasks']]
   }))
 }

--- a/core/lib/test/unit/logger.spec.ts
+++ b/core/lib/test/unit/logger.spec.ts
@@ -1,5 +1,6 @@
-import config from 'config'
 import * as coreHelper from '@vue-storefront/core/helpers'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
+const config = ConfigManager.getConfig()
 
 jest.mock('config', () => ({}))
 jest.mock('@vue-storefront/core/helpers', () => ({

--- a/core/modules/cart/store/getters.ts
+++ b/core/modules/cart/store/getters.ts
@@ -5,6 +5,7 @@ import CartState from '../types/CartState'
 import RootState from '@vue-storefront/core/types/RootState'
 import AppliedCoupon from '../types/AppliedCoupon'
 import { onlineHelper } from '@vue-storefront/core/helpers'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 const getters: GetterTree<CartState, RootState> = {
   totals (state) {
@@ -47,7 +48,8 @@ const getters: GetterTree<CartState, RootState> = {
     }
   },
   totalQuantity (state, getters, rootStore) {
-    if (rootStore.config.cart.minicartCountType === 'items') {
+    const config = ConfigManager.getConfig()
+    if (config.cart.minicartCountType === 'items') {
       return state.cartItems.length
     }
 

--- a/core/modules/cart/store/mutations.ts
+++ b/core/modules/cart/store/mutations.ts
@@ -1,8 +1,8 @@
 import Vue from 'vue'
 import { MutationTree } from 'vuex'
-import rootStore from '@vue-storefront/core/store'
 import * as types from './mutation-types'
 import CartState from '../types/CartState'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 const mutations: MutationTree<CartState> = {
   /**
@@ -67,8 +67,8 @@ const mutations: MutationTree<CartState> = {
     state.cartIsLoaded = true
     state.cartSavedAt = Date.now()
 
-    // Vue.prototype.$bus.$emit('order/PROCESS_QUEUE', { config: rootStore.state.config }) // process checkout queue
-    Vue.prototype.$bus.$emit('sync/PROCESS_QUEUE', { config: rootStore.state.config }) // process checkout queue
+    // Vue.prototype.$bus.$emit('order/PROCESS_QUEUE', { config: ConfigManager.getConfig() }) // process checkout queue
+    Vue.prototype.$bus.$emit('sync/PROCESS_QUEUE', { config: ConfigManager.getConfig() }) // process checkout queue
     Vue.prototype.$bus.$emit('application-after-loaded')
     Vue.prototype.$bus.$emit('cart-after-loaded')
   },

--- a/core/modules/cart/test/unit/store/actions.spec.ts
+++ b/core/modules/cart/test/unit/store/actions.spec.ts
@@ -80,9 +80,10 @@ describe('Cart actions', () => {
     wrapper(cartActions);
 
     expect(contextMock.commit).toBeCalledWith(types.CART_LOAD_CART, []);
+    expect(contextMock.commit).toBeCalledWith(types.CART_LOAD_CART_SERVER_TOKEN, null);
   });
 
-  it('clear dispatches creating a new cart on server with direct backend sync when its configured', async () => {
+  it('clear dispatches creating a new cart on server with direct backend sync when its configured', () => {
     const contextMock = {
       commit: jest.fn(),
       dispatch: jest.fn()
@@ -93,12 +94,12 @@ describe('Cart actions', () => {
 
     const wrapper = (actions: any) => actions.clear(contextMock);
 
-    await wrapper(cartActions);
+    wrapper(cartActions);
 
     expect(contextMock.dispatch).toBeCalledWith('serverCreate', { guestCart: false});
   });
 
-  it('clear dispatches creating a new cart on server with queuing when direct backend sync is not configured', async () => {
+  it('clear dispatches creating a new cart on server with queuing when direct backend sync is not configured', () => {
     const contextMock = {
       commit: jest.fn(),
       dispatch: jest.fn()
@@ -109,7 +110,7 @@ describe('Cart actions', () => {
 
     const wrapper = (actions: any) => actions.clear(contextMock);
 
-    await wrapper(cartActions);
+    wrapper(cartActions);
 
     expect(contextMock.dispatch).toBeCalledWith('serverCreate', { guestCart: true});
   });
@@ -130,7 +131,6 @@ describe('Cart actions', () => {
     it('pulls latest cart data and refreshes payment/shipping methods when there are products in cart', async () => {
       isOnlineSpy.mockReturnValueOnce(true);
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         dispatch: jest.fn(),
         state: {
           cartItems: [],
@@ -182,7 +182,6 @@ describe('Cart actions', () => {
     it('pulls shipping methods with default country if none is set in shipping details', async () => {
       isOnlineSpy.mockReturnValueOnce(true);
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         dispatch: jest.fn(),
         state: {
           cartItems: [],
@@ -227,7 +226,6 @@ describe('Cart actions', () => {
 
     it('doesn\'t update shipping methods if cart is empty', async () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         dispatch: jest.fn(),
         state: {
           cartItems: [],
@@ -270,7 +268,6 @@ describe('Cart actions', () => {
 
     it('doesn\'t update payment methods if they were synced recently', async () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         dispatch: jest.fn(),
         state: {
           cartItems: [],
@@ -303,7 +300,6 @@ describe('Cart actions', () => {
 
     it('doesn\'t update payment methods if they were synced recently', async () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         dispatch: jest.fn(),
         state: {
           cartItems: [],
@@ -337,7 +333,6 @@ describe('Cart actions', () => {
     it('pulls latest cart data and even when the cart was updated recently but the hash has changed' +
       '(so cart items or token wer modified)', () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         dispatch: jest.fn(),
         state: {
           cartItems: [],
@@ -370,7 +365,6 @@ describe('Cart actions', () => {
 
     it('performs a cart update request with dry run and forcing client state if its configured to do so', () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         dispatch: jest.fn(),
         state: {
           cartItems: [],
@@ -397,7 +391,6 @@ describe('Cart actions', () => {
 
     it('does not do anything if last cart sync was recently and the cart state hasn\'t been changed since then', () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         dispatch: jest.fn(),
         state: {
           cartServerToken: 'some-token',
@@ -421,7 +414,6 @@ describe('Cart actions', () => {
 
     it('does not do anything if synchronization is off', () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         dispatch: jest.fn(),
       };
 
@@ -436,7 +428,6 @@ describe('Cart actions', () => {
 
     it('does not do anything in SSR environment', () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         dispatch: jest.fn()
       };
 
@@ -454,7 +445,6 @@ describe('Cart actions', () => {
 
     it('pulls latest totals from server', async () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         state: {
           cartServerToken: 'some-token',
           cartServerTotalsAt: 1000000000,
@@ -476,7 +466,6 @@ describe('Cart actions', () => {
 
     it('pulls latest totals from server forcing client state if it\'s configured to do so', async () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         state: {
           cartServerToken: 'some-token',
           cartServerTotalsAt: 1000000000,
@@ -498,7 +487,6 @@ describe('Cart actions', () => {
 
     it('does not do anything if last totals sync was done recently', () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         state: {
           cartServerToken: 'some-token',
           cartServerTotalsAt: 1000000000,
@@ -519,7 +507,6 @@ describe('Cart actions', () => {
 
     it('does not do anything if totals synchronization is off', () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         state: {
           cartServerToken: 'some-token'
         }
@@ -571,7 +558,6 @@ describe('Cart actions', () => {
 
     it('requests to backend for creation of guest cart', async () => {
       const contextMock = {
-        rootGetters: { checkout: { isUserInCheckout: () => false }},
         state: {
           cartServerCreatedAt: 1000000000,
         }

--- a/core/modules/catalog/components/CategorySort.ts
+++ b/core/modules/catalog/components/CategorySort.ts
@@ -13,7 +13,7 @@ export const CategorySort = {
   },
   computed: {
     sortingOptions () {
-      return this.$store.state.config.products.sortByAttributes
+      return this.$config.products.sortByAttributes
     }
   }
 }

--- a/core/modules/catalog/components/ProductBundleOption.ts
+++ b/core/modules/catalog/components/ProductBundleOption.ts
@@ -1,4 +1,4 @@
-import rootStore from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export const ProductBundleOption = {
   name: 'ProductBundleOption',
@@ -37,12 +37,12 @@ export const ProductBundleOption = {
   },
   mounted() {
     this.setDefaultValues()
-    if (rootStore.state.config.usePriceTiers) {
+    if (ConfigManager.getConfig().usePriceTiers) {
       this.$bus.$on('product-after-setup-associated', this.setDefaultValues)
     }
   },
   beforeDestroy () {
-    if (rootStore.state.config.usePriceTiers) {
+    if (ConfigManager.getConfig().usePriceTiers) {
       this.$bus.$off('product-after-setup-associated', this.setDefaultValues)
     }
   },

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -14,6 +14,7 @@ import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { getThumbnailPath } from '@vue-storefront/core/helpers'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import { isServer } from '@vue-storefront/core/helpers'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager';
 
 function _filterRootProductByStockitem (context, stockItem, product, errorCallback) {
   if (stockItem) {
@@ -22,7 +23,7 @@ function _filterRootProductByStockitem (context, stockItem, product, errorCallba
       product.errors.variants = i18n.t('No available product variants')
       context.state.current.errors = product.errors
       Vue.prototype.$bus.$emit('product-after-removevariant', { product: product })
-      if (rootStore.state.config.products.listOutOfStockProducts === false) {
+      if (ConfigManager.getConfig().products.listOutOfStockProducts === false) {
         errorCallback(new Error('Product query returned an empty result'))
       }
     }
@@ -35,7 +36,7 @@ export function isOptionAvailableAsync (context, { product, configuration }) {
 }
 
 function _filterChildrenByStockitem (context, stockItems, product, diffLog) {
-  if (rootStore.state.config.products.filterUnavailableVariants) {
+  if (ConfigManager.getConfig().products.filterUnavailableVariants) {
     if (product.type_id === 'configurable' && product.configurable_children) {
       for (const stockItem of stockItems) {
         const confChild = product.configurable_children.find(p => { return p.id === stockItem.product_id })
@@ -83,7 +84,7 @@ function _filterChildrenByStockitem (context, stockItems, product, diffLog) {
 
 export function filterOutUnavailableVariants (context, product) {
   return new Promise((resolve, reject) => {
-    if (rootStore.state.config.products.filterUnavailableVariants) {
+    if (ConfigManager.getConfig().products.filterUnavailableVariants) {
       const _filterConfigurableHelper = () => {
         if (product.type_id === 'configurable' && product.configurable_children) {
           const stockItems = []
@@ -167,8 +168,8 @@ export function syncProductPrice (product, backProduct) { // TODO: we probably n
  */
 export function doPlatformPricesSync (products) {
   return new Promise((resolve, reject) => {
-    if (rootStore.state.config.products.alwaysSyncPlatformPricesOver) {
-      if (rootStore.state.config.products.clearPricesBeforePlatformSync) {
+    if (ConfigManager.getConfig().products.alwaysSyncPlatformPricesOver) {
+      if (ConfigManager.getConfig().products.clearPricesBeforePlatformSync) {
         for (let product of products) { // clear out the prices as we need to sync them with Magento
           product.priceInclTax = null
           product.originalPriceInclTax = null
@@ -236,7 +237,7 @@ export function doPlatformPricesSync (products) {
       } else { // empty list of products
         resolve(products)
       }
-      if (!rootStore.state.config.products.waitForPlatformSync && !isServer) {
+      if (!ConfigManager.getConfig().products.waitForPlatformSync && !isServer) {
         Logger.log('Returning products, the prices yet to come from backend!')()
         for (let product of products) {
           product.price_is_current = false // in case we're syncing up the prices we should mark if we do have current or not
@@ -255,7 +256,7 @@ export function doPlatformPricesSync (products) {
  */
 export function calculateTaxes (products, store) {
   return new Promise((resolve, reject) => {
-    if (rootStore.state.config.tax.calculateServerSide) {
+    if (ConfigManager.getConfig().tax.calculateServerSide) {
       Logger.debug('Taxes calculated server side, skipping')()
       doPlatformPricesSync(products).then((products) => {
         resolve(products)
@@ -399,12 +400,12 @@ export function populateProductConfigurationAsync (context, { product, selectedV
       }
       context.state.current_configuration[attribute_code] = confVal
       // @deprecated fallback for VS <= 1.0RC
-      if (!('setupVariantByAttributeCode' in rootStore.state.config.products) || rootStore.state.config.products.setupVariantByAttributeCode === false) {
+      if (!('setupVariantByAttributeCode' in ConfigManager.getConfig().products) || ConfigManager.getConfig().products.setupVariantByAttributeCode === false) {
         const fallbackKey = attribute_label
         context.state.current_configuration[fallbackKey.toLowerCase()] = confVal // @deprecated fallback for VS <= 1.0RC
       }
     }
-    if (rootStore.state.config.cart.setConfigurableProductOptions) {
+    if (ConfigManager.getConfig().cart.setConfigurableProductOptions) {
       const productOption = setConfigurableProductOptionsAsync(context, { product: product, configuration: context.state.current_configuration }) // set the custom options
       if (productOption) {
         product.options = _internalMapOptions(productOption)
@@ -419,7 +420,7 @@ export function findConfigurableChildAsync({ product, configuration = null, sele
   let selectedVariant = product.configurable_children.find((configurableChild) => {
 
     if (availabilityCheck) {
-      if (configurableChild.stock && !rootStore.state.config.products.listOutOfStockProducts) {
+      if (configurableChild.stock && !ConfigManager.getConfig().products.listOutOfStockProducts) {
         if (!configurableChild.stock.is_in_stock) {
           return false
         }
@@ -484,7 +485,7 @@ export function configureProductAsync (context, { product, configuration, select
       }
       product.is_configured = true
 
-      if (rootStore.state.config.cart.setConfigurableProductOptions && !selectDefaultVariant && !(Object.keys(configuration).length === 1 && configuration.sku)) {
+      if (ConfigManager.getConfig().cart.setConfigurableProductOptions && !selectDefaultVariant && !(Object.keys(configuration).length === 1 && configuration.sku)) {
         // the condition above: if selectDefaultVariant - then "setCurrent" is seeting the configurable options; if configuration = { sku: '' } -> this is a special case when not configuring the product but just searching by sku
         const productOption = setConfigurableProductOptionsAsync(context, { product: product, configuration: configuration }) // set the custom options
         if (productOption) {
@@ -536,7 +537,7 @@ export function getMediaGallery (product) {
         }
 
         mediaGallery.push({
-          'src': getThumbnailPath(mediaItem.image, rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
+          'src': getThumbnailPath(mediaItem.image, ConfigManager.getConfig().products.gallery.width, ConfigManager.getConfig().products.gallery.height),
           'loading': getThumbnailPath(mediaItem.image, 310, 300),
           'error': getThumbnailPath(mediaItem.image, 310, 300),
           'video': video
@@ -558,7 +559,7 @@ export function configurableChildrenImages(product) {
     let configurableAttributes = product.configurable_options.map(option => option.attribute_code)
     configurableChildrenImages = product.configurable_children.map(child =>
       ({
-        'src': getThumbnailPath(child.image, rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
+        'src': getThumbnailPath(child.image, ConfigManager.getConfig().products.gallery.width, ConfigManager.getConfig().products.gallery.height),
         'loading': getThumbnailPath(product.image, 310, 300),
         'id': configurableAttributes.reduce((result, attribute) => {
           result[attribute] = child[attribute]
@@ -578,11 +579,11 @@ export function configurableChildrenImages(product) {
 
 export function attributeImages(product) {
     let attributeImages = []
-    if (rootStore.state.config.products.gallery.imageAttributes) {
-        for (let attribute of rootStore.state.config.products.gallery.imageAttributes) {
+    if (ConfigManager.getConfig().products.gallery.imageAttributes) {
+        for (let attribute of ConfigManager.getConfig().products.gallery.imageAttributes) {
             if(product[attribute]) {
                 attributeImages.push({
-                    'src': getThumbnailPath(product[attribute], rootStore.state.config.products.gallery.width, rootStore.state.config.products.gallery.height),
+                    'src': getThumbnailPath(product[attribute], ConfigManager.getConfig().products.gallery.width, ConfigManager.getConfig().products.gallery.height),
                     'loading': getThumbnailPath(product[attribute], 310, 300),
                     'error': getThumbnailPath(product[attribute], 310, 300)
                 })

--- a/core/modules/catalog/queries/common.js
+++ b/core/modules/catalog/queries/common.js
@@ -1,20 +1,20 @@
 import SearchQuery from '@vue-storefront/core/lib/search/searchQuery'
-import store from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export function prepareQuery ({queryText = '', filters = [], queryConfig = ''}) {
   let query = new SearchQuery()
   // prepare filters and searchText
   if (filters.length === 0 && queryConfig !== '') {
     // try get filters from config
-    if (store.state.config.hasOwnProperty('query') && store.state.config.query.hasOwnProperty(queryConfig) && store.state.config.query[queryConfig].hasOwnProperty('filter')) {
-      filters = store.state.config.query[queryConfig].filter
+    if (ConfigManager.getConfig().hasOwnProperty('query') && ConfigManager.getConfig().query.hasOwnProperty(queryConfig) && ConfigManager.getConfig().query[queryConfig].hasOwnProperty('filter')) {
+      filters = ConfigManager.getConfig().query[queryConfig].filter
     }
   }
 
   if (queryText === '') {
     // try to get searchText from config
-    if (store.state.config.hasOwnProperty('query') && store.state.config.query.hasOwnProperty(queryConfig) && store.state.config.query[queryConfig].hasOwnProperty('searchText')) {
-      queryText = store.state.config.query[queryConfig].searchText
+    if (ConfigManager.getConfig().hasOwnProperty('query') && ConfigManager.getConfig().query.hasOwnProperty(queryConfig) && ConfigManager.getConfig().query[queryConfig].hasOwnProperty('searchText')) {
+      queryText = ConfigManager.getConfig().query[queryConfig].searchText
     }
   }
 

--- a/core/modules/catalog/queries/related.js
+++ b/core/modules/catalog/queries/related.js
@@ -1,5 +1,5 @@
 import SearchQuery from '@vue-storefront/core/lib/search/searchQuery'
-import store from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export function prepareRelatedQuery (key, sku) {
   let relatedProductsQuery = new SearchQuery()
@@ -10,7 +10,7 @@ export function prepareRelatedQuery (key, sku) {
     .applyFilter({key: 'visibility', value: {'in': [2, 3, 4]}})
     .applyFilter({key: 'status', value: {'in': [1]}})
 
-  if (store.state.config.products.listOutOfStockProducts === false) {
+  if (ConfigManager.getConfig().products.listOutOfStockProducts === false) {
     relatedProductsQuery = relatedProductsQuery.applyFilter({key: 'stock.is_in_stock', value: {'eq': true}})
   }
 

--- a/core/modules/catalog/queries/searchPanel.js
+++ b/core/modules/catalog/queries/searchPanel.js
@@ -1,5 +1,5 @@
 import SearchQuery from '@vue-storefront/core/lib/search/searchQuery'
-import store from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export function prepareQuickSearchQuery (queryText) {
   let searchQuery = new SearchQuery()
@@ -9,7 +9,7 @@ export function prepareQuickSearchQuery (queryText) {
     .applyFilter({key: 'visibility', value: {'in': [3, 4]}})
     .applyFilter({key: 'status', value: {'in': [0, 1]}})/* 2 = disabled, 3 = out of stock */
 
-  if (store.state.config.products.listOutOfStockProducts === false) {
+  if (ConfigManager.getConfig().products.listOutOfStockProducts === false) {
     searchQuery = searchQuery.applyFilter({key: 'stock.is_in_stock', value: {'eq': true}})
   }
 

--- a/core/modules/catalog/store/attribute/actions.ts
+++ b/core/modules/catalog/store/attribute/actions.ts
@@ -4,7 +4,7 @@ import { quickSearchByQuery } from '@vue-storefront/core/lib/search'
 import AttributeState from '../../types/AttributeState'
 import RootState from '@vue-storefront/core/types/RootState'
 import { ActionTree } from 'vuex'
-import rootStore from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 import { Logger } from '@vue-storefront/core/lib/logger'
 
 const actions: ActionTree<AttributeState, RootState> = {
@@ -13,7 +13,7 @@ const actions: ActionTree<AttributeState, RootState> = {
    * @param {Object} context
    * @param {Array} attrCodes attribute codes to load
    */
-  list (context, { filterValues = null, filterField = 'attribute_code', only_user_defined = false, only_visible = false, size = 150, start = 0, includeFields = rootStore.state.config.entities.optimize ? rootStore.state.config.entities.attribute.includeFields : null }) {
+  list (context, { filterValues = null, filterField = 'attribute_code', only_user_defined = false, only_visible = false, size = 150, start = 0, includeFields = ConfigManager.getConfig().entities.optimize ? ConfigManager.getConfig().entities.attribute.includeFields : null }) {
     const commit = context.commit
 
     let searchQuery = new SearchQuery()

--- a/core/modules/catalog/store/category/actions.ts
+++ b/core/modules/catalog/store/category/actions.ts
@@ -15,6 +15,7 @@ import SearchQuery from '@vue-storefront/core/lib/search/searchQuery'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import { isServer } from '@vue-storefront/core/helpers'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 
 const actions: ActionTree<CategoryState, RootState> = {
@@ -33,7 +34,7 @@ const actions: ActionTree<CategoryState, RootState> = {
    * @param {Object} commit promise
    * @param {Object} parent parent category
    */
-  list (context, { parent = null, key = null, value = null, level = null, onlyActive = true, onlyNotEmpty = false, size = 4000, start = 0, sort = 'position:asc', includeFields = rootStore.state.config.entities.optimize ? rootStore.state.config.entities.category.includeFields : null, excludeFields = rootStore.state.config.entities.optimize ? rootStore.state.config.entities.category.excludeFields : null, skipCache = false, updateState = true }) {
+  list (context, { parent = null, key = null, value = null, level = null, onlyActive = true, onlyNotEmpty = false, size = 4000, start = 0, sort = 'position:asc', includeFields = ConfigManager.getConfig().entities.optimize ? ConfigManager.getConfig().entities.category.includeFields : null, excludeFields = ConfigManager.getConfig().entities.optimize ? ConfigManager.getConfig().entities.category.excludeFields : null, skipCache = false, updateState = true }) {
     const commit = context.commit
     let customizedQuery = false // that means the parameteres are != defaults; with defaults parameter the data could be get from window.__INITIAL_STATE__ - this is optimisation trick
     let searchQuery = new SearchQuery()
@@ -43,7 +44,7 @@ const actions: ActionTree<CategoryState, RootState> = {
     }
     if (level !== null) {
       searchQuery = searchQuery.applyFilter({key: 'level', value: {'eq': level}})
-      if (level !== rootStore.state.config.entities.category.categoriesDynamicPrefetchLevel && !isServer) // if this is the default level we're getting the results from window.__INITIAL_STATE__ not querying the server
+      if (level !== ConfigManager.getConfig().entities.category.categoriesDynamicPrefetchLevel && !isServer) // if this is the default level we're getting the results from window.__INITIAL_STATE__ not querying the server
       customizedQuery = true
     }
 
@@ -111,7 +112,7 @@ const actions: ActionTree<CategoryState, RootState> = {
 
     return new Promise((resolve, reject) => {
       const fetchCat = ({ key, value }) => {
-        if (key !== 'id' || value >= rootStore.state.config.entities.category.categoriesRootCategorylId/* root category */) {
+        if (key !== 'id' || value >= ConfigManager.getConfig().entities.category.categoriesRootCategorylId/* root category */) {
           context.dispatch('list', { key: key, value: value }).then(res => {
             if (res && res.items && res.items.length) {
               setcat(null, res.items[0])
@@ -147,7 +148,7 @@ const actions: ActionTree<CategoryState, RootState> = {
             if (!category) {
               return
             }
-            if (category.parent_id >= rootStore.state.config.entities.category.categoriesRootCategorylId) {
+            if (category.parent_id >= ConfigManager.getConfig().entities.category.categoriesRootCategorylId) {
               dispatch('single', { key: 'id', value: category.parent_id, setCurrentCategory: false, setCurrentCategoryPath: false }).then((sc) => { // TODO: move it to the server side for one requests OR cache in indexedDb
                 if (!sc) {
                   commit(types.CATEGORY_UPD_CURRENT_CATEGORY_PATH, currentPath)
@@ -184,7 +185,7 @@ const actions: ActionTree<CategoryState, RootState> = {
       if (state.list.length > 0 && !skipCache) { // SSR - there were some issues with using localForage, so it's the reason to use local state instead, when possible
         let category = state.list.find((itm) => { return itm[key] === value })
         // Check if category exists in the store OR we have recursively reached Default category (id=1)
-        if (category && value >= rootStore.state.config.entities.category.categoriesRootCategorylId/** root category parent */) {
+        if (category && value >= ConfigManager.getConfig().entities.category.categoriesRootCategorylId/** root category parent */) {
           foundInLocalCache = true
           setcat(null, category)
         }
@@ -217,9 +218,9 @@ const actions: ActionTree<CategoryState, RootState> = {
     })
 
     let prefetchGroupProducts = true
-    if (rootStore.state.config.entities.twoStageCaching && rootStore.state.config.entities.optimize && !isServer && !rootStore.state.twoStageCachingDisabled) { // only client side, only when two stage caching enabled
-      includeFields = rootStore.state.config.entities.productListWithChildren.includeFields // we need configurable_children for filters to work
-      excludeFields = rootStore.state.config.entities.productListWithChildren.excludeFields
+    if (ConfigManager.getConfig().entities.twoStageCaching && ConfigManager.getConfig().entities.optimize && !isServer && !rootStore.state.twoStageCachingDisabled) { // only client side, only when two stage caching enabled
+      includeFields = ConfigManager.getConfig().entities.productListWithChildren.includeFields // we need configurable_children for filters to work
+      excludeFields = ConfigManager.getConfig().entities.productListWithChildren.excludeFields
       prefetchGroupProducts = false
       Logger.log('Using two stage caching for performance optimization - executing first stage product pre-fetching')()
     } else {
@@ -265,12 +266,12 @@ const actions: ActionTree<CategoryState, RootState> = {
         // rootStore.state.category.filters = { color: [], size: [], price: [] }
         return []
       } else {
-        if (rootStore.state.config.products.filterUnavailableVariants && rootStore.state.config.products.configurableChildrenStockPrefetchStatic) { // prefetch the stock items
+        if (ConfigManager.getConfig().products.filterUnavailableVariants && ConfigManager.getConfig().products.configurableChildrenStockPrefetchStatic) { // prefetch the stock items
           const skus = []
           let prefetchIndex = 0
           res.items.map(i => {
-            if (rootStore.state.config.products.configurableChildrenStockPrefetchStaticPrefetchCount > 0) {
-              if (prefetchIndex > rootStore.state.config.products.configurableChildrenStockPrefetchStaticPrefetchCount) return
+            if (ConfigManager.getConfig().products.configurableChildrenStockPrefetchStaticPrefetchCount > 0) {
+              if (prefetchIndex > ConfigManager.getConfig().products.configurableChildrenStockPrefetchStaticPrefetchCount) return
             }
             skus.push(i.sku) // main product sku to be checked anyway
             if (i.type_id === 'configurable' && i.configurable_children && i.configurable_children.length > 0) {
@@ -347,7 +348,7 @@ const actions: ActionTree<CategoryState, RootState> = {
       })
     })
 
-    if (rootStore.state.config.entities.twoStageCaching && rootStore.state.config.entities.optimize && !isServer && !rootStore.state.twoStageCachingDisabled && !cacheOnly) { // second stage - request for caching entities; if cacheOnly set - the caching took place with the stage1 request!
+    if (ConfigManager.getConfig().entities.twoStageCaching && ConfigManager.getConfig().entities.optimize && !isServer && !rootStore.state.twoStageCachingDisabled && !cacheOnly) { // second stage - request for caching entities; if cacheOnly set - the caching took place with the stage1 request!
       Logger.log('Using two stage caching for performance optimization - executing second stage product caching', 'category') // TODO: in this case we can pre-fetch products in advance getting more products than set by pageSize()
       rootStore.dispatch('product/list', {
         query: precachedQuery,

--- a/core/modules/catalog/store/category/mutations.ts
+++ b/core/modules/catalog/store/category/mutations.ts
@@ -4,7 +4,7 @@ import * as types from './mutation-types'
 import { slugify, formatBreadCrumbRoutes } from '@vue-storefront/core/helpers'
 import { entityKeyName } from '@vue-storefront/core/store/lib/entities'
 import CategoryState from '../../types/CategoryState'
-import rootStore from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 import { Logger } from '@vue-storefront/core/lib/logger'
 
 const mutations: MutationTree<CategoryState> = {
@@ -22,7 +22,7 @@ const mutations: MutationTree<CategoryState> = {
         if (category.children_data) {
           for (let subcat of category.children_data) { // TODO: fixme and move slug setting to vue-storefront-api
             if (subcat.name) {
-              subcat = Object.assign(subcat, { slug: subcat.slug ? subcat.slug : ((subcat.hasOwnProperty('url_key') && rootStore.state.config.products.useMagentoUrlKeys) ? subcat.url_key : (subcat.hasOwnProperty('name') ? slugify(subcat.name) + '-' + subcat.id : '')) })
+              subcat = Object.assign(subcat, { slug: subcat.slug ? subcat.slug : ((subcat.hasOwnProperty('url_key') && ConfigManager.getConfig().products.useMagentoUrlKeys) ? subcat.url_key : (subcat.hasOwnProperty('name') ? slugify(subcat.name) + '-' + subcat.id : '')) })
               catSlugSetter(subcat)
             }
           }

--- a/core/modules/catalog/store/product/actions.ts
+++ b/core/modules/catalog/store/product/actions.ts
@@ -26,6 +26,7 @@ import ProductState from '../../types/ProductState'
 import { Logger } from '@vue-storefront/core/lib/logger';
 import { TaskQueue } from '@vue-storefront/core/lib/sync'
 import toString from 'lodash-es/toString'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 const PRODUCT_REENTER_TIMEOUT = 20000
 
@@ -104,7 +105,7 @@ const actions: ActionTree<ProductState, RootState> = {
    */
   syncPlatformPricesOver (context, { skus }) {
     const storeView = currentStoreView()
-    return TaskQueue.execute({ url: rootStore.state.config.products.endpoint + '/render-list?skus=' + encodeURIComponent(skus.join(',')) + '&currencyCode=' + encodeURIComponent(storeView.i18n.currencyCode) + '&storeId=' + encodeURIComponent(storeView.storeId), // sync the cart
+    return TaskQueue.execute({ url: ConfigManager.getConfig().products.endpoint + '/render-list?skus=' + encodeURIComponent(skus.join(',')) + '&currencyCode=' + encodeURIComponent(storeView.i18n.currencyCode) + '&storeId=' + encodeURIComponent(storeView.storeId), // sync the cart
       payload: {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
@@ -282,12 +283,12 @@ const actions: ActionTree<ProductState, RootState> = {
       Logger.debug('Entity cache is disabled for productList')()
     }
 
-    if (rootStore.state.config.entities.optimize) {
+    if (ConfigManager.getConfig().entities.optimize) {
       if (excludeFields === null) { // if not set explicitly we do optimize the amount of data by using some default field list; this is cacheable
-        excludeFields = rootStore.state.config.entities.product.excludeFields
+        excludeFields = ConfigManager.getConfig().entities.product.excludeFields
       }
       if (includeFields === null) { // if not set explicitly we do optimize the amount of data by using some default field list; this is cacheable
-        includeFields = rootStore.state.config.entities.product.includeFields
+        includeFields = ConfigManager.getConfig().entities.product.includeFields
       }
     }
     return quickSearchByQuery({ query, start, size, entityType, sort, excludeFields, includeFields }).then((resp) => {
@@ -301,7 +302,7 @@ const actions: ActionTree<ProductState, RootState> = {
           if (!product.parentSku) {
             product.parentSku = product.sku
           }
-          if (rootStore.state.config.products.setFirstVarianAsDefaultInURL && product.hasOwnProperty('configurable_children') && product.configurable_children.length > 0) {
+          if (ConfigManager.getConfig().products.setFirstVarianAsDefaultInURL && product.hasOwnProperty('configurable_children') && product.configurable_children.length > 0) {
             product.sku = product.configurable_children[0].sku
           }
           if (configuration) {
@@ -478,12 +479,12 @@ const actions: ActionTree<ProductState, RootState> = {
             Logger.debug('Product:single - result from localForage (for ' + cacheKey + '),  ms=' + (new Date().getTime() - benchmarkTime.getTime()), 'product')()
             const _returnProductFromCacheHelper = (subresults) => {
               const cachedProduct = setupProduct(res)
-              if (rootStore.state.config.products.alwaysSyncPlatformPricesOver) {
+              if (ConfigManager.getConfig().products.alwaysSyncPlatformPricesOver) {
                 doPlatformPricesSync([cachedProduct]).then((products) => {
                     Vue.prototype.$bus.$emitFilter('product-after-single', { key: key, options: options, product: products[0] })
                     resolve(products[0])
                 })
-                if (!rootStore.state.config.products.waitForPlatformSync) {
+                if (!ConfigManager.getConfig().products.waitForPlatformSync) {
                     Vue.prototype.$bus.$emitFilter('product-after-single', { key: key, options: options, product: cachedProduct })
                     resolve(cachedProduct)
                 }
@@ -572,7 +573,7 @@ const actions: ActionTree<ProductState, RootState> = {
       // check if passed variant is the same as original
       const productUpdated = Object.assign({}, productOriginal, productVariant)
       populateProductConfigurationAsync(context, { product: productUpdated, selectedVariant: productVariant })
-      if (!rootStore.state.config.products.gallery.mergeConfigurableChildren) {
+      if (!ConfigManager.getConfig().products.gallery.mergeConfigurableChildren) {
           context.commit(types.CATALOG_UPD_GALLERY, attributeImages(productVariant))
       }
       context.commit(types.CATALOG_SET_PRODUCT_CURRENT, productUpdated)
@@ -615,13 +616,13 @@ const actions: ActionTree<ProductState, RootState> = {
       let subloaders = []
       if (product) {
         const productFields = Object.keys(product).filter(fieldName => {
-          return rootStore.state.config.entities.product.standardSystemFields.indexOf(fieldName) < 0 // don't load metadata info for standard fields
+          return ConfigManager.getConfig().entities.product.standardSystemFields.indexOf(fieldName) < 0 // don't load metadata info for standard fields
         })
         const attributesPromise = context.dispatch('attribute/list', { // load attributes to be shown on the product details - the request is now async
-          filterValues: rootStore.state.config.entities.product.useDynamicAttributeLoader ? productFields : null,
-          only_visible: rootStore.state.config.entities.product.useDynamicAttributeLoader ? true : false,
+          filterValues: ConfigManager.getConfig().entities.product.useDynamicAttributeLoader ? productFields : null,
+          only_visible: ConfigManager.getConfig().entities.product.useDynamicAttributeLoader ? true : false,
           only_user_defined: true,
-          includeFields: rootStore.state.config.entities.optimize ? rootStore.state.config.entities.attribute.includeFields : null
+          includeFields: ConfigManager.getConfig().entities.optimize ? ConfigManager.getConfig().entities.attribute.includeFields : null
         }, { root: true }) // TODO: it might be refactored to kind of: `await context.dispatch('attributes/list) - or using new Promise() .. to wait for attributes to be loaded before executing the next action. However it may decrease the performance - so for now we're just waiting with the breadcrumbs
         if (isServer) {
           subloaders.push(context.dispatch('setupBreadcrumbs', { product: product }))
@@ -641,7 +642,7 @@ const actions: ActionTree<ProductState, RootState> = {
 
         context.dispatch('setProductGallery', { product: product })
 
-        if (rootStore.state.config.products.preventConfigurableChildrenDirectAccess) {
+        if (ConfigManager.getConfig().products.preventConfigurableChildrenDirectAccess) {
           subloaders.push(context.dispatch('checkConfigurableParent', { product: product }))
         }
       } else { // error or redirect
@@ -663,10 +664,10 @@ const actions: ActionTree<ProductState, RootState> = {
 
   setProductGallery(context, { product }) {
       if (product.type_id === 'configurable' && product.hasOwnProperty('configurable_children')) {
-        if (!rootStore.state.config.products.gallery.mergeConfigurableChildren && product.is_configured) {
+        if (!ConfigManager.getConfig().products.gallery.mergeConfigurableChildren && product.is_configured) {
            context.commit(types.CATALOG_UPD_GALLERY, attributeImages(context.state.current))
         } else {
-          let productGallery = uniqBy(configurableChildrenImages(product).concat(getMediaGallery(product)), 'src').filter(f => { return f.src && f.src !== rootStore.state.config.images.productPlaceholder })
+          let productGallery = uniqBy(configurableChildrenImages(product).concat(getMediaGallery(product)), 'src').filter(f => { return f.src && f.src !== ConfigManager.getConfig().images.productPlaceholder })
           context.commit(types.CATALOG_UPD_GALLERY, productGallery)
         }
       } else {

--- a/core/modules/catalog/store/stock/actions.ts
+++ b/core/modules/catalog/store/stock/actions.ts
@@ -8,6 +8,7 @@ import StockState from '../../types/StockState'
 import rootStore from '@vue-storefront/core/store'
 import { TaskQueue } from '@vue-storefront/core/lib/sync'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 const actions: ActionTree<StockState, RootState> = {
   /**
@@ -15,8 +16,8 @@ const actions: ActionTree<StockState, RootState> = {
    */
   check (context, { product, qty = 1 }) {
     return new Promise((resolve, reject) => {
-      if (rootStore.state.config.stock.synchronize) {
-        TaskQueue.queue({ url: rootStore.state.config.stock.endpoint + '/check?sku=' + encodeURIComponent(product.sku),
+      if (ConfigManager.getConfig().stock.synchronize) {
+        TaskQueue.queue({ url: ConfigManager.getConfig().stock.endpoint + '/check?sku=' + encodeURIComponent(product.sku),
           payload: {
             method: 'GET',
             headers: { 'Content-Type': 'application/json' },
@@ -37,8 +38,8 @@ const actions: ActionTree<StockState, RootState> = {
    */
   list (context, { skus }) {
     return new Promise((resolve, reject) => {
-      if (rootStore.state.config.stock.synchronize) {
-        TaskQueue.execute({ url: rootStore.state.config.stock.endpoint + '/list?skus=' + encodeURIComponent(skus.join(',')),
+      if (ConfigManager.getConfig().stock.synchronize) {
+        TaskQueue.execute({ url: ConfigManager.getConfig().stock.endpoint + '/list?skus=' + encodeURIComponent(skus.join(',')),
           payload: {
             method: 'GET',
             headers: { 'Content-Type': 'application/json' },
@@ -70,7 +71,7 @@ const actions: ActionTree<StockState, RootState> = {
       rootStore.dispatch('cart/getItem', event.product_sku).then((cartItem) => {
         if (cartItem && event.result.code !== 'ENOTFOUND') {
           if (!event.result.is_in_stock) {
-            if (!rootStore.state.config.stock.allowOutOfStockInCart) {
+            if (!ConfigManager.getConfig().stock.allowOutOfStockInCart) {
               Logger.log('Removing product from cart' + event.product_sku, 'stock')()
               rootStore.commit('cart/' + types.CART_DEL_ITEM, { product: { sku: event.product_sku } }, {root: true})
             } else {

--- a/core/modules/mailer/store/index.ts
+++ b/core/modules/mailer/store/index.ts
@@ -1,12 +1,12 @@
-import config from 'config'
-import i18n from '@vue-storefront/i18n'
 import MailItem from '../types/MailItem'
 import { Module } from 'vuex'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export const module: Module<any, any> = {
   namespaced: true,
   actions: {
     sendEmail (context, letter: MailItem) {
+      const config = ConfigManager.getConfig()
       return new Promise((resolve, reject) => {
         fetch(config.mailer.endpoint.token)
         .then(res => res.json())

--- a/core/modules/offline-order/components/CancelOrders.ts
+++ b/core/modules/offline-order/components/CancelOrders.ts
@@ -3,6 +3,7 @@ import store from '@vue-storefront/core/store'
 
 import UniversalStorage from '@vue-storefront/core/store/lib/storage'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export const CancelOrders = {
   methods: {
@@ -10,7 +11,7 @@ export const CancelOrders = {
       const ordersCollection = new UniversalStorage(localForage.createInstance({
         name: 'shop',
         storeName: 'orders',
-        driver: localForage[store.state.config.localForage.defaultDrivers['orders']]
+        driver: localForage[ConfigManager.getConfig().localForage.defaultDrivers['orders']]
       }))
 
       ordersCollection.iterate((order, id, iterationNumber) => {

--- a/core/modules/offline-order/components/ConfirmOrders.ts
+++ b/core/modules/offline-order/components/ConfirmOrders.ts
@@ -1,8 +1,8 @@
-import config from 'config'
-
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 export const ConfirmOrders = {
   methods: {
     confirmOrders () {
+      const config = ConfigManager.getConfig()
       this.$bus.$emit('order/PROCESS_QUEUE', { config: config })
       this.$bus.$emit('sync/PROCESS_QUEUE', { config: config })
       this.$store.dispatch('cart/load')

--- a/core/modules/offline-order/helpers/onNetworkStatusChange.ts
+++ b/core/modules/offline-order/helpers/onNetworkStatusChange.ts
@@ -1,21 +1,19 @@
 import * as localForage from 'localforage'
-import store from '@vue-storefront/core/store'
-
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus/index'
-
 import UniversalStorage from '@vue-storefront/core/store/lib/storage'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export function onNetworkStatusChange (store) {
   Logger.log('Are we online: ' + navigator.onLine, 'offline-order')()
 
   if (typeof navigator !== 'undefined' && navigator.onLine) {
-    EventBus.$emit('sync/PROCESS_QUEUE', { config: store.state.config }) // process checkout queue
+    EventBus.$emit('sync/PROCESS_QUEUE', { config: ConfigManager.getConfig() }) // process checkout queue
     store.dispatch('cart/load')
 
-    if (store.state.config.orders.offline_orders.automatic_transmission_enabled || store.getters['checkout/isThankYouPage']) {
-      EventBus.$emit('order/PROCESS_QUEUE', { config: store.state.config }) // process checkout queue
+    if (ConfigManager.getConfig().orders.offline_orders.automatic_transmission_enabled || store.getters['checkout/isThankYouPage']) {
+      EventBus.$emit('order/PROCESS_QUEUE', { config: ConfigManager.getConfig() }) // process checkout queue
       // store.dispatch('cart/serverPull', { forceClientState: false })
     } else {
       const ordersToConfirm = []
@@ -23,7 +21,7 @@ export function onNetworkStatusChange (store) {
       const ordersCollection = new UniversalStorage(localForage.createInstance({
         name: 'shop',
         storeName: 'orders',
-        driver: localForage[store.state.config.localForage.defaultDrivers['orders']]
+        driver: localForage[ConfigManager.getConfig().localForage.defaultDrivers['orders']]
       }))
 
       ordersCollection.iterate((order, id, iterationNumber) => {

--- a/core/modules/order/store/mutations.ts
+++ b/core/modules/order/store/mutations.ts
@@ -3,7 +3,7 @@ import { MutationTree } from 'vuex'
 import * as types from './mutation-types'
 import * as entities from '@vue-storefront/core/store/lib/entities'
 import OrderState from '../types/OrderState'
-import rootStore from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 import { Logger } from '@vue-storefront/core/lib/logger'
 
 const mutations: MutationTree<OrderState> = {
@@ -21,7 +21,7 @@ const mutations: MutationTree<OrderState> = {
     ordersCollection.setItem(orderId.toString(), order, (err, resp) => {
       if (err) Logger.error(err, 'order')()
       if (!order.transmited) {
-        Vue.prototype.$bus.$emit('order/PROCESS_QUEUE', { config: rootStore.state.config }) // process checkout queue
+        Vue.prototype.$bus.$emit('order/PROCESS_QUEUE', { config: ConfigManager.getConfig() }) // process checkout queue
       }
       Logger.info('Order placed, orderId = ' + orderId, 'order')()
     }).catch((reason) => {

--- a/core/modules/review/store/actions.ts
+++ b/core/modules/review/store/actions.ts
@@ -11,6 +11,7 @@ import rootStore from '@vue-storefront/core/store'
 import Review from '@vue-storefront/core/modules/review/types/Review'
 import { ReviewRequest } from '@vue-storefront/core/modules/review/types/ReviewRequest'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 const actions: ActionTree<ReviewState, RootState> = {
   /**
@@ -56,9 +57,9 @@ const actions: ActionTree<ReviewState, RootState> = {
 
     Vue.prototype.$bus.$emit('notification-progress-start', i18n.t('Adding a review ...'))
 
-    let url = rootStore.state.config.reviews.create_endpoint
+    let url = ConfigManager.getConfig().reviews.create_endpoint
 
-    if (rootStore.state.config.storeViews.multistore) {
+    if (ConfigManager.getConfig().storeViews.multistore) {
       url = adjustMultistoreApiUrl(url)
     }
 

--- a/core/modules/url/helpers/index.ts
+++ b/core/modules/url/helpers/index.ts
@@ -1,5 +1,5 @@
 import { router } from '@vue-storefront/core/app'
-import rootStore from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 import { localizedDispatcherRoute, localizedRoute, LocalizedRoute } from '@vue-storefront/core/lib/multistore'
 import { RouteConfig } from 'vue-router/types/router';
 import { RouterManager } from '@vue-storefront/core/lib/router-manager'
@@ -16,7 +16,7 @@ export function parametrizeRouteData (routeData: LocalizedRoute, query: { [id: s
 export function processDynamicRoute(routeData: LocalizedRoute, fullPath: string, addToRoutes: boolean = true): LocalizedRoute[] {
   const userRoute = RouterManager.findByName(routeData.name)
   if (userRoute) {
-    const config = rootStore.state.config
+    const config = ConfigManager.getConfig()
     if (addToRoutes) {
       const routes = []
       const rootDynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + fullPath, name: `urldispatcher-${fullPath}` })
@@ -24,7 +24,7 @@ export function processDynamicRoute(routeData: LocalizedRoute, fullPath: string,
       if (config.storeViews.mapStoreUrlsFor.length > 0 && config.storeViews.multistore === true) {
         for (let storeCode of config.storeViews.mapStoreUrlsFor) {
           if (storeCode) {
-            const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + ((rootStore.state.config.defaultStoreCode !== storeCode) ? (storeCode + '/') : '') + fullPath, name: `urldispatcher-${fullPath}-${storeCode}` })
+            const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + ((ConfigManager.getConfig().defaultStoreCode !== storeCode) ? (storeCode + '/') : '') + fullPath, name: `urldispatcher-${fullPath}-${storeCode}` })
             routes.push(dynamicRoute)
           }
         }
@@ -54,7 +54,7 @@ export function normalizeUrlPath(url: string): string {
 }
 
 export function formatCategoryLink(category: { url_path: string, slug: string }): string {
-  return rootStore.state.config.seo.useUrlDispatcher ? ('/' + category.url_path) : ((rootStore.state.config.products.useShortCatalogUrls ? '/' : '/c/') + category.slug)
+  return ConfigManager.getConfig().seo.useUrlDispatcher ? ('/' + category.url_path) : ((ConfigManager.getConfig().products.useShortCatalogUrls ? '/' : '/c/') + category.slug)
 }
 
 export function formatProductLink(
@@ -68,7 +68,7 @@ export function formatProductLink(
   },
   storeCode
 ): string | LocalizedRoute {
-  if (rootStore.state.config.seo.useUrlDispatcher && product.url_path) {
+  if (ConfigManager.getConfig().seo.useUrlDispatcher && product.url_path) {
     let routeData: LocalizedRoute;
     if (product.configurable_children && product.configurable_children.length > 0) {
       routeData = {

--- a/core/modules/url/router/beforeEach.ts
+++ b/core/modules/url/router/beforeEach.ts
@@ -8,6 +8,7 @@ import { processDynamicRoute, normalizeUrlPath } from '../helpers'
 import { isServer } from '@vue-storefront/core/helpers'
 import { storeCodeFromRoute, prepareStoreView, currentStoreView, LocalizedRoute } from '@vue-storefront/core/lib/multistore'
 import Vue from 'vue'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export const UrlDispatchMapper = async (to) => {
   const routeData = await store.dispatch('url/mapUrl', { url: to.fullPath, query: to.query })
@@ -15,7 +16,7 @@ export const UrlDispatchMapper = async (to) => {
 }
 export function beforeEach(to: Route, from: Route, next) {
   if (isServer) {
-    if (store.state.config.storeViews.multistore) { // this is called before server-entry.ts router.onReady - so we have to make sure we're in the right store context
+    if (ConfigManager.getConfig().storeViews.multistore) { // this is called before server-entry.ts router.onReady - so we have to make sure we're in the right store context
       const storeCode = storeCodeFromRoute(to)
       if (storeCode) {
         prepareStoreView(storeCode)

--- a/core/modules/user/router/beforeEach.ts
+++ b/core/modules/user/router/beforeEach.ts
@@ -1,6 +1,5 @@
 import { Route } from 'vue-router'
 import rootStore from '@vue-storefront/core/store'
-import i18n from '@vue-storefront/i18n'
 import { isServer } from '@vue-storefront/core/helpers'
 
 export async function beforeEach(to: Route, from: Route, next) {

--- a/core/modules/user/store/actions.ts
+++ b/core/modules/user/store/actions.ts
@@ -10,6 +10,7 @@ import { Logger } from '@vue-storefront/core/lib/logger'
 import { TaskQueue } from '@vue-storefront/core/lib/sync'
 import { UserProfile } from '../types/UserProfile'
 import { isServer } from '@vue-storefront/core/helpers'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 // import router from '@vue-storefront/core/router'
 
 const actions: ActionTree<UserState, RootState> = {
@@ -34,7 +35,7 @@ const actions: ActionTree<UserState, RootState> = {
         context.commit(types.USER_TOKEN_CHANGED, { newToken: res })
         context.dispatch('sessionAfterAuthorized')
 
-        if (rootStore.state.config.usePriceTiers) {
+        if (ConfigManager.getConfig().usePriceTiers) {
           cache.getItem('current-user', (err, userData) => {
             if (err) {
               Logger.error(err, 'user')()
@@ -56,7 +57,7 @@ const actions: ActionTree<UserState, RootState> = {
    * Send password reset link for specific e-mail
    */
   resetPassword (context, { email }) {
-    return TaskQueue.execute({ url: rootStore.state.config.users.resetPassword_endpoint,
+    return TaskQueue.execute({ url: ConfigManager.getConfig().users.resetPassword_endpoint,
       payload: {
         method: 'POST',
         mode: 'cors',
@@ -72,8 +73,8 @@ const actions: ActionTree<UserState, RootState> = {
    * Login user and return user profile and current token
    */
   login (context, { username, password }) {
-    let url = rootStore.state.config.users.login_endpoint
-    if (rootStore.state.config.storeViews.multistore) {
+    let url = ConfigManager.getConfig().users.login_endpoint
+    if (ConfigManager.getConfig().storeViews.multistore) {
       url = adjustMultistoreApiUrl(url)
     }
     return fetch(url, { method: 'POST',
@@ -98,8 +99,8 @@ const actions: ActionTree<UserState, RootState> = {
    * Login user and return user profile and current token
    */
   register (context, { email, firstname, lastname, password }) {
-    let url = rootStore.state.config.users.create_endpoint
-    if (rootStore.state.config.storeViews.multistore) {
+    let url = ConfigManager.getConfig().users.create_endpoint
+    if (ConfigManager.getConfig().storeViews.multistore) {
       url = adjustMultistoreApiUrl(url)
     }
     return fetch(url, { method: 'POST',
@@ -129,8 +130,8 @@ const actions: ActionTree<UserState, RootState> = {
         if (err) {
           Logger.error(err, 'user')()
         }
-        let url = rootStore.state.config.users.refresh_endpoint
-        if (rootStore.state.config.storeViews.multistore) {
+        let url = ConfigManager.getConfig().users.refresh_endpoint
+        if (ConfigManager.getConfig().storeViews.multistore) {
           url = adjustMultistoreApiUrl(url)
         }
         return fetch(url, { method: 'POST',
@@ -156,7 +157,7 @@ const actions: ActionTree<UserState, RootState> = {
    * @param userData
    */
   setUserGroup(context, userData) {
-    if (rootStore.state.config.usePriceTiers) {
+    if (ConfigManager.getConfig().usePriceTiers) {
       if (userData.groupToken) {
         context.commit(types.USER_GROUP_TOKEN_CHANGED, userData.groupToken)
       }
@@ -202,7 +203,7 @@ const actions: ActionTree<UserState, RootState> = {
       }
 
       if (refresh) {
-        TaskQueue.execute({ url: rootStore.state.config.users.me_endpoint,
+        TaskQueue.execute({ url: ConfigManager.getConfig().users.me_endpoint,
           payload: { method: 'GET',
             mode: 'cors',
             headers: {
@@ -236,7 +237,7 @@ const actions: ActionTree<UserState, RootState> = {
    * Update user profile with data from My Account page
    */
   async update (context, userData:UserProfile) {
-    await TaskQueue.queue({ url: rootStore.state.config.users.me_endpoint,
+    await TaskQueue.queue({ url: ConfigManager.getConfig().users.me_endpoint,
       payload: {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -253,7 +254,7 @@ const actions: ActionTree<UserState, RootState> = {
    * Change user password
    */
   changePassword (context, passwordData) {
-    return TaskQueue.execute({ url: rootStore.state.config.users.changePassword_endpoint,
+    return TaskQueue.execute({ url: ConfigManager.getConfig().users.changePassword_endpoint,
       payload: {
         method: 'POST',
         mode: 'cors',
@@ -345,7 +346,7 @@ const actions: ActionTree<UserState, RootState> = {
       }
 
       if (refresh) {
-        return TaskQueue.execute({ url: rootStore.state.config.users.history_endpoint,
+        return TaskQueue.execute({ url: ConfigManager.getConfig().users.history_endpoint,
           payload: { method: 'GET',
             mode: 'cors',
             headers: {

--- a/core/pages/Category.js
+++ b/core/pages/Category.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import toString from 'lodash-es/toString'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 import i18n from '@vue-storefront/i18n'
 import store from '@vue-storefront/core/store'
@@ -73,10 +74,10 @@ export default {
       route: route,
       current: 0,
       perPage: 50,
-      sort: store.state.config.entities.productList.sort,
-      filters: store.state.config.products.defaultFilters,
-      includeFields: store.state.config.entities.optimize && isServer ? store.state.config.entities.productList.includeFields : null,
-      excludeFields: store.state.config.entities.optimize && isServer ? store.state.config.entities.productList.excludeFields : null,
+      sort: ConfigManager.getConfig().entities.productList.sort,
+      filters: ConfigManager.getConfig().products.defaultFilters,
+      includeFields: ConfigManager.getConfig().entities.optimize && isServer ? ConfigManager.getConfig().entities.productList.includeFields : null,
+      excludeFields: ConfigManager.getConfig().entities.optimize && isServer ? ConfigManager.getConfig().entities.productList.excludeFields : null,
       append: false
     })
   },
@@ -84,14 +85,14 @@ export default {
     Logger.info('Entering asyncData in Category Page (core)')()
     try {
       if (context) context.output.cacheTags.add(`category`)
-      const defaultFilters = store.state.config.products.defaultFilters
+      const defaultFilters = ConfigManager.getConfig().products.defaultFilters
       store.dispatch('category/resetFilters')
       EventBus.$emit('filter-reset')
       await store.dispatch('attribute/list', { // load filter attributes for this specific category
         filterValues: defaultFilters, // TODO: assign specific filters/ attribute codes dynamicaly to specific categories
-        includeFields: store.state.config.entities.optimize && isServer ? store.state.config.entities.attribute.includeFields : null
+        includeFields: ConfigManager.getConfig().entities.optimize && isServer ? ConfigManager.getConfig().entities.attribute.includeFields : null
       })
-      const parentCategory = await store.dispatch('category/single', { key: store.state.config.products.useMagentoUrlKeys ? 'url_key' : 'slug', value: route.params.slug })
+      const parentCategory = await store.dispatch('category/single', { key: ConfigManager.getConfig().products.useMagentoUrlKeys ? 'url_key' : 'slug', value: route.params.slug })
       let query = store.getters['category/getCurrentCategoryProductQuery']
       if (!query.searchProductQuery) {
         store.dispatch('category/mergeSearchOptions', {
@@ -113,7 +114,7 @@ export default {
   async beforeRouteEnter (to, from, next) {
     if (!isServer && !from.name) { // Loading category products to cache on SSR render
       next(vm => {
-        const defaultFilters = store.state.config.products.defaultFilters
+        const defaultFilters = ConfigManager.getConfig().products.defaultFilters
         let parentCategory = store.getters['category/getCurrentCategory']
         let query = store.getters['category/getCurrentCategoryProductQuery']
         if (!query.searchProductQuery) {
@@ -131,7 +132,7 @@ export default {
   beforeMount () {
     this.$bus.$on('filter-changed-category', this.onFilterChanged)
     this.$bus.$on('list-change-sort', this.onSortOrderChanged)
-    if (store.state.config.usePriceTiers) {
+    if (ConfigManager.getConfig().usePriceTiers) {
       this.$bus.$on('user-after-loggedin', this.onUserPricesRefreshed)
       this.$bus.$on('user-after-logout', this.onUserPricesRefreshed)
     }
@@ -144,7 +145,7 @@ export default {
   beforeDestroy () {
     this.$bus.$off('list-change-sort', this.onSortOrderChanged)
     this.$bus.$off('filter-changed-category', this.onFilterChanged)
-    if (store.state.config.usePriceTiers) {
+    if (ConfigManager.getConfig().usePriceTiers) {
       this.$bus.$off('user-after-loggedin', this.onUserPricesRefreshed)
       this.$bus.$off('user-after-logout', this.onUserPricesRefreshed)
     }
@@ -229,12 +230,12 @@ export default {
       this.$store.dispatch('category/resetFilters')
       this.$bus.$emit('filter-reset')
 
-      this.$store.dispatch('category/single', { key: this.$store.state.config.products.useMagentoUrlKeys ? 'url_key' : 'slug', value: route.params.slug }).then(category => {
+      this.$store.dispatch('category/single', { key: this.$config.products.useMagentoUrlKeys ? 'url_key' : 'slug', value: route.params.slug }).then(category => {
         if (!category) {
           this.$router.push(this.localizedRoute('/'))
         } else {
           this.pagination.current = 0
-          let searchProductQuery = baseFilterProductsQuery(this.getCurrentCategory, store.state.config.products.defaultFilters)
+          let searchProductQuery = baseFilterProductsQuery(this.getCurrentCategory, ConfigManager.getConfig().products.defaultFilters)
           this.$bus.$emit('current-category-changed', this.getCurrentCategoryPath)
           this.mergeSearchOptions({ // base prototype from the asyncData is being used here
             current: this.pagination.current,
@@ -264,9 +265,9 @@ export default {
       })
     },
     onUserPricesRefreshed () {
-      const defaultFilters = store.state.config.products.defaultFilters
+      const defaultFilters = ConfigManager.getConfig().products.defaultFilters
       this.$store.dispatch('category/single', {
-        key: this.$store.state.config.products.useMagentoUrlKeys ? 'url_key' : 'slug',
+        key: this.$config.products.useMagentoUrlKeys ? 'url_key' : 'slug',
         value: this.$route.params.slug
       }).then((parentCategory) => {
         if (!this.getCurrentCategoryProductQuery.searchProductQuery) {

--- a/core/pages/Checkout.js
+++ b/core/pages/Checkout.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import i18n from '@vue-storefront/i18n'
-import store from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 import VueOfflineMixin from 'vue-offline/mixin'
 import { mapGetters } from 'vuex'
 
@@ -259,8 +259,8 @@ export default {
     // This method checks if there exists a mapping of chosen payment method to one of Magento's payment methods.
     getPaymentMethod () {
       let paymentMethod = this.payment.paymentMethod
-      if (store.state.config.orders.payment_methods_mapping.hasOwnProperty(paymentMethod)) {
-        paymentMethod = store.state.config.orders.payment_methods_mapping[paymentMethod]
+      if (ConfigManager.getConfig().orders.payment_methods_mapping.hasOwnProperty(paymentMethod)) {
+        paymentMethod = ConfigManager.getConfig().orders.payment_methods_mapping[paymentMethod]
       }
       return paymentMethod
     },

--- a/core/pages/Product.js
+++ b/core/pages/Product.js
@@ -1,4 +1,5 @@
 import { mapGetters } from 'vuex'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 import store from '@vue-storefront/core/store'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
@@ -83,7 +84,7 @@ export default {
     this.$bus.$on('filter-changed-product', this.onAfterFilterChanged)
     this.$bus.$on('product-after-customoptions', this.onAfterCustomOptionsChanged)
     this.$bus.$on('product-after-bundleoptions', this.onAfterBundleOptionsChanged)
-    if (store.state.config.usePriceTiers) {
+    if (ConfigManager.getConfig().usePriceTiers) {
       this.$bus.$on('user-after-loggedin', this.onUserPricesRefreshed)
       this.$bus.$on('user-after-logout', this.onUserPricesRefreshed)
     }
@@ -191,7 +192,7 @@ export default {
         fallbackToDefaultWhenNoAvailable: false,
         setProductErorrs: true
       }).then((selectedVariant) => {
-        if (store.state.config.products.setFirstVarianAsDefaultInURL) {
+        if (ConfigManager.getConfig().products.setFirstVarianAsDefaultInURL) {
           this.$router.push({params: { childSku: selectedVariant.sku }})
         }
         if (!selectedVariant) {

--- a/core/server-entry.ts
+++ b/core/server-entry.ts
@@ -6,7 +6,8 @@ import { prepareStoreView, storeCodeFromRoute } from '@vue-storefront/core/lib/m
 import omit from 'lodash-es/omit'
 import pick from 'lodash-es/pick'
 import buildTimeConfig from 'config'
-import { AsyncDataLoader } from './lib/async-data-loader'
+import { AsyncDataLoader } from '@vue-storefront/core/lib/async-data-loader'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 import { Logger } from '@vue-storefront/core/lib/logger'
 
 function _commonErrorHandler (err, reject) {
@@ -31,12 +32,12 @@ function _ssrHydrateSubcomponents (components, store, router, resolve, reject, a
   })).then(() => {
     AsyncDataLoader.flush({ store, route: router.currentRoute, context: null } /*AsyncDataLoaderActionContext*/).then((r) => {
       if (buildTimeConfig.ssr.useInitialStateFilter) {
-        context.state = omit(store.state, store.state.config.ssr.initialStateFilter)
+        context.state = omit(store.state, ConfigManager.getConfig().ssr.initialStateFilter)
       } else {
         context.state = store.state
       }
       if (!buildTimeConfig.server.dynamicConfigReload) { // if dynamic config reload then we're sending config along with the request
-        context.state = omit(store.state, buildTimeConfig.ssr.useInitialStateFilter ?  [...store.state.config.ssr.initialStateFilter, 'config'] : ['config'])
+        context.state = omit(store.state, buildTimeConfig.ssr.useInitialStateFilter ?  [...ConfigManager.getConfig().ssr.initialStateFilter, 'config'] : ['config'])
       } else {
         const excludeFromConfig = buildTimeConfig.server.dynamicConfigExclude
         const includeFromConfig = buildTimeConfig.server.dynamicConfigInclude
@@ -65,7 +66,7 @@ export default async context => {
     router.push(context.url)
     context.meta = meta
     router.onReady(() => {
-      if (store.state.config.storeViews.multistore === true) {
+      if (ConfigManager.getConfig().storeViews.multistore === true) {
         let storeCode = context.vs.storeCode // this is from http header or env variable
         if (router.currentRoute) { // this is from url
           storeCode = storeCodeFromRoute(router.currentRoute)

--- a/docs/guide/integrations/payment-gateway.md
+++ b/docs/guide/integrations/payment-gateway.md
@@ -33,7 +33,7 @@ Here is an example of a "Cash on delivery" payment method main logic. It's place
 
 ```js
 import InfoComponent from '../components/Info.vue'
-import rootStore from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export function afterRegistration({ Vue, config, store, isServer }) {
   // Place the order. Payload is empty as we don't have any specific info to add for this payment method '{}'

--- a/docs/guide/upgrade-notes/README.md
+++ b/docs/guide/upgrade-notes/README.md
@@ -270,11 +270,11 @@ We added Reviews support, however, Magento 2 is still lacking Reviews support in
 
 ### Upgrade step-by-step
 
-#### `global.$VS` replaced with `rootStore` and `config` was moved to `rootStore.state.config`
+#### `global.$VS` replaced with `rootStore` and `config` was moved to `ConfigManager.getConfig()`
 
 To get access to rootStore, import it by
 
-`import rootStore from '@vue-storefront/core/store'`
+`import { ConfigManager } from '@vue-storefront/core/lib/config-manager'`
 
 #### cms extenstion was renamed to extension-magento2-cms
 

--- a/src/modules/magento-2-cms/components/CmsData.vue
+++ b/src/modules/magento-2-cms/components/CmsData.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import store from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 export default {
@@ -59,18 +59,18 @@ export default {
   },
   data () {
     return {
-      isMultistoreEnable: store.state.config.storeViews.multistore
+      isMultistoreEnable: ConfigManager.getConfig().storeViews.multistore
     }
   },
   methods: {
     getEndpointPath () {
       let url
       if (this.id) {
-        url = (store.state.config.cms.endpoint)
+        url = (ConfigManager.getConfig().cms.endpoint)
           .replace('{{type}}', this.type)
           .replace('{{cmsId}}', this.id)
       } else if (this.identifier) {
-        url = (store.state.config.cms.endpointIdentifier)
+        url = (ConfigManager.getConfig().cms.endpointIdentifier)
           .replace('{{type}}', this.type)
           .replace('{{cmsIdentifier}}', this.identifier)
           .replace('{{storeId}}', this.storeView)

--- a/src/modules/mailchimp/store/index.ts
+++ b/src/modules/mailchimp/store/index.ts
@@ -1,8 +1,8 @@
 import * as types from './mutation-types'
-import config from 'config'
 import { Module } from 'vuex'
 import { mailchimpState } from '../types/mailchimpState'
 import { cacheStorage } from '../'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export const module: Module<mailchimpState, any> ={
   namespaced: true,
@@ -23,6 +23,7 @@ export const module: Module<mailchimpState, any> ={
   },
   actions: {
     subscribe ({ commit, state }, email): Promise<Response> {
+      const config = ConfigManager.getConfig() 
       if (!state.isSubscribed) {
         return new Promise((resolve, reject) => {
           fetch(config.mailchimp.endpoint, {
@@ -42,6 +43,7 @@ export const module: Module<mailchimpState, any> ={
       }
     },
     unsubscribe ({ commit, state }, email): Promise<Response> {
+      const config = ConfigManager.getConfig()
       if (!state.isSubscribed) {
         return new Promise((resolve, reject) => {
           fetch(config.mailchimp.endpoint, {

--- a/src/themes/default-amp/components/core/ProductTile.vue
+++ b/src/themes/default-amp/components/core/ProductTile.vue
@@ -50,6 +50,7 @@
 <script>
 import rootStore from '@vue-storefront/core/store'
 import { ProductTile } from '@vue-storefront/core/modules/catalog/components/ProductTile.ts'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export default {
   mixins: [ProductTile],
@@ -71,7 +72,7 @@ export default {
     },
     visibilityChanged (isVisible, entry) {
       if (isVisible) {
-        if (rootStore.state.config.products.configurableChildrenStockPrefetchDynamic && rootStore.products.filterUnavailableVariants) {
+        if (ConfigManager.getConfig().products.configurableChildrenStockPrefetchDynamic && rootStore.products.filterUnavailableVariants) {
           const skus = [this.product.sku]
           if (this.product.type_id === 'configurable' && this.product.configurable_children && this.product.configurable_children.length > 0) {
             for (const confChild of this.product.configurable_children) {

--- a/src/themes/default-amp/index.js
+++ b/src/themes/default-amp/index.js
@@ -1,6 +1,5 @@
 import { setupMultistoreRoutes } from '@vue-storefront/core/lib/multistore'
 import { RouterManager } from '@vue-storefront/core/lib/router-manager'
-import config from 'config'
 import routes from './router'
 
 export default function (app, router, store) {

--- a/src/themes/default-amp/router/index.ts
+++ b/src/themes/default-amp/router/index.ts
@@ -3,8 +3,8 @@
 import Category from '../pages/Category.vue'
 import Product from '../pages/Product.vue'
 import { RouteConfig } from 'vue-router'
-
-import config from 'config'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
+const config = ConfigManager.getConfig()
 
 let routes: RouteConfig[] = [
 ]

--- a/src/themes/default/components/core/ColorSelector.vue
+++ b/src/themes/default/components/core/ColorSelector.vue
@@ -13,14 +13,14 @@
 
 <script>
 import GenericSelector from '@vue-storefront/core/compatibility/components/GenericSelector'
-import rootStore from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 export default {
   mixins: [GenericSelector],
   methods: {
     colorFrom (label) {
-      if (rootStore.state.config.products.colorMappings) {
-        if (typeof rootStore.state.config.products.colorMappings[label] !== 'undefined') {
-          label = rootStore.state.config.products.colorMappings[label]
+      if (ConfigManager.getConfig().products.colorMappings) {
+        if (typeof ConfigManager.getConfig().products.colorMappings[label] !== 'undefined') {
+          label = ConfigManager.getConfig().products.colorMappings[label]
         }
       }
       if (label.indexOf('/') >= 0) label = label.replace('/', ',') // to be honest - this is a hack for colors like "ink/white"

--- a/src/themes/default/components/core/ProductGalleryCarousel.vue
+++ b/src/themes/default/components/core/ProductGalleryCarousel.vue
@@ -67,7 +67,7 @@
 </template>
 
 <script>
-import store from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 import { Carousel, Slide } from 'vue-carousel'
 import ProductVideo from './ProductVideo'
 import reduce from 'lodash-es/reduce'
@@ -161,7 +161,7 @@ export default {
       }
     },
     selectVariant () {
-      if (store.state.config.products.gallery.mergeConfigurableChildren) {
+      if (ConfigManager.getConfig().products.gallery.mergeConfigurableChildren) {
         const option = reduce(map(this.configuration, 'attribute_code'), (result, attribute) => {
           result[attribute] = this.configuration[attribute].id
           return result

--- a/src/themes/default/components/core/ProductTile.vue
+++ b/src/themes/default/components/core/ProductTile.vue
@@ -54,6 +54,7 @@
 import rootStore from '@vue-storefront/core/store'
 import { ProductTile } from '@vue-storefront/core/modules/catalog/components/ProductTile.ts'
 import { isServer } from '@vue-storefront/core/helpers'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export default {
   mixins: [ProductTile],
@@ -80,7 +81,7 @@ export default {
     },
     visibilityChanged (isVisible, entry) {
       if (isVisible) {
-        if (rootStore.state.config.products.configurableChildrenStockPrefetchDynamic && rootStore.products.filterUnavailableVariants) {
+        if (ConfigManager.getConfig().products.configurableChildrenStockPrefetchDynamic && rootStore.products.filterUnavailableVariants) {
           const skus = [this.product.sku]
           if (this.product.type_id === 'configurable' && this.product.configurable_children && this.product.configurable_children.length > 0) {
             for (const confChild of this.product.configurable_children) {

--- a/src/themes/default/components/core/blocks/Checkout/ThankYouPage.vue
+++ b/src/themes/default/components/core/blocks/Checkout/ThankYouPage.vue
@@ -107,7 +107,7 @@ export default {
       return this.$store.state.checkout.personalDetails.emailAddress
     },
     mailerElements () {
-      return this.$store.state.config.mailer.contactAddress
+      return this.$config.mailer.contactAddress
     }
   },
   methods: {

--- a/src/themes/default/components/core/blocks/Footer/Footer.vue
+++ b/src/themes/default/components/core/blocks/Footer/Footer.vue
@@ -153,7 +153,7 @@ export default {
   name: 'MainFooter',
   computed: {
     multistoreEnabled () {
-      return this.$store.state.config.storeViews.multistore
+      return this.$config.storeViews.multistore
     },
     getVersionInfo () {
       return `v${process.env.__APPVERSION__} ${process.env.__BUILDTIME__}`

--- a/src/themes/default/components/core/blocks/Footer/MinimalFooter.vue
+++ b/src/themes/default/components/core/blocks/Footer/MinimalFooter.vue
@@ -182,7 +182,7 @@ export default {
   name: 'MainFooter',
   computed: {
     multistoreEnabled () {
-      return this.$store.state.config.storeViews.multistore
+      return this.$config.storeViews.multistore
     }
   },
   mixins: [CurrentPage]

--- a/src/themes/default/components/core/blocks/Microcart/Product.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Product.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script>
-import rootStore from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 import Product from '@vue-storefront/core/compatibility/components/blocks/Microcart/Product'
 
 import RemoveButton from './RemoveButton'
@@ -105,7 +105,7 @@ export default {
   mixins: [Product],
   data () {
     return {
-      displayItemDiscounts: rootStore.state.config.cart.displayItemDiscounts
+      displayItemDiscounts: ConfigManager.getConfig().cart.displayItemDiscounts
     }
   }
 }

--- a/src/themes/default/components/core/blocks/Product/Related.vue
+++ b/src/themes/default/components/core/blocks/Product/Related.vue
@@ -21,7 +21,7 @@ import ProductListing from 'theme/components/core/ProductListing'
 
 import { prepareRelatedQuery } from '@vue-storefront/core/modules/catalog/queries/related'
 import i18n from '@vue-storefront/i18n'
-import store from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export default {
   name: 'Related',
@@ -42,7 +42,7 @@ export default {
   beforeMount () {
     this.$bus.$on('product-after-load', this.refreshList)
 
-    if (store.state.config.usePriceTiers) {
+    if (ConfigManager.getConfig().usePriceTiers) {
       this.$bus.$on('user-after-loggedin', this.refreshList)
       this.$bus.$on('user-after-logout', this.refreshList)
     }
@@ -50,7 +50,7 @@ export default {
     this.refreshList()
   },
   beforeDestroy () {
-    if (store.state.config.usePriceTiers) {
+    if (ConfigManager.getConfig().usePriceTiers) {
       this.$bus.$off('user-after-loggedin', this.refreshList)
       this.$bus.$off('user-after-logout', this.refreshList)
     }

--- a/src/themes/default/components/core/blocks/SidebarMenu/SubBtn.vue
+++ b/src/themes/default/components/core/blocks/SidebarMenu/SubBtn.vue
@@ -46,7 +46,7 @@ export default {
   },
   methods: {
     next () {
-      if (this.$store.state.config.entities.category.categoriesDynamicPrefetch) this.$store.dispatch('category/list', { parent: this.id })
+      if (this.$config.entities.category.categoriesDynamicPrefetch) this.$store.dispatch('category/list', { parent: this.id })
       this.$store.commit('ui/setSubmenu', {
         id: this.id,
         depth: ++this.submenu.depth

--- a/src/themes/default/components/core/blocks/SidebarMenu/SubCategory.vue
+++ b/src/themes/default/components/core/blocks/SidebarMenu/SubCategory.vue
@@ -117,7 +117,7 @@ export default {
   },
   computed: {
     children () {
-      if (!this.$store.state.config.entities.category.categoriesDynamicPrefetch && (this.categoryLinks && this.categoryLinks.length > 0 && this.categoryLinks[0].name)) { // we're using dynamic prefetching and getting just category.children_data.id from 1.7
+      if (!this.$config.entities.category.categoriesDynamicPrefetch && (this.categoryLinks && this.categoryLinks.length > 0 && this.categoryLinks[0].name)) { // we're using dynamic prefetching and getting just category.children_data.id from 1.7
         return this.categoryLinks
       } else {
         return this.$store.state.category.list.filter(c => { return c.parent_id === this.id }) // return my child categories

--- a/src/themes/default/components/core/blocks/Switcher/Language.vue
+++ b/src/themes/default/components/core/blocks/Switcher/Language.vue
@@ -23,7 +23,7 @@
 </template>
 <script>
 import Modal from 'theme/components/core/Modal.vue'
-import store from '@vue-storefront/core/store'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 export default {
   components: {
     Modal
@@ -36,14 +36,14 @@ export default {
   },
   computed: {
     storeViews () {
-      return store.state.config.storeViews
+      return ConfigManager.getConfig().storeViews
     },
     config () {
-      return store.state.config
+      return ConfigManager.getConfig()
     },
     enableColumns () {
-      var enableStoreViews = Object.keys(store.state.config.storeViews).filter((key) => {
-        var value = store.state.config.storeViews[key]
+      var enableStoreViews = Object.keys(ConfigManager.getConfig().storeViews).filter((key) => {
+        var value = ConfigManager.getConfig().storeViews[key]
         return (typeof value === 'object' && value.disabled === false)
       })
       return enableStoreViews.length > this.minCountryPerColumn

--- a/src/themes/default/layouts/Default.vue
+++ b/src/themes/default/layouts/Default.vue
@@ -85,7 +85,7 @@ export default {
       this.$bus.$emit('modal-show', 'modal-order-confirmation')
     },
     fetchMenuData () {
-      return this.$store.dispatch('category/list', { level: this.$store.state.config.entities.category.categoriesDynamicPrefetch && this.$store.state.config.entities.category.categoriesDynamicPrefetchLevel ? this.$store.state.config.entities.category.categoriesDynamicPrefetchLevel : null, includeFields: this.$store.state.config.entities.optimize && isServer ? this.$store.state.config.entities.category.includeFields : null, skipCache: isServer })
+      return this.$store.dispatch('category/list', { level: this.$config.entities.category.categoriesDynamicPrefetch && this.$config.entities.category.categoriesDynamicPrefetchLevel ? this.$config.entities.category.categoriesDynamicPrefetchLevel : null, includeFields: this.$config.entities.optimize && isServer ? this.$config.entities.category.includeFields : null, skipCache: isServer })
     }
   },
   serverPrefetch () {

--- a/src/themes/default/pages/Home.vue
+++ b/src/themes/default/pages/Home.vue
@@ -45,6 +45,7 @@ import PromotedOffers from 'theme/components/theme/blocks/PromotedOffers/Promote
 import TileLinks from 'theme/components/theme/blocks/TileLinks/TileLinks'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import { mapGetters } from 'vuex'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
 
 export default {
   mixins: [Home],
@@ -91,7 +92,7 @@ export default {
     }
   },
   async asyncData ({ store, route }) { // this is for SSR purposes to prefetch data
-    const config = store.state.config
+    const config = ConfigManager.getConfig()
 
     Logger.info('Calling asyncData in Home (theme)')()
 

--- a/src/themes/default/router/index.js
+++ b/src/themes/default/router/index.js
@@ -1,4 +1,6 @@
-import config from 'config'
+import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
+const config = ConfigManager.getConfig()
+
 const Home = () => import(/* webpackChunkName: "vsf-home" */ 'theme/pages/Home.vue')
 const PageNotFound = () => import(/* webpackChunkName: "vsf-not-found" */ 'theme/pages/PageNotFound.vue')
 const ErrorPage = () => import(/* webpackChunkName: "vsf-error" */ 'theme/pages/Error.vue')


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #2649 

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

I've refactored the way we access the config. The `rootStore.state.config` is still available however - deprecated. I belive we should remove this property starting with Vue Storefront 2.0.

From 1.10.rc-1 the only recommended way to access the config file is:
```js
import { ConfigManager } from '@vue-storefront/core/lib/config-manager'
const config = ConfigManager.getConfig()
```

I've tested the code with the `config.dynamicConfigReload=true` which provides the user with the modified config files within each request.

`ConfigManager.geConfig()` - returns the current, dynamically reloaded configuration
`ConfigManager.getBaseConfig()` - returns the bundled in, static configuration file - it's just required with some of the calls that.. basically set up the dynamic config mechanism :)

The naming is after previously accepter `RouterManager`

**Note to CR** We shouldn't have root module level calls like: 

```
const config = ConfigManager.getConfig()
```

The config should be obtained at the function level to make sure it's the updated reference/object after the runtime changes. Kind of IoC for config. Therefore in many places, I used the `ConfigManager.getConfig().someProperty` accessors that of course violates the Demeter Principle. It could be optimized in the second step by extracting the subsequent getConfig() calls within single JS function to single `const config = ConfigManager.getConfig()`. I haven't had time to optimize and test it properly and because of the V8 optimizations, this optimization is just to .. improve the readability :)

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
