### PR TITLE
[fix] 3495 - categoriesDynamicPrefetchLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - Unreleased
+
+### Fixed
+- Fixed `categoriesDynamicPrefetchLevel` that now can be equal to 0 - @pkarw (#3495)
+
 ## [1.10.1] - 2019.09.03
 
 ### Fixed

--- a/core/compatibility/components/blocks/SidebarMenu/SidebarMenu.js
+++ b/core/compatibility/components/blocks/SidebarMenu/SidebarMenu.js
@@ -11,7 +11,7 @@ export default {
     ...mapGetters('category', ['getCategories']),
     categories () {
       return this.getCategories.filter((op) => {
-        return op.level === (config.entities.category.categoriesDynamicPrefetchLevel ? config.entities.category.categoriesDynamicPrefetchLevel : 2) // display only the root level (level =1 => Default Category), categoriesDynamicPrefetchLevel = 2 by default
+        return op.level === (config.entities.category.categoriesDynamicPrefetchLevel >= 0 ? config.entities.category.categoriesDynamicPrefetchLevel : 2) // display only the root level (level =1 => Default Category), categoriesDynamicPrefetchLevel = 2 by default
       })
     },
     ...mapState({

--- a/src/themes/default/layouts/Default.vue
+++ b/src/themes/default/layouts/Default.vue
@@ -85,7 +85,7 @@ export default {
       this.$bus.$emit('modal-show', 'modal-order-confirmation')
     },
     fetchMenuData () {
-      return this.$store.dispatch('category/list', { level: config.entities.category.categoriesDynamicPrefetch && config.entities.category.categoriesDynamicPrefetchLevel ? config.entities.category.categoriesDynamicPrefetchLevel : null, includeFields: config.entities.optimize && isServer ? config.entities.category.includeFields : null, skipCache: isServer })
+      return this.$store.dispatch('category/list', { level: config.entities.category.categoriesDynamicPrefetch && config.entities.category.categoriesDynamicPrefetchLevel >= 0 ? config.entities.category.categoriesDynamicPrefetchLevel : null, includeFields: config.entities.optimize && isServer ? config.entities.category.includeFields : null, skipCache: isServer })
     }
   },
   serverPrefetch () {


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3495 

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

The config variable `categoriesDynamicPrefetchLevel` now can be equal to 0


