### PR TITLE
Bugfix/multistore mixin outdated references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Problem with placing an order if shipping method is different than default one - @patzick (#3203)
 - Fixed product video embed on PDP - @juho-jaakkola (#3263)
 - Fixed memory leak with loading DayJS in SSR - @lukeromanowicz (#3310) 
+- Fixed invalid localized routes in SSR content of multistore configuration - @lukeromanowicz (#3262)
 
 ### Changed
 - Renamed the `stock/check` to `stock/queueCheck` to better emphasize it's async nature; added `stock/check` which does exactly what name suggests - returning the true stock values - @pkarw (#3150)

--- a/core/mixins/multistore.js
+++ b/core/mixins/multistore.js
@@ -1,5 +1,3 @@
-import { localizedRoute as localizedRouteHelper, localizedDispatcherRoute as localizedDispatcherRouteHelper, currentStoreView } from '@vue-storefront/core/lib/multistore'
-
 export const multistore = {
   methods: {
     /**
@@ -8,9 +6,11 @@ export const multistore = {
      * @param {Int} width
      * @param {Int} height
      */
-    localizedRoute (routeObj) {
+    async localizedRoute (routeObj) {
+      // importing this way is crucial to always have a fresh multistore instance reference to store in SSR
+      const {localizedRoute, currentStoreView} = await import('@vue-storefront/core/lib/multistore')
       const storeView = currentStoreView()
-      return localizedRouteHelper(routeObj, storeView.storeCode)
+      return localizedRoute(routeObj, storeView.storeCode)
     },
     /**
      * Return localized route params for URL Dispatcher
@@ -18,9 +18,10 @@ export const multistore = {
      * @param {Int} width
      * @param {Int} height
      */
-    localizedDispatcherRoute (routeObj) {
+    async localizedDispatcherRoute (routeObj) {
+      const {localizedDispatcherRoute, currentStoreView} = await import('@vue-storefront/core/lib/multistore')
       const storeView = currentStoreView()
-      return localizedDispatcherRouteHelper(routeObj, storeView.storeCode)
+      return localizedDispatcherRoute(routeObj, storeView.storeCode)
     }
   }
 }


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3262 

### Short description and why it's useful
With every request, Webpack reinitializes Vue instance, router, store along with all other dependencies. Mixins kept in Vue prototype are registered only once (due to memory leaks) so they tend to keep old references. This PR fixes that. 

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module

## Important notes
We should get rid of global mixins anyway.