### PR TITLE
fix configurable options label in cart after product just added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ value); `final_price` might been used along with `special_price` with Magento fo
 - Make image proxy url work with relative base url - @cewald (#3158)
 - Fixed memory leak with enabled dynamicConfigReload - @dimasch (#3075)
 - Fixed error for the orderhistory null for google-tag-manager extension - @cnviradiya (#3195)
+- Fixed label of configurable options in cart after product just added - @cheeerd (#3164)
 
 ### Changed / Improved
 - Shipping address is saved as default when not logged in user chooses to create account during checkout - @iwonapiotrowska (#2636)

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -377,13 +377,13 @@ export function setConfigurableProductOptionsAsync (context, { product, configur
           existingOption = {
             option_id: option.attribute_id,
             option_value: configOption.id,
-            label: i18n.t(configOption.attribute_code),
+            label: option.label || i18n.t(configOption.attribute_code),
             value: configOption.label
           }
           configurable_item_options.push(existingOption)
         }
         existingOption.option_value = configOption.id
-        existingOption.label = i18n.t(configOption.attribute_code)
+        existingOption.label = option.label || i18n.t(configOption.attribute_code)
         existingOption.value = configOption.label
       }
     }


### PR DESCRIPTION
### Related issues
#3164

### Short description and why it's useful
When product have been just added to cart, attribute code was printed instead of attribute label in configurable product's options in cart.

### Screenshots of visual changes before/after (if there are any)
Before:
![image](https://user-images.githubusercontent.com/21987340/61042323-a6ea0d00-a3dc-11e9-90e7-c07979c8dd5a.png)
It is easy to see if emulate slow 3g connection in browser.

### Which environment this relates to

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature