### PR TITLE
fix problem with synchronizing totals after shipping method change

### DIFF
--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -421,7 +421,7 @@ const actions: ActionTree<CartState, RootState> = {
       Logger.debug('Skipping payment & shipping methods update as cart has not been changed', 'cart')()
     }
     const storeView = currentStoreView()
-    let hasShippingInformation = false
+    let hasShippingInformation = !!(methodsData && methodsData.method_code)
     if (getters.isTotalsSyncEnabled && getters.isCartConnected && (getters.isTotalsSyncRequired || payload.forceServerSync)) {
       if (!methodsData) {
         const country = rootGetters['checkout/getShippingDetails'].country ? rootGetters['checkout/getShippingDetails'].country : storeView.tax.defaultCountry

--- a/core/modules/checkout/components/Shipping.ts
+++ b/core/modules/checkout/components/Shipping.ts
@@ -65,6 +65,7 @@ export const Shipping = {
   },
   mounted () {
     this.checkDefaultShippingMethod()
+    this.changeShippingMethod()
   },
   methods: {
     checkDefaultShippingMethod () {

--- a/core/pages/Checkout.js
+++ b/core/pages/Checkout.js
@@ -131,8 +131,8 @@ export default {
         this.$router.push(this.localizedRoute('/'))
       }
     },
-    onAfterShippingMethodChanged (payload) {
-      this.$store.dispatch('cart/syncTotals', { forceServerSync: true, methodsData: payload })
+    async onAfterShippingMethodChanged (payload) {
+      await this.$store.dispatch('cart/syncTotals', { forceServerSync: true, methodsData: payload })
       this.shippingMethod = payload
     },
     onBeforeShippingMethods (country) {


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3203

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Fixes problem with synchronizing totals after shipping method change

### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

![image](https://user-images.githubusercontent.com/13100280/62523034-3c898880-b833-11e9-917a-bcd97712f244.png)

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change
