### PR TITLE
Fixes video embedding on PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User token re-validation fixed to use proper HTTP codes - @pkarw (#3151, #3178)
 - Fixed undefined id of color swatches issue for simple product - @vishal-7037 (#3239)
 - Problem with placing an order if shipping method is different than default one - @patzick (#3203)
+- Fixed product video embed on PDP - @juho-jaakkola (#3263)
 
 ### Changed
 - Renamed the `stock/check` to `stock/queueCheck` to better emphasize it's async nature; added `stock/check` which does exactly what name suggests - returning the true stock values - @pkarw (#3150)

--- a/core/modules/catalog/components/ProductVideo.ts
+++ b/core/modules/catalog/components/ProductVideo.ts
@@ -5,7 +5,7 @@ export const ProductVideo = {
       type: String,
       required: true
     },
-    id: {
+    video_id: {
       type: String,
       required: true
     },
@@ -38,9 +38,9 @@ export const ProductVideo = {
     embedUrl () {
       switch (this.type) {
         case 'youtube':
-          return `https://www.youtube.com/embed/${this.id}?autoplay=1`
+          return `https://www.youtube.com/embed/${this.video_id}?autoplay=1`
         case 'vimeo':
-          return `https://player.vimeo.com/video/${this.id}?autoplay=1`
+          return `https://player.vimeo.com/video/${this.video_id}?autoplay=1`
         default:
       }
     }


### PR DESCRIPTION
### Related issues

closes #3263

### Short description and why it's useful

After this fix, it is again possible to watch product videos on the PDP.

### Which environment this relates to

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/doc/Upgrade%20notes.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
