### PR TITLE
Added i18n support for modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added husky package to manage lint check only for staged files in git @lorenaramonda (#3444)
 - Change text from "is out of the stock" to "is out of stock" - @indiebytes (#3452)
 - Added general purpose hooks - @andrzejewsky (#3389)
+- Added i18n support for modules - @dz3n (#3369)
 
 ### Fixed
 

--- a/core/build/webpack.base.config.ts
+++ b/core/build/webpack.base.config.ts
@@ -18,6 +18,7 @@ fs.writeFileSync(
 import themeRoot from './theme-path';
 
 const themesRoot = '../../src/themes'
+const moduleRoot = path.resolve(__dirname, '../../src/modules')
 const themeResources = themeRoot + '/resource'
 const themeCSS = themeRoot + '/css'
 const themeApp = themeRoot + '/App.vue'
@@ -26,11 +27,23 @@ const themedIndexMinimal = path.join(themeRoot, '/templates/index.minimal.templa
 const themedIndexBasic = path.join(themeRoot, '/templates/index.basic.template.html')
 const themedIndexAmp = path.join(themeRoot, '/templates/index.amp.template.html')
 
-const translationPreprocessor = require('@vue-storefront/i18n/scripts/translation.preprocessor.js')
-translationPreprocessor([
+
+const csvDirectories = [
   path.resolve(__dirname, '../../node_modules/@vue-storefront/i18n/resource/i18n/'),
-  path.resolve(__dirname, themeResources + '/i18n/')
-], config)
+];
+
+fs.readdirSync(moduleRoot).forEach(directory => {
+  const dirName = moduleRoot + '/' +  directory + '/resource/i18n'
+
+  if(fs.existsSync(dirName)) {
+    csvDirectories.push(dirName);
+  }
+});
+
+csvDirectories.push(path.resolve(__dirname, themeResources + '/i18n/'));
+
+const translationPreprocessor = require('@vue-storefront/i18n/scripts/translation.preprocessor.js')
+translationPreprocessor(csvDirectories, config)
 
 const postcssConfig = {
   loader: 'postcss-loader',


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/DivanteLtd/vue-storefront/issues/3369

### Short description and why it's useful
This feature provide a possibility to use i18n in modules on the same way like themes.
If translation key is duplicated in core/themes/modules the priority is as follow:

Priority goes from higher to lower:
1. Themes
2. Modules
3. Core

The structure for module translations should be: ~/src/modules/MODULE_NAME/**resource/i18n/**


### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [ ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [ ] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
