### PR TITLE
Bugfix/category hydration issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Invalid Discount code error handled by theme - @grimasod (#3385)
+- Hydration problems on category page caused by to early hydration - @patzick (#3403)
 
 ## [1.10.0] - 2019.08.10
 

--- a/config/default.json
+++ b/config/default.json
@@ -421,6 +421,9 @@
       "sendConfirmation": true
     },
     "theme": "@vue-storefront/theme-default",
+    "themeConfig": {
+      "lazyRouteComponentHydration": true
+    },
     "analytics": {
       "id": false
     },

--- a/core/i18n/resource/i18n/en-US.csv
+++ b/core/i18n/resource/i18n/en-US.csv
@@ -73,4 +73,5 @@
 "You need to be logged in to see this page","You need to be logged in to see this page"
 "Quantity must be above 0","Quantity must be above 0"
 "Error: Error while adding products","Error: Error while adding products"
-"Unexpected authorization error. Check your Network conection.","Unexpected authorization error. Check your Network conection."
+"Unexpected authorization error. Check your Network conection.","Unexpected authorization error. Check your Network conection.",
+"Columns","Columns"

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "vue-carousel": "^0.6.9",
     "vue-gtm": "^2.0.0",
     "vue-i18n": "^8.0.0",
+    "vue-lazy-hydration": "^1.0.0-beta.9",
     "vue-lazyload": "^1.2.6",
     "vue-meta": "^1.5.3",
     "vue-no-ssr": "^0.2.2",

--- a/src/themes/default/App.vue
+++ b/src/themes/default/App.vue
@@ -1,13 +1,16 @@
 <template>
   <div id="app">
-    <component :is="layout">
-      <router-view />
-    </component>
+    <lazy-hydrate when-idle>
+      <component :is="layout">
+        <router-view />
+      </component>
+    </lazy-hydrate>
   </div>
 </template>
 
 <script>
 import { mapState } from 'vuex'
+import LazyHydrate from 'vue-lazy-hydration'
 const DefaultLayout = () => import(/* webpackChunkName: "vsf-layout-default" */ './layouts/Default')
 const EmptyLayout = () => import(/* webpackChunkName: "vsf-layout-empty" */ './layouts/Empty')
 const MinimalLayout = () => import(/* webpackChunkName: "vsf-layout-minimal" */ './layouts/Minimal')
@@ -29,7 +32,8 @@ export default {
   components: {
     DefaultLayout,
     EmptyLayout,
-    MinimalLayout
+    MinimalLayout,
+    LazyHydrate
   }
 }
 </script>

--- a/src/themes/default/App.vue
+++ b/src/themes/default/App.vue
@@ -1,16 +1,13 @@
 <template>
   <div id="app">
-    <lazy-hydrate when-idle>
-      <component :is="layout">
-        <router-view />
-      </component>
-    </lazy-hydrate>
+    <component :is="layout">
+      <router-view />
+    </component>
   </div>
 </template>
 
 <script>
 import { mapState } from 'vuex'
-import LazyHydrate from 'vue-lazy-hydration'
 const DefaultLayout = () => import(/* webpackChunkName: "vsf-layout-default" */ './layouts/Default')
 const EmptyLayout = () => import(/* webpackChunkName: "vsf-layout-empty" */ './layouts/Empty')
 const MinimalLayout = () => import(/* webpackChunkName: "vsf-layout-minimal" */ './layouts/Minimal')
@@ -32,8 +29,7 @@ export default {
   components: {
     DefaultLayout,
     EmptyLayout,
-    MinimalLayout,
-    LazyHydrate
+    MinimalLayout
   }
 }
 </script>

--- a/src/themes/default/layouts/Default.vue
+++ b/src/themes/default/layouts/Default.vue
@@ -25,7 +25,11 @@
         :is-open="isWishlistOpen"
         @close="$store.commit('ui/setWishlist')"
       />
-      <slot />
+      <lazy-hydrate when-idle :trigger-hydration="!isRouteComponentLazyHydrated">
+        <div>
+          <slot />
+        </div>
+      </lazy-hydrate>
       <main-footer />
       <notification />
       <sign-up />
@@ -51,6 +55,7 @@ import OfflineBadge from 'theme/components/core/OfflineBadge.vue'
 import { isServer } from '@vue-storefront/core/helpers'
 import Head from 'theme/head'
 import config from 'config'
+import LazyHydrate from 'vue-lazy-hydration'
 
 const SidebarMenu = () => import(/* webpackPreload: true */ /* webpackChunkName: "vsf-sidebar-menu" */ 'theme/components/core/blocks/SidebarMenu/SidebarMenu.vue')
 const Microcart = () => import(/* webpackPreload: true */ /* webpackChunkName: "vsf-microcart" */ 'theme/components/core/blocks/Microcart/Microcart.vue')
@@ -76,7 +81,10 @@ export default {
       isSidebarOpen: state => state.ui.sidebar,
       isMicrocartOpen: state => state.ui.microcart,
       isWishlistOpen: state => state.ui.wishlist
-    })
+    }),
+    isRouteComponentLazyHydrated () {
+      return config.themeConfig.lazyRouteComponentHydration
+    }
   },
   methods: {
     onOrderConfirmation (payload) {
@@ -118,7 +126,8 @@ export default {
     CookieNotification,
     OfflineBadge,
     OrderConfirmation,
-    AsyncSidebar
+    AsyncSidebar,
+    LazyHydrate
   }
 }
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13112,6 +13112,11 @@ vue-jest@^3.0.2:
     tsconfig "^7.0.0"
     vue-template-es2015-compiler "^1.6.0"
 
+vue-lazy-hydration@^1.0.0-beta.9:
+  version "1.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/vue-lazy-hydration/-/vue-lazy-hydration-1.0.0-beta.9.tgz#d5c8f7c36717a57cc6f7472f77fbbe5ff5358bde"
+  integrity sha512-SkThbDGtkZN15Eu7D/IJhkf1tgzfrn+8Zkn4lTvjnd4hIfSrUOk8pmJdbgafxM0Z+ERYBIJV34Roc+l0DjQITg==
+
 vue-lazyload@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/vue-lazyload/-/vue-lazyload-1.2.6.tgz#baa04c172d52a812608eb12c7a6bfb14f5c91079"


### PR DESCRIPTION
### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Fixes hydration errors caused randomly by not fetching scripts before client hydration started.
This should increase TTI and get rid of this problem.

During tests, this error hasn't shown up even once. Haven't noticed any unpleasant side-effects.

QA - please test it thoroughly by refreshing category page multiple times.
As change is in the root of the application, please also check Other pages to be sure.

### Edit: Extended explanation
The error appears mostly on Linux-based systems distributions (with docker, Linux, mac). When a client gets server image it starts hydrating too fast, even if didn't get yet route component or it's dependencies.
To avoid that kind of situations route chunks (and all dependencies) should be smaller. In some points, client browser can skip waiting for all dependencies and start hydrating too soon.

To switch off this new set of lazy hydrating route component we have the property:
`themeConfig.lazyRouteComponentHydration`
in a config file, which by default is set to `true`

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change