### PR TITLE
fix: attribute labels - #3530

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix for the product attribute labels displayedd on the PDP - @pkarw (#3530)
 - Fix for comparison list being not preserved between page reloads - @vue-kacper (#3508)
 - Fix 'fist' typos - @jakubmakielkowski (#3491)
 - Fix for wrong breadcrumb urls in the multistore mode - @pkarw (#3359)

--- a/core/modules/catalog/components/ProductAttribute.ts
+++ b/core/modules/catalog/components/ProductAttribute.ts
@@ -16,7 +16,7 @@ export const ProductAttribute = {
   },
   computed: {
     label () {
-      return (this.attribute && this.attribute.default_frontend_label) ? this.attribute.default_frontend_label : ''
+      return (this.attribute && this.attribute.frontend_label) ? this.attribute.frontend_label : ((this.attribute && this.attribute.default_frontend_label) ? this.attribute.default_frontend_label : '')
     },
     value () {
       let parsedValues = this.product[this.attribute.attribute_code]


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3530

I've fixed the way we display the product attributes taking the `frontend_label` as default and `default_frontendd_label` only when it's not set
