### PR TITLE
Robots.txt from theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,53 @@ Vue Storefront is a Community effort brought to You by our great Core Team and s
         </a>
 </td>
     <td align="center" valign="middle"> 
+<a href="https://www.novusweb.com/">
+          <img
+            src="https://divante.co/partners/Vue-Storefront/blue_novusweb.png"
+            alt="Novusweb"
+            height="30"
+          >
+        </a>
+</td>
+   <td align="center" valign="middle"> 
+<a href="www.trellis.co">
+          <img
+            src="https://divante.co/partners/Vue-Storefront/trellis.png"
+            alt="Trellis"
+            height="30"
+          >
+        </a>
+</td>
+    </tr>
+      <tr>
+      <td align="center" valign="middle"> 
+<a href="https://ittweb.net/it?utm_source=referral&utm_medium=vsf&utm_campaign=partners">
+          <img
+            src="https://divante.co/partners/Vue-Storefront/ITTweb.png"
+            alt="ITT Web"
+            height="40"
+          >
+        </a>
+</td>
+  <td align="center" valign="middle"> 
+<a href="">
+          <img
+            src=""
+            alt=""
+            height="40"
+          >
+        </a>
+</td>
+     <td align="center" valign="middle"> 
+<a href="">
+          <img
+            src=""
+            alt=""
+            height="40"
+          >
+        </a>
+</td>
+    <td align="center" valign="middle"> 
 <a href="">
           <img
             src=""

--- a/README.md
+++ b/README.md
@@ -735,10 +735,10 @@ Vue Storefront is a Community effort brought to You by our great Core Team and s
         </a>
 </td>
   <td align="center" valign="middle"> 
-<a href="">
+<a href="https://www.yireo.com/">
           <img
-            src=""
-            alt=""
+            src="https://divante.co/partners/Vue-Storefront/yireo-logo-trans-520x520.png"
+            alt="Yireo"
             height="40"
           >
         </a>

--- a/src/server/robots.js
+++ b/src/server/robots.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const themePath = require('../../core/build/theme-path')
-const robots = `${themePath}/assets/robots.txt`
+const robots = `${themePath}/robots.txt`
 
 module.exports = expressApp => {
   expressApp.get('/robots.txt', (req, res) => {

--- a/src/server/robots.js
+++ b/src/server/robots.js
@@ -1,6 +1,14 @@
+const fs = require('fs')
+const themePath = require('../../core/build/theme-path')
+const robots = `${themePath}/assets/robots.txt`
 
-module.exports = (expressApp) => {
+module.exports = expressApp => {
   expressApp.get('/robots.txt', (req, res) => {
-    res.end('User-agent: *\nDisallow: ')
+    if (fs.existsSync(robots)) {
+      res.type('text/plain')
+      res.sendFile(robots)
+    } else {
+      res.end('User-agent: *\nDisallow: ')
+    }
   })
 }


### PR DESCRIPTION
### Related issues
https://github.com/DivanteLtd/vue-storefront/issues/2110

### Short description and why it's useful
It is more flexible to have robots.txt in the theme instead of src/server/robots.js

### Which environment this relates to
- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
