### PR TITLE
upgrade notes 1.9.1 trouble shooting memory leak

### DIFF
--- a/docs/guide/upgrade-notes/README.md
+++ b/docs/guide/upgrade-notes/README.md
@@ -27,6 +27,8 @@ const module = createModule(moduleConfig)
 ### Troubleshooting 
 - In case of CORS problem after upgrade check your elasticsearch url in config file. Best practice for that change can be found [here](https://github.com/DivanteLtd/vue-storefront/commit/77fc9c2765068303879c75ef9ed4a4b98f6763b6)
 
+- In case of app crashing, especially when opening `vue devtools` in browser, try setting `storeViews.commonCache` to `false`.
+
 ## 1.7 -> 1.8
 Full changelog is available [here](https://github.com/DivanteLtd/vue-storefront/blob/master/CHANGELOG.md)
 


### PR DESCRIPTION
### Short description and why it's useful
After upgrading from 1.8 to 1.9 you may encounter memory leak caused by caching
added info about that to upgrading notes