### PR TITLE
Added workaround to fix a problem with jest watch not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for tax calculation where the values from customer_tax_class_ids is used - @resubaka (#3245)
 - Added loading product attributes (`entities.productListWithChildren.includeFields`) on category page - @andrzejewsky (#3220)
 - Added config to set Cache-Control header for static assets based on mime type - @phoenix-bjoern (#3268)
+- Added test:unit:watch with a workaround of a jest problem with template strings - @resubaka (#3351)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build:server": "cross-env NODE_ENV=production TS_NODE_PROJECT=\"tsconfig-build.json\" webpack --config ./core/build/webpack.prod.server.config.ts --mode production --progress --hide-modules",
     "build": "rimraf dist && yarn build:client && yarn build:server && yarn build:sw",
     "test:unit": "jest -c test/unit/jest.conf.js",
+    "test:unit:watch": "jest -c test/unit/jest.conf.js --watch",
     "test:e2e": "cypress open",
     "test:e2e:ci": "cypress run",
     "lint": "eslint --ext .js,.vue,.ts core src --fix",

--- a/src/themes/default/store/promoted-offers.ts
+++ b/src/themes/default/store/promoted-offers.ts
@@ -29,7 +29,9 @@ export const promotedStore = {
     async updatePromotedOffers ({commit, rootState}, data) {
       let promotedBannersResource = rootState.storeView && rootState.storeView.storeCode ? `banners/${rootState.storeView.storeCode}_promoted_offers` : `promoted_offers`
       try {
-        const promotedOffersModule = await import(/* webpackChunkName: "vsf-promoted-offers-[request]" */ `theme/resource/${promotedBannersResource}.json`)
+        // Workaround to get jest --watch to work
+        const promotedBannersResourceImport = `theme/resource/${promotedBannersResource}.json`
+        const promotedOffersModule = await import(/* webpackChunkName: "vsf-promoted-offers-[request]" */ promotedBannersResourceImport)
         commit('updatePromotedOffers', promotedOffersModule)
       } catch (err) {
         Logger.debug('Unable to load promotedOffers' + err)()
@@ -38,7 +40,9 @@ export const promotedStore = {
     async updateHeadImage ({commit, rootState}, data) {
       let mainImageResource = rootState.storeView && rootState.storeView.storeCode ? `banners/${rootState.storeView.storeCode}_main-image` : `main-image`
       try {
-        const imageModule = await import(/* webpackChunkName: "vsf-head-img-[request]" */ `theme/resource/${mainImageResource}.json`)
+        // Workaround to get jest --watch to work
+        const mainImageResourceImport = `theme/resource/${mainImageResource}.json`
+        const imageModule = await import(/* webpackChunkName: "vsf-head-img-[request]" */ mainImageResourceImport)
         commit('SET_HEAD_IMAGE', imageModule.image)
       } catch (err) {
         Logger.debug('Unable to load headImage' + err)()


### PR DESCRIPTION
### Short description and why it's useful
With this you can now run jest in watch mode. Before this you got the error below: 

```javascript
Determining test suites to run...

  ● Test suite failed to run

    Configuration error:
    
    Could not locate module theme/resource/${promotedBannersResource}.json mapped as:
   vue-storefront/node_modules/@vue-storefront/theme-default/resource/${promotedBannersResource}.json.
    
    Please check your configuration for these entries:
    {
      "moduleNameMapper": {
        "/^theme(.*)$/": "vue-storefront/node_modules/@vue-storefront/theme-default$1"
      },
      "resolver": null
    }

      at createNoMappedModuleFoundError (node_modules/jest-resolve/build/index.js:472:17)
          at Array.reduce (<anonymous>)
      at SearchSource.findRelatedTests (node_modules/@jest/core/build/SearchSource.js:280:30)
      at SearchSource.findTestRelatedToChangedFiles (node_modules/@jest/core/build/SearchSource.js:363:14)
```


### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
