### PR TITLE
Bugfix - #2898

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added back to top functionality - @vishal-7037 (#2866)
 
 ### Fixed
+- Products removed from the cart are no longer add back on the conectivity return - @pkarw (#2898)
 - Sidebar menu wasn't possible to scroll - @PanMisza (#2627)
 - Confirmation popup 'Product has beed added to cart' is displayed only once - @JKrupinski (#2610)
 - Moved My Account options from Categories - @bartdominiak (#2612)

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -179,7 +179,7 @@ const actions: ActionTree<CartState, RootState> = {
       return task
     })
   },
-  load (context, { forceClientState = true }:{forceClientState?:boolean} = {}) {
+  load (context, { forceClientState = false }:{forceClientState?:boolean} = {}) {
     return new Promise((resolve, reject) => {
       if (isServer) return
       const commit = context.commit

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -179,7 +179,7 @@ const actions: ActionTree<CartState, RootState> = {
       return task
     })
   },
-  load (context) {
+  load (context, cartLoadOptions: { forceClientState: boolean } = { forceClientState: true }) {
     return new Promise((resolve, reject) => {
       if (isServer) return
       const commit = context.commit
@@ -204,7 +204,7 @@ const actions: ActionTree<CartState, RootState> = {
               commit(types.CART_LOAD_CART_SERVER_TOKEN, token)
               Logger.info('Cart token received from cache.', 'cache', token)()
               Logger.info('Pulling cart from server.','cart')()
-              context.dispatch('serverPull', { forceClientState: false, dryRun: !config.cart.serverMergeByDefault })
+              context.dispatch('serverPull', { forceClientState: cartLoadOptions.forceClientState, dryRun: !config.cart.serverMergeByDefault })
             } else {
               Logger.info('Creating server cart token', 'cart')()
               context.dispatch('serverCreate', { guestCart: false })

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -179,7 +179,7 @@ const actions: ActionTree<CartState, RootState> = {
       return task
     })
   },
-  load (context, cartLoadOptions: { forceClientState: boolean } = { forceClientState: true }) {
+  load (context, { forceClientState = true }:{forceClientState?:boolean} = {}) {
     return new Promise((resolve, reject) => {
       if (isServer) return
       const commit = context.commit

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -204,7 +204,7 @@ const actions: ActionTree<CartState, RootState> = {
               commit(types.CART_LOAD_CART_SERVER_TOKEN, token)
               Logger.info('Cart token received from cache.', 'cache', token)()
               Logger.info('Pulling cart from server.','cart')()
-              context.dispatch('serverPull', { forceClientState: cartLoadOptions.forceClientState, dryRun: !config.cart.serverMergeByDefault })
+              context.dispatch('serverPull', { forceClientState, dryRun: !config.cart.serverMergeByDefault })
             } else {
               Logger.info('Creating server cart token', 'cart')()
               context.dispatch('serverCreate', { guestCart: false })

--- a/core/modules/offline-order/helpers/onNetworkStatusChange.ts
+++ b/core/modules/offline-order/helpers/onNetworkStatusChange.ts
@@ -10,7 +10,7 @@ export function onNetworkStatusChange (store) {
 
   if (typeof navigator !== 'undefined' && navigator.onLine) {
     EventBus.$emit('sync/PROCESS_QUEUE', { config: config }) // process checkout queue
-    store.dispatch('cart/load')
+    store.dispatch('cart/load', { forceClientState: true })
     if (config.orders.offline_orders.automatic_transmission_enabled || store.getters['checkout/isThankYouPage']) {
       EventBus.$emit('order/PROCESS_QUEUE', { config: config }) // process checkout queue
       // store.dispatch('cart/serverPull', { forceClientState: false })

--- a/core/modules/offline-order/helpers/onNetworkStatusChange.ts
+++ b/core/modules/offline-order/helpers/onNetworkStatusChange.ts
@@ -12,7 +12,7 @@ export function onNetworkStatusChange (store) {
 
   if (typeof navigator !== 'undefined' && navigator.onLine) {
     EventBus.$emit('sync/PROCESS_QUEUE', { config: store.state.config }) // process checkout queue
-    store.dispatch('cart/load')
+    store.dispatch('cart/load', { forceClientState: true })
 
     if (store.state.config.orders.offline_orders.automatic_transmission_enabled || store.getters['checkout/isThankYouPage']) {
       EventBus.$emit('order/PROCESS_QUEUE', { config: store.state.config }) // process checkout queue

--- a/core/modules/offline-order/helpers/onNetworkStatusChange.ts
+++ b/core/modules/offline-order/helpers/onNetworkStatusChange.ts
@@ -10,7 +10,7 @@ export function onNetworkStatusChange (store) {
 
   if (typeof navigator !== 'undefined' && navigator.onLine) {
     EventBus.$emit('sync/PROCESS_QUEUE', { config: config }) // process checkout queue
-    store.dispatch('cart/load', { forceClientState: true })
+    store.dispatch('cart/load')
     if (config.orders.offline_orders.automatic_transmission_enabled || store.getters['checkout/isThankYouPage']) {
       EventBus.$emit('order/PROCESS_QUEUE', { config: config }) // process checkout queue
       // store.dispatch('cart/serverPull', { forceClientState: false })

--- a/core/pages/Checkout.js
+++ b/core/pages/Checkout.js
@@ -62,7 +62,7 @@ export default {
     this.$bus.$on('checkout-after-shippingMethodChanged', this.onAfterShippingMethodChanged)
     this.$bus.$on('checkout-after-validationError', this.focusField)
     if (!this.isThankYouPage) {
-      this.$store.dispatch('cart/load', { forceClientState: true }).then(() => {
+      this.$store.dispatch('cart/load').then(() => {
         if (this.$store.state.cart.cartItems.length === 0) {
           this.notifyEmptyCart()
           this.$router.push(this.localizedRoute('/'))

--- a/core/pages/Checkout.js
+++ b/core/pages/Checkout.js
@@ -62,7 +62,7 @@ export default {
     this.$bus.$on('checkout-after-shippingMethodChanged', this.onAfterShippingMethodChanged)
     this.$bus.$on('checkout-after-validationError', this.focusField)
     if (!this.isThankYouPage) {
-      this.$store.dispatch('cart/load').then(() => {
+      this.$store.dispatch('cart/load', { forceClientState: true }).then(() => {
         if (this.$store.state.cart.cartItems.length === 0) {
           this.notifyEmptyCart()
           this.$router.push(this.localizedRoute('/'))

--- a/src/themes/default/components/core/blocks/Microcart/Product.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Product.vue
@@ -65,7 +65,7 @@
           {{ product.priceInclTax * product.qty | price }}
         </span>
       </div>
-      <div class="prices" v-else-if="product.totals && onli">
+      <div class="prices" v-else-if="product.totals">
         <span class="h4 serif cl-error price-special" v-if="product.totals.discount_amount">
           {{ product.totals.row_total_incl_tax - product.totals.discount_amount | price }}&nbsp;
         </span>


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #2898

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

I've changed the `forceClientState` = `true` in case the network mode changed. Now - the client's state cart is pushed and forced to the server when user is entering back the online mode


### Which environment this relates to

Not deployed, please do check on local branch.

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
