### PR TITLE
Bugfix/3167 category next fixes

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -408,7 +408,9 @@
     "sourcePriceIncludesTax": false,
     "calculateServerSide": true,
     "userGroupId": null,
-    "useOnlyDefaultUserGroupId": false
+    "useOnlyDefaultUserGroupId": false,
+    "deprecatedPriceFieldsSupport": true,
+    "finalPriceIncludesTax": false
   },
   "shipping": {
     "methods": [

--- a/core/modules/catalog-next/store/category/actions.ts
+++ b/core/modules/catalog-next/store/category/actions.ts
@@ -4,7 +4,7 @@ import * as types from './mutation-types'
 import RootState from '@vue-storefront/core/types/RootState'
 import CategoryState from './CategoryState'
 import { quickSearchByQuery } from '@vue-storefront/core/lib/search'
-import { buildFilterProductsQuery } from '@vue-storefront/core/helpers'
+import { buildFilterProductsQuery, isServer } from '@vue-storefront/core/helpers'
 import { router } from '@vue-storefront/core/app'
 import FilterVariant from '../../types/FilterVariant'
 import { CategoryService } from '@vue-storefront/core/data-resolver'
@@ -15,7 +15,10 @@ import { DataResolver } from 'core/data-resolver/types/DataResolver';
 import { Category } from '../../types/Category';
 import { _prepareCategoryPathIds } from '../../helpers/categoryHelpers';
 import { prefetchStockItems } from '../../helpers/cacheProductsHelper';
+import { preConfigureProduct } from '@vue-storefront/core/modules/catalog/helpers/search'
 import chunk from 'lodash-es/chunk'
+import omit from 'lodash-es/omit'
+import config from 'config'
 
 const actions: ActionTree<CategoryState, RootState> = {
   async loadCategoryProducts ({ commit, getters, dispatch, rootState }, { route, category } = {}) {
@@ -30,16 +33,18 @@ const actions: ActionTree<CategoryState, RootState> = {
       excludeFields: entities.productList.excludeFields
     })
     commit(types.CATEGORY_SET_SEARCH_PRODUCTS_STATS, { perPage, start, total })
+    await dispatch('tax/calculateTaxes', { products: items }, { root: true }) // TODO: The `url/registerMapping` for each individual product loaded is called only in the second request - I mean in the: `cacheProducts` -> `product/list`; without  mapping registered from the ategory  level when user clicks the product link VS will fetch with additional request the url mapping; not sure if this is  a risky situation as we have lazy-hydrate on; waiting for this second request anyway; @patzik let's diiscuss this tomorrow
     let configuredProducts = items.map(product => {
+      product = Object.assign({}, preConfigureProduct({ product, populateRequestCacheTags: config.server.useOutputCacheTagging })) // this is setting the output cache tags and setting parentSku which is crucial for product sync
       const configuredProductVariant = configureProductAsync({rootState}, {product, configuration: searchQuery.filters, selectDefaultVariant: false, fallbackToDefaultWhenNoAvailable: true, setProductErorrs: false})
-      return Object.assign(product, configuredProductVariant)
+      return Object.assign(product, omit(configuredProductVariant, ['visibility']))
     })
     commit(types.CATEGORY_SET_PRODUCTS, configuredProducts)
     // await dispatch('loadAvailableFiltersFrom', searchResult)
 
     return items
   },
-  async loadMoreCategoryProducts ({ commit, getters, rootState }) {
+  async loadMoreCategoryProducts ({ commit, getters, rootState, dispatch }) {
     const { perPage, start, total } = getters.getCategorySearchProductsStats
     if (start >= total || total < perPage) return
 
@@ -58,9 +63,11 @@ const actions: ActionTree<CategoryState, RootState> = {
       start: searchResult.start,
       total: searchResult.total
     })
-    let configuredProducts = searchResult.items.map(product => {
+    await dispatch('tax/calculateTaxes', { products: searchResult.items }, { root: true })
+    let configuredProducts = searchResult.items.map(product => { // TODO: we've got a code duplication here with the `loadCategoryProducts` above - we probably need to extract this logic to some kind of helper (?)
+      product = Object.assign({}, preConfigureProduct({ product, populateRequestCacheTags: config.server.useOutputCacheTagging }))
       const configuredProductVariant = configureProductAsync({rootState, state: {current_configuration: {}}}, {product, configuration: searchQuery.filters, selectDefaultVariant: false, fallbackToDefaultWhenNoAvailable: true, setProductErorrs: false})
-      return Object.assign(product, configuredProductVariant)
+      return Object.assign(product, omit(configuredProductVariant, ['visibility']))
     })
     commit(types.CATEGORY_ADD_PRODUCTS, configuredProducts)
 
@@ -71,7 +78,7 @@ const actions: ActionTree<CategoryState, RootState> = {
     const searchQuery = getters.getCurrentFiltersFrom(route[products.routerFiltersSource])
     let filterQr = buildFilterProductsQuery(searchCategory, searchQuery.filters)
 
-    const cachedProductsResponse = await dispatch('product/list', {
+    const cachedProductsResponse = await dispatch('product/list', { // configure and calculateTaxes is being executed in the product/list - we don't need another call in here
       query: filterQr,
       sort: searchQuery.sort,
       updateState: false // not update the product listing - this request is only for caching

--- a/core/modules/catalog/store/tax/actions.ts
+++ b/core/modules/catalog/store/tax/actions.ts
@@ -49,7 +49,9 @@ const actions: ActionTree<TaxState, RootState> = {
     const {
       defaultCountry,
       defaultRegion,
-      sourcePriceIncludesTax
+      sourcePriceIncludesTax,
+      finalPriceIncludesTax,
+      deprecatedPriceFieldsSupport
     } = rootState.storeView.tax
 
     const recalculatedProducts = products.map(product =>
@@ -58,8 +60,10 @@ const actions: ActionTree<TaxState, RootState> = {
         taxClasses: tcs.items,
         taxCountry: defaultCountry,
         taxRegion: defaultRegion,
+        finalPriceInclTax: finalPriceIncludesTax,
         sourcePriceInclTax: sourcePriceIncludesTax,
         userGroupId: getters.getUserTaxGroupId,
+        deprecatedPriceFieldsSupport: deprecatedPriceFieldsSupport,
         isTaxWithUserGroupIsActive: getters.getIsUserGroupedTaxActive
       })
     )


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

I found some missing calls - to `calculateTaxes` + missing output cache tagging in the new `catalog-next` implementation. @patzick let's have a short chat tomorrow morning on this; please double-check the `product/findProducts` actions and subsequent actions - to double-check if we're not missing anything else

One thing to  rethink:  The `url/registerMapping` for each individual product loaded is called only in the second request - I mean in the: `cacheProducts` -> `product/list`; without  mapping registered from the category  level when user clicks the product link VS will fetch with additional request the URL mapping; not sure if this is  a risky situation as we have lazy-hydrate on; waiting for this second request anyway; @patzik let's discuss this tomorrow


@alinadivante, @andrzejewsky this was related to #3384 in a way: I've double-checked and the wrong prices were generated when both: vs-api + vs were in charge of taxes (if you set `tax.calculateServerSide=false` in the frontend app you have to set `tax.calculateServerSide=false` in the `vue-storefront-api` as well; otherwise the taxes will be calculated twice; frontend by default considers prices as tax-included and backend is modifying the `final_price` to exclude price - well it's complicated; but with the right setting taxes are set correctly; moreover the category was not calling `calculateTaxes` at all so I had empty prices in the `tax.calculateServerSide=false`0
