### PR TITLE
Enable choice of transition for Modal content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed product link in wishlist and microcart - @michasik (#2987)
 
 ### Changed / Improved
--
+- Can set transition style for Modal content - @grimasod (#3146)
 
 ## [1.10.0-rc.1] - 2019.06.19
 
@@ -110,8 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Product video - retrieve video id from 'video_id' field (if set) instead of 'id' - @afirlejczyk
 - Webpack config improvement - @yogeshsuhagiya (#2689)
 - BaseSelect input event - @ResuBaka (#2683)
-- Fixed static file handler to immediately return 404 status for missing files - @grimason (#2685)
-- Fixed maxAge Response Header for static files and Content-Type for Service Worker - @grimason (#2686)
+- Fixed static file handler to immediately return 404 status for missing files - @grimasod (#2685)
+- Fixed maxAge Response Header for static files and Content-Type for Service Worker - @grimasod (#2686)
 - Default log verbosity is changed to show only errors - @lromanowicz (#2717)
 - Remembering last search query - @webdiver, @patzick (#2787)
 - Extracted ProductImage component to support faster images loading - @przemyslawspaczek (#2925)

--- a/docs/guide/components/modal.md
+++ b/docs/guide/components/modal.md
@@ -22,10 +22,12 @@ Simple modal component. Visibility of modal container is based on internal state
 
 ### Available props
 
-| Prop  | Type   | Required | Default | Description           |
-| ----- | ------ | -------- | ------- | --------------------- |
-| name  | String | true     |         | Unique name of modal  |
-| delay | Number | false    | 300     | Timeout to show modal |
+| Prop           | Type   | Required | Default        | Description                                |
+| -------------- | ------ | -------- | -------------- | ------------------------------------------ |
+| name           | String | true     |                | Unique name of modal                       |
+| delay          | Number | false    | 300            | Timeout to show modal                      |
+| width          | Number | false    | 0              | Optional fixed width of content, in pixels |
+| transitionName | String | false    | 'fade-in-down' | Content transition style                   |
 
 ### Available Methods
 
@@ -37,3 +39,15 @@ Simple modal component. Visibility of modal container is based on internal state
 ### Styles
 
 Core component doesn't have CSS styles. If you want to see an example of our implementation please look [here](https://github.com/DivanteLtd/vue-storefront/blob/master/src/themes/default/components/core/Modal.vue)
+
+### Transitions
+
+The default theme defines one transition, `fade-in-down`, which can be seen [here](https://github.com/DivanteLtd/vue-storefront/blob/master/src/themes/default/css/animations/_transitions.scss). This is the default value for the `transitionName` prop. Further transitions can be defined in a custom theme by following this example. Vue transitions are explained [here](https://vuejs.org/v2/guide/transitions.html).
+
+To have modal content display immediately, without any transition, just supply an empty string for the `transitionName` prop. For example:
+
+```html
+<modal name="modal-example" transition-name="" :delay="0" :width="600">
+  <!-- modal content goes here -->
+</modal>
+```

--- a/src/themes/default/components/core/Modal.vue
+++ b/src/themes/default/components/core/Modal.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition name="fade-in-down">
+  <transition :name="transitionName">
     <div
       class="modal"
       v-if="isVisible"
@@ -93,6 +93,10 @@ export default {
     width: {
       type: Number,
       default: 0
+    },
+    transitionName: {
+      type: String,
+      default: 'fade-in-down'
     }
   },
   computed: {
@@ -103,7 +107,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import '~theme/css/base/global_vars';
 $z-index-modal: map-get($z-index, modal);
 


### PR DESCRIPTION
Enable choice of transition for Modal content
Also scope Modal scss

### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->


### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Currently the transition style of Modal content is hard-coded to `fade-in-down`. By adding a `transition-name` prop, the transition style can be changed. So, for example, in a modal with an empty `transition-name`,  the content appears immediately, without any transition.

```
<modal name="modal-example" transition-name="" :delay="0" :width="630" :height="750">
```

With `fade-in-down` as the default value of the prop, existing modals won't be affected.

Also in this PR, `scoped` was added to the SCCS tag. All classes are within this component, so this should have no effect, except to prevent accidental scope leakage.

### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
