### PR TITLE
Hotfix/#3549 Broken sidebar menu in mobile view 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.3] - unreleased
+
+### Fixed
+- Fixed broken sidebar menu in mobile view - @przspa (#3549)
+
 ## [1.10.2] - 2019.09.06
 
 ### Fixed

--- a/src/themes/default/components/core/blocks/SearchPanel/SearchPanel.vue
+++ b/src/themes/default/components/core/blocks/SearchPanel/SearchPanel.vue
@@ -155,7 +155,7 @@ export default {
   z-index: 3;
   overflow-y: auto;
   overflow-x: hidden;
-
+  -webkit-overflow-scrolling: touch;
   .close-icon-row {
     display: flex;
     justify-content: flex-end;

--- a/src/themes/default/components/core/blocks/SidebarMenu/SidebarMenu.vue
+++ b/src/themes/default/components/core/blocks/SidebarMenu/SidebarMenu.vue
@@ -245,6 +245,7 @@ $color-mine-shaft: color(mine-shaft);
     overflow-y: auto;
     overflow-x: hidden;
     height: calc(100% - 55px);
+    -webkit-overflow-scrolling: touch;
   }
 
   &__list {

--- a/src/themes/default/components/core/blocks/SidebarMenu/SidebarMenu.vue
+++ b/src/themes/default/components/core/blocks/SidebarMenu/SidebarMenu.vue
@@ -243,6 +243,7 @@ $color-mine-shaft: color(mine-shaft);
 
   &__container {
     overflow-y: auto;
+    overflow-x: hidden;
     height: calc(100% - 55px);
   }
 

--- a/src/themes/default/components/theme/blocks/AsyncSidebar/AsyncSidebar.vue
+++ b/src/themes/default/components/theme/blocks/AsyncSidebar/AsyncSidebar.vue
@@ -81,6 +81,7 @@ export default {
     min-width: 320px;
     overflow-y: auto;
     overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
   }
 
   .left-sidebar{
@@ -91,7 +92,7 @@ export default {
     overflow: hidden;
     overflow-y: auto;
     z-index: 3;
-
+    -webkit-overflow-scrolling: touch;
     @media (max-width: 767px) {
       width: 100vh;
     }


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3549

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Setted overflow-x hidden for menu sidebar. Added -webkit-overflow-scrolling: touch;

### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->
![_](https://user-images.githubusercontent.com/12138170/64945044-0a2a6c80-d870-11e9-91c1-24c461b43385.gif)

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

