### PR TITLE
Fix #2933 Configurable Products not accessible in CSR when children visibility set to 'not visible inidividually'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Remove security vulnerabilities by updating project dependencies - @patzick (#2942)
-- Fix Configurable Products not accessible in CSR when children visibility is set to "not visible individually" (#2933) - @revlis-x
+- Fix Configurable Products not accessible in CSR when children visibility is set to "not visible individually" - @revlis-x (#2933)
 
 ## [1.9.0] - 2019.05.06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Remove security vulnerabilities by updating project dependencies - @patzick (#2942)
+- Fix Configurable Products not accessible in CSR when children visibility is set to "not visible individually" (#2933) - @revlis-x
 
 ## [1.9.0] - 2019.05.06
 
@@ -50,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Offline orders with out of stock products don't stack anymore and get canceled after going back to online - @lukeromanowicz (#2740)
 - Build ServiceWorker on Docker - @patzick (#2793)
 - Product image load after comming back to online - @patzick (#2573)
-- Insufficent validation for city field in checkout address - @lromanowicz (#2653) 
+- Insufficent validation for city field in checkout address - @lromanowicz (#2653)
 - Incorrect hover activity on the 'filter by categories' in the search view on mobile - @idodidodi (#2783)
 - Unit tests written in JavaScript now support async/await functions and dynamic import - @michaelKurowski, @lukeromanowicz (#2851)
 

--- a/core/modules/catalog/store/product/actions.ts
+++ b/core/modules/catalog/store/product/actions.ts
@@ -208,7 +208,7 @@ const actions: ActionTree<ProductState, RootState> = {
   },
   /**
    * Load required configurable attributes
-   * @param context 
+   * @param context
    * @param product
    */
   loadConfigurableAttributes(context, { product }) {
@@ -306,7 +306,7 @@ const actions: ActionTree<ProductState, RootState> = {
           }
           if (configuration) {
             let selectedVariant = configureProductAsync(context, { product: product, configuration: configuration, selectDefaultVariant: false })
-            Object.assign(product, selectedVariant)
+            Object.assign(product, omit(selectedVariant, ['visibility']))
           }
           if (product.url_path) {
             rootStore.dispatch('url/registerMapping', {


### PR DESCRIPTION
### Related issues
closes #2933 

### Short description and why it's useful
With this fix, we do not overwrite the Configurable Product visibility with the visibility of its children.

### Which environment this relates to

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

