### PR TITLE
BUGFIX check for different spelling of session outdated exceptions on…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.3] 
+
+### Fixed
+- Check for differend spelling of session outdated exceptions on Magento Side - @danielmaier42 (#3178 + #3151)
+
 ## [1.9.2] - 2019.06.10
 
 ### Fixed

--- a/core/lib/sync/task.ts
+++ b/core/lib/sync/task.ts
@@ -65,7 +65,12 @@ function _internalExecute (resolve, reject, task: Task, currentToken, currentCar
     if (jsonResponse) {
       if (parseInt(jsonResponse.code) !== 200) {
         let resultString = jsonResponse.result ? toString(jsonResponse.result) : null
-        if (resultString && (resultString.indexOf(i18n.t('not authorized')) >= 0 || resultString.indexOf('not authorized')) >= 0 && currentToken !== null) { // the token is no longer valid, try to invalidate it
+        if (resultString && currentToken !== null && (
+          resultString.indexOf(i18n.t('not authorized')) >= 0 ||
+          resultString.indexOf('not authorized') >= 0 ||
+          resultString.indexOf(i18n.t('isn\'t authorized')) >= 0 ||
+          resultString.indexOf('isn\'t authorized') >= 0)) {
+          // the token is no longer valid, try to invalidate it
           Logger.error('Invalid token - need to be revalidated' + currentToken + task.url + rootStore.state.userTokenInvalidateLock, 'sync')()
           if (isNaN(rootStore.state.userTokenInvalidateAttemptsCount) || isUndefined(rootStore.state.userTokenInvalidateAttemptsCount)) rootStore.state.userTokenInvalidateAttemptsCount = 0
           if (isNaN(rootStore.state.userTokenInvalidateLock) || isUndefined(rootStore.state.userTokenInvalidateLock)) rootStore.state.userTokenInvalidateLock = 0


### PR DESCRIPTION
… magento-side

### Related issues
closes #3178 
closes #3151 

### Short description and why it's useful
As mentioned by nikblack on Issue #3151 and @pkarw on #3178 the token auto refreshing cannot work when the wrong string is checked. Therefore i am submitting this pull request which compares the message not just with "not authorized" (backward compatibility) but also against "isn't authorized".

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module

@pkarw - could you please check? 🙂 