### PR TITLE
Load modules on-demand

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -88,7 +88,7 @@
       "amp": "dist/index.amp.html"
     },
     "executeMixedinAsyncData": true,
-    "initialStateFilter": ["__DEMO_MODE__", "version", "storeView", "attribute", "checkout"],
+    "initialStateFilter": ["__DEMO_MODE__", "version", "storeView", "attribute"],
     "useInitialStateFilter": true
   },
   "queues": {

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -4,24 +4,17 @@ import { CatalogNextModule } from '@vue-storefront/core/modules/catalog-next'
 import { CartModule } from '@vue-storefront/core/modules/cart'
 import { CheckoutModule } from '@vue-storefront/core/modules/checkout'
 import { CompareModule } from '@vue-storefront/core/modules/compare'
-import { ReviewModule } from '@vue-storefront/core/modules/review'
-import { MailerModule } from '@vue-storefront/core/modules/mailer'
 import { WishlistModule } from '@vue-storefront/core/modules/wishlist'
-import { NewsletterModule } from '@vue-storefront/core/modules/newsletter'
 import { NotificationModule } from '@vue-storefront/core/modules/notification'
-import { RecentlyViewedModule } from '@vue-storefront/core/modules/recently-viewed'
 import { UrlModule } from '@vue-storefront/core/modules/url'
 import { BreadcrumbsModule } from '@vue-storefront/core/modules/breadcrumbs'
-import { OrderModule } from '@vue-storefront/core/modules/order'
-import { CmsModule } from '@vue-storefront/core/modules/cms'
 import { UserModule } from '@vue-storefront/core/modules/user'
-// import { GoogleAnalyticsModule } from './google-analytics';
-// import { HotjarModule } from './hotjar';
+import { CmsModule } from '@vue-storefront/core/modules/cms'
 import { GoogleTagManagerModule } from './google-tag-manager';
 import { AmpRendererModule } from './amp-renderer';
-import { PaymentBackendMethodsModule } from './payment-backend-methods';
-import { PaymentCashOnDeliveryModule } from './payment-cash-on-delivery';
-import { InstantCheckoutModule } from './instant-checkout'
+import { PaymentBackendMethodsModule } from './payment-backend-methods'
+import { PaymentCashOnDeliveryModule } from './payment-cash-on-delivery'
+import { NewsletterModule } from '@vue-storefront/core/modules/newsletter'
 
 import { registerModule } from '@vue-storefront/core/lib/modules'
 
@@ -31,25 +24,18 @@ export function registerNewModules () {
   registerModule(CatalogModule)
   registerModule(CheckoutModule) // To Checkout
   registerModule(CartModule)
-  registerModule(ReviewModule) // To Product
-  registerModule(MailerModule) // load lazily
+  registerModule(PaymentBackendMethodsModule)
+  registerModule(PaymentCashOnDeliveryModule)
   registerModule(WishlistModule) // Trigger on wishlist icon click
-  registerModule(NewsletterModule) // Load lazily
   registerModule(NotificationModule)
   registerModule(UserModule) // Trigger on user icon click
   registerModule(CatalogNextModule)
   registerModule(CompareModule)
   registerModule(BreadcrumbsModule)
-  registerModule(OrderModule)
-  registerModule(CmsModule)
-  registerModule(RecentlyViewedModule) // To HomePage
   registerModule(GoogleTagManagerModule)
-  // registerModule(GoogleAnalyticsModule)
-  // registerModule(HotjarModule)
-  registerModule(PaymentBackendMethodsModule)
-  registerModule(PaymentCashOnDeliveryModule) // To checkout
   registerModule(AmpRendererModule)
-  registerModule(InstantCheckoutModule) // Load lazily from Microcart
+  registerModule(CmsModule)
+  registerModule(NewsletterModule)
 }
 
 // Deprecated API, will be removed in 2.0

--- a/src/themes/default/components/core/blocks/Checkout/OrderReview.vue
+++ b/src/themes/default/components/core/blocks/Checkout/OrderReview.vue
@@ -116,6 +116,8 @@ import ButtonFull from 'theme/components/theme/ButtonFull'
 import CartSummary from 'theme/components/core/blocks/Checkout/CartSummary'
 import Modal from 'theme/components/core/Modal'
 import { OrderReview } from '@vue-storefront/core/modules/checkout/components/OrderReview'
+import { OrderModule } from '@vue-storefront/core/modules/order'
+import { registerModule } from '@vue-storefront/core/lib/modules'
 
 export default {
   components: {
@@ -131,6 +133,9 @@ export default {
         required
       }
     }
+  },
+  beforeCreate () {
+    registerModule(OrderModule)
   },
   methods: {
     onSuccess () {

--- a/src/themes/default/components/core/blocks/Checkout/ThankYouPage.vue
+++ b/src/themes/default/components/core/blocks/Checkout/ThankYouPage.vue
@@ -85,10 +85,15 @@ import VueOfflineMixin from 'vue-offline/mixin'
 import { EmailForm } from '@vue-storefront/core/modules/mailer/components/EmailForm'
 import { isServer } from '@vue-storefront/core/helpers'
 import config from 'config'
+import { registerModule } from '@vue-storefront/core/lib/modules'
+import { MailerModule } from '@vue-storefront/core/modules/mailer'
 
 export default {
   name: 'ThankYouPage',
   mixins: [Composite, VueOfflineMixin, EmailForm],
+  beforeCreate () {
+    registerModule(MailerModule)
+  },
   data () {
     return {
       feedback: ''

--- a/src/themes/default/components/core/blocks/Microcart/Microcart.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Microcart.vue
@@ -131,6 +131,7 @@ import { isModuleRegistered } from '@vue-storefront/core/lib/modules'
 import VueOfflineMixin from 'vue-offline/mixin'
 import onEscapePress from '@vue-storefront/core/mixins/onEscapePress'
 import InstantCheckout from 'src/modules/instant-checkout/components/InstantCheckout.vue'
+import { registerModule } from '@vue-storefront/core/lib/modules'
 
 import BaseInput from 'theme/components/core/blocks/Form/BaseInput'
 import ClearCartButton from 'theme/components/core/blocks/Microcart/ClearCartButton'
@@ -138,6 +139,7 @@ import ButtonFull from 'theme/components/theme/ButtonFull'
 import ButtonOutline from 'theme/components/theme/ButtonOutline'
 import Product from 'theme/components/core/blocks/Microcart/Product'
 import EditMode from './EditMode'
+import { InstantCheckoutModule } from 'src/modules/instant-checkout'
 
 export default {
   components: {
@@ -167,6 +169,9 @@ export default {
       required: false,
       default: () => false
     }
+  },
+  beforeCreate () {
+    registerModule(InstantCheckoutModule)
   },
   mounted () {
     this.$nextTick(() => {

--- a/src/themes/default/pages/Checkout.vue
+++ b/src/themes/default/pages/Checkout.vue
@@ -36,6 +36,8 @@ import Payment from 'theme/components/core/blocks/Checkout/Payment'
 import OrderReview from 'theme/components/core/blocks/Checkout/OrderReview'
 import CartSummary from 'theme/components/core/blocks/Checkout/CartSummary'
 import ThankYouPage from 'theme/components/core/blocks/Checkout/ThankYouPage'
+import { registerModule } from '@vue-storefront/core/lib/modules'
+import { OrderModule } from '@vue-storefront/core/modules/order'
 
 export default {
   components: {
@@ -47,6 +49,9 @@ export default {
     ThankYouPage
   },
   mixins: [Checkout],
+  beforeCreate () {
+    registerModule(OrderModule)
+  },
   methods: {
     notifyEmptyCart () {
       this.$store.dispatch('notification/spawnNotification', {

--- a/src/themes/default/pages/CmsPage.vue
+++ b/src/themes/default/pages/CmsPage.vue
@@ -15,6 +15,7 @@
 
 <script>
 import CmsPage from '@vue-storefront/core/pages/CmsPage'
+
 export default {
   computed: {
     cmsPageContent () {

--- a/src/themes/default/pages/Home.vue
+++ b/src/themes/default/pages/Home.vue
@@ -50,6 +50,8 @@ import TileLinks from 'theme/components/theme/blocks/TileLinks/TileLinks'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import { mapGetters } from 'vuex'
 import config from 'config'
+import { registerModule } from '@vue-storefront/core/lib/modules'
+import { RecentlyViewedModule } from '@vue-storefront/core/modules/recently-viewed'
 
 export default {
   mixins: [Home],
@@ -74,6 +76,9 @@ export default {
     isOnline () {
       return onlineHelper.isOnline
     }
+  },
+  beforeCreate () {
+    registerModule(RecentlyViewedModule)
   },
   created () {
     // Load personal and shipping details for Checkout page from IndexedDB

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -236,6 +236,9 @@ import SizeGuide from 'theme/components/core/blocks/Product/SizeGuide'
 import AddToWishlist from 'theme/components/core/blocks/Wishlist/AddToWishlist'
 import AddToCompare from 'theme/components/core/blocks/Compare/AddToCompare'
 import LazyHydrate from 'vue-lazy-hydration'
+import { ReviewModule } from '@vue-storefront/core/modules/review'
+import { RecentlyViewedModule } from '@vue-storefront/core/modules/recently-viewed'
+import { registerModule, isModuleRegistered } from '@vue-storefront/core/lib/modules'
 
 export default {
   components: {
@@ -262,6 +265,10 @@ export default {
   },
   mixins: [Product, VueOfflineMixin],
   directives: { focusClean },
+  beforeCreate () {
+    registerModule(ReviewModule)
+    registerModule(RecentlyViewedModule)
+  },
   data () {
     return {
       detailsOpen: false,


### PR DESCRIPTION
### Short description and why it's useful
As we talked with @filrak this is short PR introduces loading modules on demand. Of course we can't move all of registering module calls as they are linked to the other modules via getters or actions.

### Which environment this relates to
- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
