### PR TITLE
Load custom fonts without webfont.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added optional attributes to catalog/product.ts - @ZeevGerstner (#2792)
 - Formatted dates in CHANGELOG.md to match ISO standard - @phoenixdev-kl (#2839)
 - Moved Filter Price Ranges (used for ES aggregations and UI Filter) to the config - @jpetar (#2873)
+- Load custom fonts without webfont.js - @jahvi (#2944)
 
 ## [1.9.0] - 2019.05.06
 

--- a/src/themes/default/css/base/_fonts.scss
+++ b/src/themes/default/css/base/_fonts.scss
@@ -1,0 +1,1 @@
+@import url('https://fonts.googleapis.com/css?family=Playfair+Display:400,700|Roboto:400,700|Material+Icons&display=swap');

--- a/src/themes/default/css/main.scss
+++ b/src/themes/default/css/main.scss
@@ -1,3 +1,4 @@
+@import 'base/fonts';
 @import 'vendor/flexboxgrid2';
 
 @import 'variables/variables';

--- a/src/themes/default/templates/index.basic.template.html
+++ b/src/themes/default/templates/index.basic.template.html
@@ -5,22 +5,8 @@
 		{{{ meta.inject().meta.text() }}}
 		<meta name="generator" content="Vue Storefront">
 		{{{ meta.inject().link.text() }}}
-		<script type="text/javascript">
-			WebFontConfig = {
-				google: { families: [ 'Playfair+Display:400,700', 'Roboto:400,700', 'Material+Icons' ] }
-			};
-			(function() {
-				var wf = document.createElement('script');
-				wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
-				'://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js';
-				wf.type = 'text/javascript';
-				wf.async = 'true';
-				var s = document.getElementsByTagName('script')[0];
-				s.parentNode.insertBefore(wf, s);
-			})(); 
-		</script>
 		{{{ renderStyles() }}}
-		{{{ output.appendHead() }}}		
+		{{{ output.appendHead() }}}
 	</head>
   <body>
 		<!--vue-ssr-outlet-->

--- a/src/themes/default/templates/index.template.html
+++ b/src/themes/default/templates/index.template.html
@@ -6,27 +6,13 @@
 		<meta name="generator" content="Vue Storefront">
 		{{{ meta.inject().link.text() }}}
 		{{{ meta.inject().script.text() }}}
-		<script type="text/javascript">
-			WebFontConfig = {
-				google: { families: [ 'Playfair+Display:400,700', 'Roboto:400,700', 'Material+Icons' ] }
-			};
-			(function() {
-				var wf = document.createElement('script');
-				wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
-				'://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js';
-				wf.type = 'text/javascript';
-				wf.async = 'true';
-				var s = document.getElementsByTagName('script')[0];
-				s.parentNode.insertBefore(wf, s);
-			})(); 
-		</script>
 		{{{ renderResourceHints() }}}
 		{{{ renderStyles() }}}
-		{{{ output.appendHead() }}}		
+		{{{ output.appendHead() }}}
 	</head>
   <body>
 		<!--vue-ssr-outlet-->
     {{{ renderState() }}}
-    {{{ renderScripts() }}}		
+    {{{ renderScripts() }}}
   </body>
 </html>


### PR DESCRIPTION
### Related issues
N/A

### Short description and why it's useful
Right now custom google fonts (Playfair Display, Robot and Material Icons) are loaded using webfont.js which is useful because it helps load custom fonts asynchronously and prevent FOUC however it comes at a cost.

I noticed this also run some expensive tasks in the browser that triggers "Style Recalculations" which can be very costly for the browser and one the things [Google recommends minimising](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations).

**Purple spikes = style recalculations**
<img width="1328" alt="Screenshot 2019-05-23 at 9 27 49 pm" src="https://user-images.githubusercontent.com/661330/58284044-b1efcc00-7da1-11e9-9e3a-fbdd93e619f2.png">
_Performance trace (before)_

I replaced this to use a css `@import` which is not the best but I believe with the addition of `font-display: swap` it can help cover the benefits of webfont.js without the processing drawbacks (and also reduces the JS used by ~3%)

**Fewer purple spikes**
<img width="951" alt="Screenshot 2019-05-23 at 9 34 54 pm" src="https://user-images.githubusercontent.com/661330/58284507-a5b83e80-7da2-11e9-914e-8f1009454041.png">
_Performance trace (after)_

It's hard for me to measure the performance benefits with my local server but I noticed around ~10% increase in FP, FCP and FMP. We can include the `@font-face` declarations directly which should help with latency while getting the fonts as well but that's open to discussion.

### Screenshots of visual changes before/after (if there are any)
See above

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
