### PR TITLE
add single choice filter variant and set price to that

### DIFF
--- a/core/modules/catalog-next/helpers/filterHelpers.ts
+++ b/core/modules/catalog-next/helpers/filterHelpers.ts
@@ -19,10 +19,14 @@ export const changeFilterQuery = ({currentQuery = {}, filterVariant}: {currentQu
     if (!Array.isArray(queryFilter)) queryFilter = [queryFilter]
     if (queryFilter.includes(filterVariant.id)) {
       queryFilter = queryFilter.filter(value => value !== filterVariant.id)
+    } else if (filterVariant.single) {
+      queryFilter = [filterVariant.id]
     } else {
       queryFilter.push(filterVariant.id)
     }
-    newQuery[filterVariant.type] = queryFilter
+    // delete or add filter variant to query
+    if (!queryFilter.length) delete newQuery[filterVariant.type]
+    else newQuery[filterVariant.type] = queryFilter
   }
   return newQuery
 }

--- a/core/modules/catalog-next/store/category/getters.ts
+++ b/core/modules/catalog-next/store/category/getters.ts
@@ -62,7 +62,8 @@ const getters: GetterTree<CategoryState, RootState> = {
                 type: attrToFilter,
                 from: option.from,
                 to: option.to,
-                label: (index === 0 || (index === count - 1)) ? (option.to ? '< ' + currencySign + option.to : '> ' + currencySign + option.from) : currencySign + option.from + (option.to ? ' - ' + option.to : '')// TODO: add better way for formatting, extract currency sign
+                label: (index === 0 || (index === count - 1)) ? (option.to ? '< ' + currencySign + option.to : '> ' + currencySign + option.from) : currencySign + option.from + (option.to ? ' - ' + option.to : ''), // TODO: add better way for formatting, extract currency sign
+                single: true
               })
               index++
             }

--- a/core/modules/catalog-next/test/unit/changeFilterQuery.spec.ts
+++ b/core/modules/catalog-next/test/unit/changeFilterQuery.spec.ts
@@ -5,73 +5,120 @@ describe('changeFilterQuery method', () => {
   it('should not change query when no filter variant provided', () => {
     const currentQuery = {
       color: 1
-    }
-    const result = changeFilterQuery({currentQuery})
-    expect(result).toEqual(currentQuery)
-  })
+    };
+    const result = changeFilterQuery({ currentQuery });
+    expect(result).toEqual(currentQuery);
+  });
 
   it('should not return same query object instance', () => {
     const currentQuery = {
       color: 1
-    }
-    const result = changeFilterQuery({currentQuery})
-    expect(result).not.toBe(currentQuery)
+    };
+    const result = changeFilterQuery({ currentQuery });
+    expect(result).not.toBe(currentQuery);
   });
 
   it('should add filter to array', () => {
-    const currentQuery = {}
+    const currentQuery = {};
     const filterVariant: FilterVariant = {
       id: '33',
       label: 'Red',
       type: 'color'
-    }
-    const result = changeFilterQuery({currentQuery, filterVariant})
-    expect(result).toEqual({color: ['33']})
+    };
+    const result = changeFilterQuery({ currentQuery, filterVariant });
+    expect(result).toEqual({ color: ['33'] });
   });
 
   it('should remove filter if exist in query', () => {
     const currentQuery = {
       color: ['23', '33']
-    }
+    };
     const filterVariant: FilterVariant = {
       id: '33',
       label: 'Red',
       type: 'color'
-    }
-    const result = changeFilterQuery({currentQuery, filterVariant})
-    expect(result).toEqual({color: ['23']})
+    };
+    const result = changeFilterQuery({ currentQuery, filterVariant });
+    expect(result).toEqual({ color: ['23'] });
   });
 
   it('should add sort filter', () => {
-    const currentQuery = {}
+    const currentQuery = {};
     const filterVariant: FilterVariant = {
       id: 'final_price',
       label: 'Price: Low to high',
       type: 'sort'
-    }
-    const result = changeFilterQuery({currentQuery, filterVariant})
-    expect(result).toEqual({sort: 'final_price'})
+    };
+    const result = changeFilterQuery({ currentQuery, filterVariant });
+    expect(result).toEqual({ sort: 'final_price' });
   });
 
   it('should remove sort filter', () => {
-    const currentQuery = {sort: 'final_price'}
+    const currentQuery = { sort: 'final_price' };
     const filterVariant: FilterVariant = {
       id: 'final_price',
       label: 'Price: Low to high',
       type: 'sort'
-    }
-    const result = changeFilterQuery({currentQuery, filterVariant})
-    expect(result).toEqual({})
+    };
+    const result = changeFilterQuery({ currentQuery, filterVariant });
+    expect(result).toEqual({});
   });
 
   it('should change sort filter', () => {
-    const currentQuery = {sort: 'final_price'}
+    const currentQuery = { sort: 'final_price' };
     const filterVariant: FilterVariant = {
       id: 'updated_at',
       label: 'Latest',
       type: 'sort'
-    }
-    const result = changeFilterQuery({currentQuery, filterVariant})
-    expect(result).toEqual({sort: 'updated_at'})
+    };
+    const result = changeFilterQuery({ currentQuery, filterVariant });
+    expect(result).toEqual({ sort: 'updated_at' });
   });
-})
+
+  it('should add single filter when there is none', () => {
+    const currentQuery = {
+    };
+    const filterVariant: FilterVariant = {
+      id: '50.0-100.0',
+      type: 'price',
+      from: '50',
+      to: '100',
+      label: '$50 - 100',
+      single: true
+    };
+    const result = changeFilterQuery({ currentQuery, filterVariant });
+    expect(result).toEqual({ price: ['50.0-100.0'] });
+  });
+
+  it('should remove single filter when adding is the same', () => {
+    const currentQuery = {
+      price: ['50.0-100.0']
+    };
+    const filterVariant: FilterVariant = {
+      id: '50.0-100.0',
+      type: 'price',
+      from: '50',
+      to: '100',
+      label: '$50 - 100',
+      single: true
+    };
+    const result = changeFilterQuery({ currentQuery, filterVariant });
+    expect(result).toEqual({});
+  });
+
+  it('should change single filter when adding another single', () => {
+    const currentQuery = {
+      price: ['100.0-150.0']
+    };
+    const filterVariant: FilterVariant = {
+      id: '50.0-100.0',
+      type: 'price',
+      from: '50',
+      to: '100',
+      label: '$50 - 100',
+      single: true
+    };
+    const result = changeFilterQuery({ currentQuery, filterVariant });
+    expect(result).toEqual({ price: ['50.0-100.0'] });
+  });
+});

--- a/core/modules/catalog-next/types/FilterVariant.ts
+++ b/core/modules/catalog-next/types/FilterVariant.ts
@@ -3,5 +3,6 @@ export default interface FilterVariant {
   label: string,
   type: string,
   from?: string,
-  to?: string
+  to?: string,
+  single?: boolean
 }


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3163

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Added single filter option and used it for pricing.
In order to discussions this is best way, if ranges should be dynamic, then theme should have range slider or inputs for values in it.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change
