### PR TITLE
3508 fixed comparison list preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix for comparison list being not preserved between page reloads - @vue-kacper (#3508)
 - Fix 'fist' typos - @jakubmakielkowski (#3491)
 - Fix for wrong breadcrumb urls in the multistore mode - @pkarw (#3359)
 - Fix for displaying gallery images for unavaialble product variants - @pkarw (#3436)

--- a/core/modules/compare/store/plugin.ts
+++ b/core/modules/compare/store/plugin.ts
@@ -6,8 +6,7 @@ const watchedMutations = [types.COMPARE_ADD_ITEM, types.COMPARE_DEL_ITEM, types.
 const cacheStorage = StorageManager.get('compare')
 
 const cachePersistPlugin = (mutation, state) => {
-  const mutations = watchedMutations
-  if (mutations.includes(mutation.type)) {
+  if (watchedMutations.includes(mutation.type)) {
     cacheStorage.setItem('current-compare', state.compare.items).catch((reason) => {
       Logger.error(reason, 'compare')
     })

--- a/core/modules/compare/store/plugin.ts
+++ b/core/modules/compare/store/plugin.ts
@@ -6,8 +6,7 @@ const watchedMutations = [types.COMPARE_ADD_ITEM, types.COMPARE_DEL_ITEM, types.
 const cacheStorage = StorageManager.get('compare')
 
 const cachePersistPlugin = (mutation, state) => {
-  const mutations = watchedMutations.map(m => `compare/${m}`)
-
+  const mutations = watchedMutations
   if (mutations.includes(mutation.type)) {
     cacheStorage.setItem('current-compare', state.compare.items).catch((reason) => {
       Logger.error(reason, 'compare')


### PR DESCRIPTION
closes #3508

### Short description and why it's useful
Comparison list is now preserved between page refresh action


### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
- [x ] I read the [TypeScript Action Plan](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/TypeScript%20Action%20Plan.md) and adjusted my PR according to it
- [x] I read about [Vue Storefront Modules](https://github.com/DivanteLtd/vue-storefront/blob/master/doc/api-modules/about-modules.md) and I am aware that every new feature should be a module
