### PR TITLE
Update introduction.md

### DIFF
--- a/docs/guide/vuex/introduction.md
+++ b/docs/guide/vuex/introduction.md
@@ -24,7 +24,7 @@ Before you start working with Vuex, it's recommended to get familiar with our [v
 
 ## Override existing core modules
 
-Existing core modules can be overridden in the themes store. Just import any core store modules and override them using the `extendStore()` utility method like the example given below in `themes/default/modules/ui-store/index.ts`.
+Existing core modules can be overridden in the themes store. Just import any core store modules and override them using the `extendStore()` utility method like the example given below in `src/modules/ui-store/index.ts`.
 
 ```
 import coreStore from '@vue-storefront/core/store/modules/ui-store'
@@ -49,7 +49,7 @@ export default extendStore(coreStore, {
 })
 ```
 
-And then import it in `themes/default/modules/index.ts`
+And then import it in `src/modules/index.ts`
 
 ```
 import ui from './ui-store'

--- a/docs/guide/vuex/introduction.md
+++ b/docs/guide/vuex/introduction.md
@@ -24,7 +24,7 @@ Before you start working with Vuex, it's recommended to get familiar with our [v
 
 ## Override existing core modules
 
-Existing core modules can be overridden in the themes store. Just import any core store modules and override them using the `extendStore()` utility method like the example given below in `themes/default/store/ui-store.js`.
+Existing core modules can be overridden in the themes store. Just import any core store modules and override them using the `extendStore()` utility method like the example given below in `themes/default/modules/ui-store/index.ts`.
 
 ```
 import coreStore from '@vue-storefront/core/store/modules/ui-store'
@@ -49,7 +49,7 @@ export default extendStore(coreStore, {
 })
 ```
 
-And then import it in `themes/default/store/index.js`
+And then import it in `themes/default/modules/index.ts`
 
 ```
 import ui from './ui-store'


### PR DESCRIPTION
This PR only changes one site of the docs. More might follow while I find my way through the docs and updated docs are welcome.

### Related issues
none

closes #

### Short description and why it's useful
The docs still show the old filestructure (before the refactoring into encapsulated modules). This commit corrects the locations for this page of the docs.



### Screenshots of visual changes before/after (if there are any)
none

### Which environment this relates to
none