### PR TITLE
Add debounce for updating quantity method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Translation file improvements - @vishal-7037 (#3198)
 - Added configuration for max attempt task & cart by pass - @cnviradiya (#3193)
 - Added catching of errors when ES is down - @qiqqq
+- Added debounce for updating quantity method in the cart - @andrzejewsky (#3233)
 
 ## [1.10.0-rc.2] - UNRELEASED
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Translation file improvements - @vishal-7037 (#3198)
 - Added configuration for max attempt task & cart by pass - @cnviradiya (#3193)
 - Added catching of errors when ES is down - @qiqqq
-- Added debounce for updating quantity method in the cart - @andrzejewsky (#3233)
+- Added debounce for updating quantity method in the cart - @andrzejewsky (#3191)
 
 ## [1.10.0-rc.2] - UNRELEASED
 

--- a/core/compatibility/components/blocks/Microcart/Product.js
+++ b/core/compatibility/components/blocks/Microcart/Product.js
@@ -1,6 +1,7 @@
 import { MicrocartProduct } from '@vue-storefront/core/modules/cart/components/Product.ts'
 import i18n from '@vue-storefront/i18n'
 import config from 'config'
+import debounce from 'lodash-es/debounce'
 
 export default {
   data () {
@@ -12,11 +13,13 @@ export default {
     // deprecated, will be moved to theme or removed in the near future #1742
     this.$bus.$on('cart-after-itemchanged', this.onProductChanged)
     this.$bus.$on('notification-after-itemremoved', this.onProductRemoved)
+    this.updateQuantity = debounce(this.updateQuantity, 5000)
   },
   beforeDestroy () {
     // deprecated, will be moved to theme or removed in the near future #1742
     this.$bus.$off('cart-after-itemchanged', this.onProductChanged)
     this.$bus.$off('notification-after-itemremoved', this.onProductRemoved)
+    this.updateQuantity.cancel()
   },
   methods: {
     removeItem () {


### PR DESCRIPTION
### Related issues
closes #3191

### Short description and why it's useful
It limits number of calls/sync for updating quantity.

### Which environment this relates to
- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
