### PR TITLE
Apply lazy-hydrate on category page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Brazilian Portuguese (pt_BR) translation improved - @pxfm (#3288)
 - Moved store/lib to /lib - @pxfm (#3253)
 - Corrected usage of "configurableChildrenStockPrefetchStatic" setting, refactored logic to tested helper - @philippsander (#859)
-- Improved some of the german translations in spelling and wording - @MariaKern (#3297) 
+- Improved some of the german translations in spelling and wording - @MariaKern (#3297)
+- Added lazy-hydrate for category products - @andrzejewsky (#3327)
 
 ## [1.10.0] - 2019.08.10
 
@@ -148,14 +149,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No placeholders / no photos for Get Inspire section in offline - @przspa (#3072)
 - Back icon on product page causing inconsistent behavior - @patzick (#3056)
 - Remove static definition of `cashondelivery` in payment module - @danielmaier42 (#2983)
-- Fixed wrong meta description attribute by page overwrite - @przspa (#3091) 
+- Fixed wrong meta description attribute by page overwrite - @przspa (#3091)
 - Fixed the `AddToCart` button behavior in case of synchronization errors - @pkarw (#3150)
 - User token re-validation fixed to use proper HTTP codes - @pkarw (#3151, #3178)
 - Fixed undefined id of color swatches issue for simple product - @vishal-7037 (#3239)
 - Date filter ignoring format param and locales - @grimasod, @patzick (#3102)
 - Problem with placing an order if shipping method is different than default one - @patzick (#3203)
 - Fixed product video embed on PDP - @juho-jaakkola (#3263)
-- Fixed memory leak with loading DayJS in SSR - @lukeromanowicz (#3310) 
+- Fixed memory leak with loading DayJS in SSR - @lukeromanowicz (#3310)
 - Fixed invalid localized routes in SSR content of multistore configuration - @lukeromanowicz (#3262)
 - Fixed startSession which loaded from the wrong place the user when multistore was active - @resubaka (#3322)
 - Login after registration - @patzick (#3343)

--- a/config/default.json
+++ b/config/default.json
@@ -280,6 +280,7 @@
   "products": {
     "disablePersistentProductsCache": true,
     "useMagentoUrlKeys": true,
+    "lazyLoadingCategoryProducts": true,
     "setFirstVarianAsDefaultInURL": false,
     "configurableChildrenStockPrefetchStatic": false,
     "configurableChildrenStockPrefetchDynamic": false,

--- a/core/app.ts
+++ b/core/app.ts
@@ -12,7 +12,8 @@ import Vuelidate from 'vuelidate'
 import Meta from 'vue-meta'
 import { sync } from 'vuex-router-sync'
 import VueObserveVisibility from 'vue-observe-visibility'
-
+import cloneDeep from 'lodash-es/cloneDeep'
+import omit from 'lodash-es/omit'
 // Apollo GraphQL client
 import { getApolloProvider } from './scripts/resolvers/resolveGraphQL'
 
@@ -62,7 +63,9 @@ once('__VUE_EXTEND_RR__', () => {
   Vue.use(VueRouter)
 })
 
-const createApp = async (ssrContext, config, storeCode = null): Promise<{app: Vue, router: VueRouter, store: Store<RootState>}> => {
+const initialState = cloneDeep(store.state)
+
+const createApp = async (ssrContext, config, storeCode = null): Promise<{app: Vue, router: VueRouter, store: Store<RootState>, initialState: RootState}> => {
   router = createRouter()
   // sync router with vuex 'router' store
   sync(store, router)
@@ -132,7 +135,7 @@ const createApp = async (ssrContext, config, storeCode = null): Promise<{app: Vu
   // @deprecated from 2.0
   EventBus.$emit('application-after-init', app)
 
-  return { app, router, store }
+  return { app, router, store, initialState }
 }
 
 export { router, createApp }

--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -1,10 +1,10 @@
 import Vue from 'vue'
 import union from 'lodash-es/union'
-
 import { createApp } from '@vue-storefront/core/app'
 import rootStore from '@vue-storefront/core/store'
 import { registerSyncTaskProcessor } from '@vue-storefront/core/lib/sync/task'
 import i18n from '@vue-storefront/i18n'
+import omit from 'lodash-es/omit'
 import { prepareStoreView, storeCodeFromRoute, currentStoreView, localizedRoute } from '@vue-storefront/core/lib/multistore'
 import { onNetworkStatusChange } from '@vue-storefront/core/modules/offline-order/helpers/onNetworkStatusChange'
 import '@vue-storefront/core/service-worker/registration' // register the service worker
@@ -20,7 +20,9 @@ const invokeClientEntry = async () => {
   const { app, router, store } = await createApp(null, dynamicRuntimeConfig, storeCode)
 
   if (window.__INITIAL_STATE__) {
-    store.replaceState(Object.assign({}, store.state, window.__INITIAL_STATE__, { config: globalConfig }))
+    // skip fields that were set by createApp
+    const initialState = omit(window.__INITIAL_STATE__, ['storeView', 'config', 'version'])
+    store.replaceState(Object.assign({}, store.state, initialState, { config: globalConfig }))
   }
 
   await store.dispatch('url/registerDynamicRoutes')

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -147,7 +147,7 @@ export function storeCodeFromRoute (matchedRouteOrUrl: LocalizedRoute | RawLocat
         return storeCode
       }
     }
-  } 
+  }
   return ''
 }
 

--- a/core/server-entry.ts
+++ b/core/server-entry.ts
@@ -1,5 +1,4 @@
 import union from 'lodash-es/union'
-
 import { createApp } from '@vue-storefront/core/app'
 import { HttpError } from '@vue-storefront/core/helpers/internal'
 import { prepareStoreView, storeCodeFromRoute } from '@vue-storefront/core/lib/multistore'
@@ -31,14 +30,8 @@ function _ssrHydrateSubcomponents (components, store, router, resolve, reject, a
     }
   })).then(() => {
     AsyncDataLoader.flush({ store, route: router.currentRoute, context: null } /* AsyncDataLoaderActionContext */).then((r) => {
-      if (buildTimeConfig.ssr.useInitialStateFilter) {
-        context.state = omit(store.state, config.ssr.initialStateFilter)
-      } else {
-        context.state = store.state
-      }
-      if (!buildTimeConfig.server.dynamicConfigReload) { // if dynamic config reload then we're sending config along with the request
-        context.state = omit(store.state, buildTimeConfig.ssr.useInitialStateFilter ? [...config.ssr.initialStateFilter, 'config'] : ['config'])
-      } else {
+      context.state = store.state
+      if (buildTimeConfig.server.dynamicConfigReload) {
         const excludeFromConfig = buildTimeConfig.server.dynamicConfigExclude
         const includeFromConfig = buildTimeConfig.server.dynamicConfigInclude
         console.log(excludeFromConfig, includeFromConfig)
@@ -63,7 +56,8 @@ function getHostFromHeader (headers: string[]): string {
 }
 
 export default async context => {
-  const { app, router, store } = await createApp(context, context.vs && context.vs.config ? context.vs.config : buildTimeConfig)
+  const { app, router, store, initialState } = await createApp(context, context.vs && context.vs.config ? context.vs.config : buildTimeConfig)
+  context.initialState = initialState
   return new Promise((resolve, reject) => {
     context.output.cacheTags = new Set<string>()
     const meta = (app as any).$meta()

--- a/core/store/index.ts
+++ b/core/store/index.ts
@@ -24,7 +24,12 @@ const state = {
   ui: {},
   newsletter: {},
   wishlist: {},
-  attribute: '',
+  attribute: {
+    list_by_code: {},
+    list_by_id: {},
+    blacklist: [],
+    labels: {}
+  },
   category: {
     current_path: '',
     current_product_query: {},

--- a/core/types/RootState.ts
+++ b/core/types/RootState.ts
@@ -10,7 +10,7 @@ export default interface RootState {
   shipping: any,
   user: any,
   wishlist: any,
-  attribute: string,
+  attribute: any,
   ui: any,
   newsletter: any,
   category: {

--- a/docs/guide/basics/configuration.md
+++ b/docs/guide/basics/configuration.md
@@ -483,6 +483,12 @@ Product attributes representing the images. We'll see it in the Product page gal
 
 The dimensions of the images in the gallery.
 
+```json
+  "lazyLoadingCategoryProducts": true
+```
+It this option is enabled, the category products will not be applied in the `window.__INITIAL_STATE__`.
+The client side will be responsible for loading them and store in vuex state.
+
 ## Orders
 
 ```json

--- a/src/themes/default/pages/Category.vue
+++ b/src/themes/default/pages/Category.vue
@@ -67,7 +67,10 @@
             </h4>
             <p>{{ $t('Please change Your search criteria and try again. If still not finding anything relevant, please visit the Home page and try out some of our bestsellers!') }}</p>
           </div>
-          <product-listing :columns="defaultColumn" :products="getCategoryProducts" />
+          <lazy-hydrate :trigger-hydration="!loading" v-if="isLazyHydrateEnabled">
+            <product-listing :columns="defaultColumn" :products="getCategoryProducts" />
+          </lazy-hydrate>
+          <product-listing v-else :columns="defaultColumn" :products="getCategoryProducts" />
         </div>
       </div>
     </div>
@@ -75,6 +78,7 @@
 </template>
 
 <script>
+import LazyHydrate from 'vue-lazy-hydration'
 import Sidebar from '../components/core/blocks/Category/Sidebar.vue'
 import ProductListing from '../components/core/ProductListing.vue'
 import Breadcrumbs from '../components/core/Breadcrumbs.vue'
@@ -86,6 +90,7 @@ import ButtonFull from 'theme/components/theme/ButtonFull.vue'
 import { mapGetters } from 'vuex'
 import uniq from 'lodash-es/uniq'
 import onBottomScroll from '@vue-storefront/core/mixins/onBottomScroll'
+import rootStore from '@vue-storefront/core/store';
 
 const composeInitialPageState = async (store, route) => {
   try {
@@ -106,6 +111,7 @@ const composeInitialPageState = async (store, route) => {
 
 export default {
   components: {
+    LazyHydrate,
     ButtonFull,
     ProductListing,
     Breadcrumbs,
@@ -118,7 +124,8 @@ export default {
     return {
       mobileFilters: false,
       defaultColumn: 3,
-      loadingProducts: false
+      loadingProducts: false,
+      loading: true
     }
   },
   computed: {
@@ -129,6 +136,9 @@ export default {
       getCategoryProductsTotal: 'category-next/getCategoryProductsTotal',
       getAvailableFilters: 'category-next/getAvailableFilters'
     }),
+    isLazyHydrateEnabled () {
+      return config.products.lazyLoadingCategoryProducts
+    },
     isCategoryEmpty () {
       return this.getCategoryProductsTotal === 0
     },
@@ -143,12 +153,16 @@ export default {
     if (isServer) next() // SSR no need to invoke SW caching here
     else if (from.name) { // SSR but client side invocation, we need to cache products
       next(async vm => {
+        vm.loading = true
         await vm.$store.dispatch('category-next/cacheProducts', { route: to })
+        vm.loading = false
       })
     } else { // Pure CSR, with no initial category state
       next(async vm => {
+        vm.loading = true
         await composeInitialPageState(vm.$store, to)
         await vm.$store.dispatch('category-next/cacheProducts', { route: to })
+        vm.loading = false
       })
     }
   },


### PR DESCRIPTION
### Related issues
closes #3327 

### Short description and why it's useful
This is a PoC of introducing lazy-hydrate for category pages. I had to face many issues with that. First of all the goal was to remove `category-next.products` from `__INITIAL_STATE__` but it causes lack of reactivity in the vuex so the `products` field will not be refreshed. Second one - SSR rendering - the `asyncData` is calling before components were rendered and it stores the products in the vuex state that you have deleted beforehand.... and even more...

let me explain what I did and why:
1. In order to keep reactivity we can't just remove fields from the `state` - I've introduced `filterInitialState` which uses new option in the config `initialStateFilterDefaults ` that includes _fields that will be set to their default values_ I used new option because we might need a possibility to remove totally some field, so `initialStateFilter` still works as before.
2. Because we have deleted (set to default) products by the filter (`initialStateFilterDefaults`), so there is no data in the state but we actually have fetched products so... I stored them in the just ordinary variable `ssrProducts` and if it's a SSR, it uses this variable, otherwise - read the data from getter (computed property `categoryProducts`)

The rest of code should be understandable. I know it's a bit _hacky_ not it does work. I've not noticed a big difference in the lighthouse, but I tested this only on the dev environment. I have to admit that it reduces page size by ~40-44% though. 

Let me know guys what you think.

### Which environment this relates to
- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
