### PR TITLE
Fix #3102 - Date fitler ignoring format. Use format object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.10.0-rc.2] - UNRELEASED
 
 ### Fixed
-- Fixed wrong meta description attribute by page overwrite - @przspa (#3091) 
+- Fixed wrong meta description attribute by page overwrite - @przspa (#3091)
+- Fixed date filter ignoring format param - @grimasod (#3176)
 
 ## [1.10.0-rc.1] - 2019.06.19
 

--- a/core/filters/date.js
+++ b/core/filters/date.js
@@ -3,9 +3,9 @@ import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 /**
  * Converts date to format provided as an argument or defined in config file (if argument not provided)
  * @param {String} date
- * @param {String} format
+ * @param {Object} format
  */
-export function date (date, format) {
+export function date (date, format = {}) {
   const storeView = currentStoreView()
-  return new Date(date).toLocaleString(storeView.i18n.defaultLocale)
+  return new Date(date).toLocaleString(storeView.i18n.defaultLocale, format)
 }

--- a/core/filters/date.js
+++ b/core/filters/date.js
@@ -3,9 +3,46 @@ import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 /**
  * Converts date to format provided as an argument or defined in config file (if argument not provided)
  * @param {String} date
- * @param {Object} format
+ * @param {String} format
  */
-export function date (date, format = {}) {
+export function date (date, format = '') {
   const storeView = currentStoreView()
-  return new Date(date).toLocaleString(storeView.i18n.defaultLocale, format)
+  let options = {}
+  switch (format) {
+    case 'LT':
+      options = {hour: 'numeric', minute: 'numeric'}
+      break
+    case 'LTS':
+      options = {hour: 'numeric', minute: 'numeric', second: 'numeric'}
+      break
+    case 'L':
+      options = {year: 'numeric', month: '2-digit', day: '2-digit'}
+      break
+    case 'l':
+      options = {year: 'numeric', month: 'numeric', day: 'numeric'}
+      break
+    case 'LL':
+      options = {year: 'numeric', month: 'long', day: 'numeric'}
+      break
+    case 'll':
+      options = {year: 'numeric', month: 'short', day: 'numeric'}
+      break
+    case 'LLL':
+      options = {year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric'}
+      break
+    case 'lll':
+      options = {year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric'}
+      break
+    case 'LLLL':
+      options = {year: 'numeric', month: 'long', day: 'numeric', weekday: 'long', hour: 'numeric', minute: 'numeric'}
+      break
+    case 'llll':
+      options = {year: 'numeric', month: 'short', day: 'numeric', weekday: 'short', hour: 'numeric', minute: 'numeric'}
+      break
+    default:
+      // use empty object
+  }
+  console.log(format)
+  console.log(options)
+  return new Date(date).toLocaleString(storeView.i18n.defaultLocale, options)
 }

--- a/src/themes/default/components/core/blocks/MyAccount/MyOrder.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyOrder.vue
@@ -17,7 +17,7 @@
     <!-- My order body -->
     <div class="row fs16 mb20">
       <div class="col-xs-12 h4">
-        <p>{{ order.created_at | date('MMMM D, YYYY') }}</p>
+        <p>{{ order.created_at | date({year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric'}) }}</p>
         <p class="mt35">
           <a href="#" class="underline" @click.prevent="remakeOrder(skipGrouped(order.items))">{{ $t('Remake order') }}</a>
         </p>

--- a/src/themes/default/components/core/blocks/MyAccount/MyOrder.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyOrder.vue
@@ -17,7 +17,7 @@
     <!-- My order body -->
     <div class="row fs16 mb20">
       <div class="col-xs-12 h4">
-        <p>{{ order.created_at | date({year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric'}) }}</p>
+        <p>{{ order.created_at | date('LLL') }}</p>
         <p class="mt35">
           <a href="#" class="underline" @click.prevent="remakeOrder(skipGrouped(order.items))">{{ $t('Remake order') }}</a>
         </p>


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3102

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Date filter was not using format. Now uses a format object. Applied to default theme Order details view.

### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

Before
<img width="879" alt="Screen Shot 2019-07-04 at 11 11 11 AM" src="https://user-images.githubusercontent.com/29225088/60636082-0467e200-9e50-11e9-8e32-a807c8459e36.png">

After
<img width="873" alt="Screen Shot 2019-07-04 at 11 10 07 AM" src="https://user-images.githubusercontent.com/29225088/60636087-0af65980-9e50-11e9-9c78-ead5b2ded679.png">


### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
