### PR TITLE
Add multiple bundle products in the cart

### DIFF
--- a/core/modules/cart/helpers/index.ts
+++ b/core/modules/cart/helpers/index.ts
@@ -1,0 +1,13 @@
+import { cartCacheHandlerFactory } from './cartCacheHandler'
+import optimizeProduct from './optimizeProduct'
+import prepareProductsToAdd from './prepareProductsToAdd'
+import productChecksum from './productChecksum'
+import productsEquals from './productsEquals'
+
+export {
+  cartCacheHandlerFactory,
+  optimizeProduct,
+  prepareProductsToAdd,
+  productChecksum,
+  productsEquals
+}

--- a/core/modules/cart/helpers/optimizeProduct.ts
+++ b/core/modules/cart/helpers/optimizeProduct.ts
@@ -1,8 +1,9 @@
+import CartItem from '@vue-storefront/core/modules/cart/types/CartItem'
 import config from 'config'
 import omit from 'lodash-es/omit'
 import pullAll from 'lodash-es/pullAll'
 
-const optimizeProduct = (product) => {
+const optimizeProduct = (product: CartItem): CartItem => {
   let fieldsToOmit = config.entities.optimizeShoppingCartOmitFields
 
   if (config.cart.productsAreReconfigurable) {

--- a/core/modules/cart/helpers/prepareProductsToAdd.ts
+++ b/core/modules/cart/helpers/prepareProductsToAdd.ts
@@ -1,0 +1,18 @@
+import CartItem from '@vue-storefront/core/modules/cart/types/CartItem'
+import productChecksum from './productChecksum'
+
+const prepareProductsToAdd = (product: CartItem): CartItem[] => {
+  if (product.type_id === 'grouped') {
+    return product.product_links
+      .filter(p => p.link_type === 'associated')
+      .map(p => p.product)
+  }
+
+  if (product.type_id === 'bundle') {
+    product.checksum = productChecksum(product)
+  }
+
+  return [product]
+}
+
+export default prepareProductsToAdd

--- a/core/modules/cart/helpers/productChecksum.ts
+++ b/core/modules/cart/helpers/productChecksum.ts
@@ -1,0 +1,22 @@
+import CartItem from '@vue-storefront/core/modules/cart/types/CartItem'
+import { sha3_224 } from 'js-sha3'
+
+const getDataToHash = (product: CartItem): any => {
+  if (!product.product_option) {
+    return null
+  }
+
+  const { extension_attributes } = product.product_option
+
+  if (extension_attributes.bundle_options) {
+    const { bundle_options } = extension_attributes
+    return Array.isArray(bundle_options) ? bundle_options : Object.values(bundle_options)
+  }
+
+  return product.product_option
+}
+
+const productChecksum = (product: CartItem): string =>
+  sha3_224(JSON.stringify(getDataToHash(product)))
+
+export default productChecksum

--- a/core/modules/cart/helpers/productsEquals.ts
+++ b/core/modules/cart/helpers/productsEquals.ts
@@ -1,0 +1,35 @@
+import CartItem from '@vue-storefront/core/modules/cart/types/CartItem'
+import productChecksum from './productChecksum';
+
+const getChecksum = (product: CartItem) => {
+  if (product.checksum) {
+    return product.checksum
+  }
+
+  return productChecksum(product)
+}
+
+const getProductType = (product: CartItem): string =>
+  product.type_id || product.product_type
+
+const getServerItemId = (product: CartItem): number =>
+  product.server_item_id || product.item_id
+
+const isServerIdsEquals = (product1: CartItem, product2: CartItem): boolean =>
+  getServerItemId(product1) === getServerItemId(product2)
+
+const isChecksumEquals = (product1: CartItem, product2: CartItem): boolean =>
+  getChecksum(product1) === getChecksum(product2)
+
+const productsEquals = (product1: CartItem, product2: CartItem): boolean => {
+  const typeProduct1 = getProductType(product1)
+  const typeProduct2 = getProductType(product2)
+
+  if (typeProduct1 === 'bundle' || typeProduct2 === 'bundle') {
+    return isServerIdsEquals(product1, product2) || isChecksumEquals(product1, product2)
+  }
+
+  return product1.sku === product2.sku
+}
+
+export default productsEquals

--- a/core/modules/cart/index.ts
+++ b/core/modules/cart/index.ts
@@ -1,6 +1,6 @@
 import { StorefrontModule } from '@vue-storefront/core/lib/modules'
 import { cartStore } from './store'
-import { cartCacheHandlerFactory } from './helpers/cartCacheHandler';
+import { cartCacheHandlerFactory } from './helpers';
 import { isServer } from '@vue-storefront/core/helpers'
 import Vue from 'vue'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -16,7 +16,7 @@ import Task from '@vue-storefront/core/lib/sync/types/Task'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import { configureProductAsync } from '@vue-storefront/core/modules/catalog/helpers'
-import optimizeProduct from './../helpers/optimizeProduct'
+import { optimizeProduct, prepareProductsToAdd, productsEquals } from './../helpers'
 
 let _connectBypassCount = 0
 
@@ -263,21 +263,15 @@ const actions: ActionTree<CartState, RootState> = {
     }
   },
   /** Get one single item from the client's cart */
-  getItem ({ getters }, sku) {
-    return getters.getCartItems.find(p => p.sku === sku)
+  getItem ({ getters }, { product }) {
+    return getters.getCartItems.find(p => productsEquals(p, product))
   },
   goToCheckout () {
     router.push(localizedRoute('/checkout', currentStoreView().storeCode))
   },
   /** add item to the client's cart + sync with server if enabled @description this method is part of "public" cart API */
   async addItem ({ dispatch }, { productToAdd, forceServerSilence = false }) {
-    let productsToAdd = []
-    if (productToAdd.type_id === 'grouped') { // TODO: add bundle support
-      productsToAdd = productToAdd.product_links.filter((pl) => { return pl.link_type === 'associated' }).map((pl) => { return pl.product })
-    } else {
-      productsToAdd.push(productToAdd)
-    }
-    return dispatch('addItems', { productsToAdd: productsToAdd, forceServerSilence })
+    return dispatch('addItems', { productsToAdd: prepareProductsToAdd(productToAdd), forceServerSilence })
   },
   /** add multiple items to the client's cart and execute single sync with the server when needed  @description this method is part of "public" cart API */
   async addItems ({ commit, dispatch, getters }, { productsToAdd, forceServerSilence = false }) {
@@ -314,7 +308,7 @@ const actions: ActionTree<CartState, RootState> = {
           continue
         }
       }
-      const record = getters.getCartItems.find(p => p.sku === product.sku)
+      const record = getters.getCartItems.find(p => productsEquals(p, product))
       const result = await dispatch('stock/queueCheck', { product: product, qty: record ? record.qty + 1 : (product.qty ? product.qty : 1) }, {root: true}) // queueCheck returns control immediately and checks in the background; returning just the cached stock data; we're using it because cart/sync checks the stock anyway; but if cart.synchronize is disabeld or offline mode is enabled then this queued check could be usefull there is also `stock/check` actions that returns the exact values
       product.onlineStockCheckid = result.onlineCheckTaskId // used to get the online check result
       if (result.status === 'volatile') {
@@ -366,8 +360,9 @@ const actions: ActionTree<CartState, RootState> = {
     let product = payload
     if (payload.product) { // new call format since 1.4
       product = payload.product
-      removeByParentSku = payload.removeByParentSku
+      removeByParentSku = !!payload.removeByParentSku && payload.product.type_id !== 'bundle'
     }
+
     commit(types.CART_DEL_ITEM, { product, removeByParentSku })
     if (getters.isCartSyncEnabled && product.server_item_id) {
       return dispatch('sync', { forceClientState: true })
@@ -588,7 +583,16 @@ const actions: ActionTree<CartState, RootState> = {
     /** helper - sub method to update the item in the cart */
     const _updateClientItem = async function ({ dispatch }, event, clientItem) {
       if (typeof event.result.item_id !== 'undefined') {
-        await dispatch('updateItem', { product: { server_item_id: event.result.item_id, sku: clientItem.sku, server_cart_id: event.result.quote_id, prev_qty: clientItem.qty } }) // update the server_id reference
+        const product = {
+          server_item_id: event.result.item_id,
+          sku: clientItem.sku,
+          server_cart_id: event.result.quote_id,
+          prev_qty: clientItem.qty,
+          product_option: event.result.product_option,
+          type_id: event.result.product_type
+        }
+
+        await dispatch('updateItem', { product }) // update the server_id reference
         EventBus.$emit('cart-after-itemchanged', { item: clientItem })
       }
     }
@@ -602,7 +606,7 @@ const actions: ActionTree<CartState, RootState> = {
         if (!serverItem) {
           commit(types.CART_DEL_ITEM, { product: clientItem, removeByParentSku: false })
         } else if (clientItem.item_id) {
-          dispatch('getItem', clientItem.sku).then((cartItem) => {
+          dispatch('getItem', clientItem).then((cartItem) => {
             if (cartItem) {
               Logger.log('Restoring qty after error' + clientItem.sku + cartItem.prev_qty, 'cart')()
               if (cartItem.prev_qty > 0) {
@@ -637,7 +641,7 @@ const actions: ActionTree<CartState, RootState> = {
         }
       }
       if (clientItem === null) {
-        const cartItem = await dispatch('getItem', event.result.sku)
+        const cartItem = await dispatch('getItem', event.result)
         if (cartItem) {
           await _updateClientItem({ dispatch }, event, cartItem)
         }
@@ -647,9 +651,8 @@ const actions: ActionTree<CartState, RootState> = {
     }
     for (const clientItem of clientItems) {
       cartHasItems = true
-      const serverItem = serverItems.find((itm) => {
-        return itm.sku === clientItem.sku || itm.sku.indexOf(clientItem.sku + '-') === 0 /* bundle products */
-      })
+
+      const serverItem = serverItems.find(itm => productsEquals(itm, clientItem))
 
       if (!serverItem) {
         Logger.warn('No server item with sku ' + clientItem.sku + ' on stock.', 'cart')()
@@ -700,16 +703,22 @@ const actions: ActionTree<CartState, RootState> = {
       } else {
         Logger.info('Server and client item with SKU ' + clientItem.sku + ' synced. Updating cart.', 'cart', 'cart')()
         if (!dryRun) {
-          await dispatch('updateItem', { product: { sku: clientItem.sku, server_cart_id: serverItem.quote_id, server_item_id: serverItem.item_id, product_option: serverItem.product_option } })
+          await dispatch('updateItem', {
+            product: {
+              sku: clientItem.sku,
+              server_cart_id: serverItem.quote_id,
+              server_item_id: serverItem.item_id,
+              product_option: serverItem.product_option,
+              type_id: serverItem.product_type
+            }
+          })
         }
       }
     }
 
     for (const serverItem of serverItems) {
       if (serverItem) {
-        const clientItem = clientItems.find((itm) => {
-          return itm.sku === serverItem.sku || serverItem.sku.indexOf(itm.sku + '-') === 0 /* bundle products */
-        })
+        const clientItem = clientItems.find(itm => productsEquals(itm, serverItem))
         if (!clientItem) {
           Logger.info('No client item for' + serverItem.sku, 'cart')()
           diffLog.items.push({ 'party': 'client', 'sku': serverItem.sku, 'status': 'no-item' })

--- a/core/modules/cart/test/unit/helpers/prepareProductsToAdd.spec.ts
+++ b/core/modules/cart/test/unit/helpers/prepareProductsToAdd.spec.ts
@@ -1,0 +1,28 @@
+import CartItem from '@vue-storefront/core/modules/cart/types/CartItem'
+import prepareProductsToAdd from './../../../helpers/prepareProductsToAdd';
+
+jest.mock('@vue-storefront/core/modules/cart/helpers/productChecksum', () => () => 'some checksum')
+
+const createProduct = ({ type_id }): CartItem => ({
+  type_id,
+  product_links: [
+    {
+      link_type: 'associated',
+      product: {
+        sku: 'SK-001'
+      }
+    }
+  ]
+} as any as CartItem)
+
+describe('Cart prepareProductsToAdd', () => {
+  it('returns associated products', async () => {
+    const product = createProduct({ type_id: 'grouped' })
+    expect(prepareProductsToAdd(product)).toEqual([{ sku: 'SK-001' }])
+  });
+
+  it('returns products with checksum applied', async () => {
+    const product = createProduct({ type_id: 'bundle' })
+    expect(prepareProductsToAdd(product)).toEqual([{ ...product, checksum: 'some checksum' }])
+  });
+});

--- a/core/modules/cart/test/unit/helpers/productChecksum.spec.ts
+++ b/core/modules/cart/test/unit/helpers/productChecksum.spec.ts
@@ -1,0 +1,58 @@
+import CartItem from '@vue-storefront/core/modules/cart/types/CartItem'
+import productChecksum from './../../../helpers/productChecksum';
+
+const configurableProduct: CartItem = {
+  product_option: {
+    extension_attributes: {
+      configurable_item_options: [
+        {
+          option_id: '93',
+          option_value: 53
+        },
+        {
+          option_id: '142',
+          option_value: 169
+        }
+      ]
+    }
+  }
+} as any as CartItem;
+
+const bundleProduct: CartItem = {
+  product_option: {
+    extension_attributes: {
+      bundle_options: [
+        {
+          option_id: 1,
+          option_qty: 1,
+          option_selections: [2]
+        },
+        {
+          option_id: 2,
+          option_qty: 1,
+          option_selections: [4]
+        },
+        {
+          option_id: 3,
+          option_qty: 1,
+          option_selections: [5]
+        },
+        {
+          option_id: 4,
+          option_qty: 1,
+          option_selections: [8]
+        }
+      ]
+    }
+  }
+} as any as CartItem;
+
+describe('Cart productChecksum', () => {
+  it('returns checksum for bundle product', async () => {
+    expect(productChecksum(bundleProduct)).toBe('d8ba5d5baf59fe28647d6a08fdaeb683a7b39ccdebc77eecabc6457c');
+  });
+
+  it('returns checksum for configurable product', async () => {
+    expect(productChecksum(configurableProduct)).toBe('0bbb27ec7a3cb5dfd1d3f6c4ee54c8b522c4063fe6ea0571794d446f');
+  });
+});

--- a/core/modules/cart/test/unit/helpers/productEquals.spec.ts
+++ b/core/modules/cart/test/unit/helpers/productEquals.spec.ts
@@ -1,0 +1,88 @@
+import CartItem from '@vue-storefront/core/modules/cart/types/CartItem'
+import productsEquals from './../../../helpers/productsEquals';
+
+const createBundleOptions = (options) => {
+  if (!options) {
+    return []
+  }
+
+  return [
+    {
+      option_id: 1,
+      option_qty: 1
+    },
+    {
+      option_id: 2,
+      option_qty: 1
+    },
+    {
+      option_id: 3,
+      option_qty: 1
+    },
+    {
+      option_id: 4,
+      option_qty: 1
+    }
+  ].map((o, index) => ({ ...o, option_selections: [options[index]] }))
+}
+
+const createBundleProduct = ({ id, sku, type_id, options }): CartItem => ({
+  sku,
+  type_id,
+  server_item_id: id,
+  product_option: {
+    extension_attributes: {
+      bundle_options: createBundleOptions(options)
+    }
+  }
+} as any as CartItem)
+
+const createConfigurableProduct = ({ id, sku }): CartItem => ({
+  sku,
+  type_id: 'configurable',
+  server_item_id: id,
+  product_option: {
+    extension_attributes: {
+      configurable_item_options: [
+        {
+          option_id: '93',
+          option_value: 53
+        },
+        {
+          option_id: '142',
+          option_value: 169
+        }
+      ]
+    }
+  }
+} as any as CartItem)
+
+describe('Cart productEquals', () => {
+  it('returns true because bundle products have the same options selected', async () => {
+    const product1 = createBundleProduct({ id: 1, sku: 'WG-001', type_id: 'bundle', options: [2, 4, 5, 8] })
+    const product2 = createBundleProduct({ id: 2, sku: 'WG-001', type_id: 'bundle', options: [2, 4, 5, 8] })
+
+    expect(productsEquals(product1, product2)).toBeTruthy()
+  });
+
+  it('returns false because bundle products have not the same options selected', async () => {
+    const product1 = createBundleProduct({ id: 1, sku: 'WG-001', type_id: 'bundle', options: [2, 2, 5, 8] })
+    const product2 = createBundleProduct({ id: 2, sku: 'WG-001', type_id: 'bundle', options: [2, 4, 5, 8] })
+
+    expect(productsEquals(product1, product2)).toBeFalsy()
+  });
+
+  it('returns true because bundle products have the same server id', async () => {
+    const product1 = createBundleProduct({ id: 1, sku: 'WG-001', type_id: 'bundle', options: null })
+    const product2 = createBundleProduct({ id: 1, sku: 'WG-001', type_id: 'none', options: [2, 4, 5, 8] })
+
+    expect(productsEquals(product1, product2)).toBeTruthy()
+  });
+
+  it('returns true because configurable products have the same eku', async () => {
+    const product1 = createConfigurableProduct({ id: 1, sku: 'WG-001' })
+    const product2 = createConfigurableProduct({ id: 2, sku: 'WG-001' })
+
+    expect(productsEquals(product1, product2)).toBeTruthy()
+  });
+});

--- a/core/modules/cart/types/CartItem.ts
+++ b/core/modules/cart/types/CartItem.ts
@@ -8,5 +8,8 @@ export default interface CartItem extends Product {
   options: CartItemOption[],
   totals: CartItemTotals,
   server_item_id: number,
-  server_cart_id: any
+  server_cart_id: any,
+  product_type?: string,
+  item_id?: number,
+  checksum?: string
 }

--- a/core/modules/catalog/components/ProductBundleOptions.ts
+++ b/core/modules/catalog/components/ProductBundleOptions.ts
@@ -63,7 +63,7 @@ export const ProductBundleOptions = {
     },
     optionChanged ({fieldName, option, qty, value}) {
       if (!fieldName) return
-      this.setBundleOptionValue({ optionId: option.option_id, optionQty: parseInt(qty), optionSelections: [value.id] })
+      this.setBundleOptionValue({ optionId: option.option_id, optionQty: parseInt(qty), optionSelections: [parseInt(value.id)] })
       this.$store.dispatch('product/setBundleOptions', { product: this.product, bundleOptions: this.$store.state.product.current_bundle_options }) // TODO: move it to "AddToCart"
       this.selectedOptions[fieldName] = {qty, value}
       const valueId = value ? value.id : null

--- a/core/modules/catalog/store/stock/actions.ts
+++ b/core/modules/catalog/store/stock/actions.ts
@@ -83,7 +83,7 @@ const actions: ActionTree<StockState, RootState> = {
   async stockAfterCheck (context, event) {
     setTimeout(async () => {
       // TODO: Move to cart module
-      const cartItem: any = await context.dispatch('cart/getItem', event.product_sku, { root: true })
+      const cartItem: any = await context.dispatch('cart/getItem', { product: { sku: event.product_sku } }, { root: true })
       if (cartItem && event.result.code !== 'ENOTFOUND') {
         if (!event.result.is_in_stock) {
           if (!config.stock.allowOutOfStockInCart && !config.cart.synchronize) { // if config.cart.synchronize is true then - the items are being removed by the result of cart/update action executed from cart/sync

--- a/src/themes/default/components/core/Overlay.vue
+++ b/src/themes/default/components/core/Overlay.vue
@@ -20,6 +20,7 @@ export default {
       this.$store.commit('ui/setWishlist', false)
       this.$store.commit('ui/setSearchpanel', false)
       this.$store.commit('ui/setSidebar', false)
+      this.$store.dispatch('themeCart/closeEditMode')
     }
   }
 }

--- a/src/themes/default/components/core/blocks/Microcart/Microcart.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Microcart.vue
@@ -5,7 +5,7 @@
     data-testid="microcart"
   >
     <transition name="fade">
-      <div v-if="isEditMode" class="overlay" />
+      <div v-if="isEditMode" class="overlay" @click="closeEditMode" />
     </transition>
     <div class="row bg-cl-primary px40 actions">
       <div class="col-xs end-xs">
@@ -49,7 +49,7 @@
       {{ $t('to find something beautiful for You!') }}
     </div>
     <ul v-if="productsInCart.length" class="bg-cl-primary m0 px40 pb40 products">
-      <product v-for="product in productsInCart" :key="product.sku" :product="product" />
+      <product v-for="product in productsInCart" :key="product.checksum || product.sku" :product="product" />
     </ul>
     <div v-if="productsInCart.length" class="summary px40 cl-accent serif">
       <h3 class="m0 pt40 mb30 weight-400 summary-heading">

--- a/src/themes/default/components/core/blocks/Microcart/Product.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Product.vue
@@ -85,7 +85,7 @@
           </div>
           <div class="prices" v-else>
             <span class="h4 serif price-regular">
-              {{ product.regular_price * product.qty | price }}
+              {{ (product.regular_price || product.price_incl_tax) * product.qty | price }}
             </span>
           </div>
         </div>


### PR DESCRIPTION
### Related issues
closes #2994

### Short description and why it's useful
It adds a possibility to add many bundle products with different configuration to the cart

### Screenshots of visual changes before/after (if there are any)
<img width="746" alt="Screenshot 2019-07-20 at 21 43 14" src="https://user-images.githubusercontent.com/7943292/61583430-0ca26b80-ab38-11e9-900f-b3ccbcbaa366.png">

### Which environment this relates to
- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
