### PR TITLE
Bugfix/multistore routes

### DIFF
--- a/core/app.ts
+++ b/core/app.ts
@@ -72,7 +72,6 @@ const createApp = async (ssrContext, config, storeCode = null): Promise<{app: Vu
   if (!store.state.config) store.state.config = globalConfig //  @deprecated - we should avoid the `config`
   const storeView = prepareStoreView(storeCode) // prepare the default storeView
   store.state.storeView = storeView
-  // store.state.shipping.methods = shippingMethods
 
   // to depreciate in near future
   once('__VUE_EXTEND__', () => {

--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -24,7 +24,7 @@ const invokeClientEntry = async () => {
     store.replaceState(Object.assign({}, store.state, window.__INITIAL_STATE__, { config: globalConfig }))
   }
 
-  store.dispatch('url/registerDynamicRoutes')
+  await store.dispatch('url/registerDynamicRoutes')
   function _commonErrorHandler (err, reject) {
     if (err.message.indexOf('query returned empty result') > 0) {
       rootStore.dispatch('notification/spawnNotification', {
@@ -74,8 +74,6 @@ const invokeClientEntry = async () => {
           if (storeCode !== '' && storeCode !== null) {
             if (storeCode !== currentStore.storeCode) {
               (document as any).location = to.path // full reload
-            } else {
-              prepareStoreView(storeCode)
             }
           }
         }

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -67,9 +67,9 @@ export function prepareStoreView (storeCode: string): StoreView {
     storeView.storeCode = config.defaultStoreCode || ''
     rootStore.state.user.current_storecode = config.defaultStoreCode || ''
   }
-  loadLanguageAsync(storeView.i18n.defaultLocale)
   if (storeViewHasChanged) {
     rootStore.state.storeView = storeView
+    loadLanguageAsync(storeView.i18n.defaultLocale)
   }
   if (storeViewHasChanged || Vue.prototype.$db.currentStoreCode !== storeCode) {
     if (typeof Vue.prototype.$db === 'undefined') {
@@ -78,7 +78,6 @@ export function prepareStoreView (storeCode: string): StoreView {
     initializeSyncTaskStorage()
     Vue.prototype.$db.currentStoreCode = storeView.storeCode
   }
-
   return storeView
 }
 

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -143,7 +143,7 @@ export function adjustMultistoreApiUrl (url: string): string {
 export function localizedDispatcherRoute (routeObj: LocalizedRoute | string, storeCode: string): LocalizedRoute | string {
   if (!storeCode) {
     storeCode = currentStoreView().storeCode
-  }  
+  }
   const appendStoreCodePrefix = config.storeViews[storeCode] ? config.storeViews[storeCode].appendStoreCode : false
 
   if (typeof routeObj === 'string') {

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -147,14 +147,16 @@ export function localizedDispatcherRoute (routeObj: LocalizedRoute | string, sto
   const appendStoreCodePrefix = config.storeViews[storeCode] ? config.storeViews[storeCode].appendStoreCode : false
 
   if (typeof routeObj === 'string') {
-    return appendStoreCodePrefix ? '/' + storeCode + routeObj : routeObj
+    if (routeObj[0] !== '/') routeObj = `/${routeObj}`
+    return appendStoreCodePrefix ? `/${storeCode}${routeObj}` : routeObj
   }
 
   if (routeObj && routeObj.fullPath) { // case of using dispatcher
     const routeCodePrefix = config.defaultStoreCode !== storeCode && appendStoreCodePrefix ? `/${storeCode}` : ''
     const qrStr = queryString.stringify(routeObj.params)
 
-    return `${routeCodePrefix}/${routeObj.fullPath}${qrStr ? `?${qrStr}` : ''}`
+    const normalizedPath = routeObj.fullPath[0] !== '/' ? `/${routeObj.fullPath}` : routeObj.fullPath
+    return `${routeCodePrefix}${normalizedPath}${qrStr ? `?${qrStr}` : ''}`
   }
 
   return routeObj

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -141,6 +141,9 @@ export function adjustMultistoreApiUrl (url: string): string {
 }
 
 export function localizedDispatcherRoute (routeObj: LocalizedRoute | string, storeCode: string): LocalizedRoute | string {
+  if (!storeCode) {
+    storeCode = currentStoreView().storeCode
+  }  
   const appendStoreCodePrefix = config.storeViews[storeCode] ? config.storeViews[storeCode].appendStoreCode : false
 
   if (typeof routeObj === 'string') {
@@ -158,6 +161,9 @@ export function localizedDispatcherRoute (routeObj: LocalizedRoute | string, sto
 }
 
 export function localizedRoute (routeObj: LocalizedRoute | string | RouteConfig | RawLocation, storeCode: string): any {
+  if (!storeCode) {
+    storeCode = currentStoreView().storeCode
+  }
   if (routeObj && (routeObj as LocalizedRoute).fullPath && config.seo.useUrlDispatcher) {
     return localizedDispatcherRoute(Object.assign({}, routeObj, { params: null }) as LocalizedRoute, storeCode)
   }

--- a/core/lib/router-manager.ts
+++ b/core/lib/router-manager.ts
@@ -12,8 +12,10 @@ const RouterManager = {
         (registeredRoute) => registeredRoute.name === route.name && registeredRoute.path === route.path
       ) === -1
     )
-    this._registeredRoutes.push(...uniqueRoutes)
-    router.addRoutes(uniqueRoutes)
+    if (uniqueRoutes.length > 0)  {
+      this._registeredRoutes.push(...uniqueRoutes)
+      router.addRoutes(uniqueRoutes)
+    }
   },
   addDispatchCallback: function (callback: Function) {
     this._callbacks.push(callback)

--- a/core/lib/router-manager.ts
+++ b/core/lib/router-manager.ts
@@ -12,7 +12,7 @@ const RouterManager = {
         (registeredRoute) => registeredRoute.name === route.name && registeredRoute.path === route.path
       ) === -1
     )
-    if (uniqueRoutes.length > 0)  {
+    if (uniqueRoutes.length > 0) {
       this._registeredRoutes.push(...uniqueRoutes)
       router.addRoutes(uniqueRoutes)
     }

--- a/core/modules/catalog/store/category/actions.ts
+++ b/core/modules/catalog/store/category/actions.ts
@@ -71,7 +71,7 @@ const actions: ActionTree<CategoryState, RootState> = {
         for (let category of resp.items) {
           if (category.url_path && updateState) {
             rootStore.dispatch('url/registerMapping', {
-              url: localizedDispatcherRoute('/' + category.url_path, currentStoreView().storeCode),
+              url: localizedDispatcherRoute(category.url_path, currentStoreView().storeCode),
               routeData: {
                 params: {
                   'slug': category.slug

--- a/core/modules/catalog/store/category/actions.ts
+++ b/core/modules/catalog/store/category/actions.ts
@@ -12,10 +12,11 @@ import { optionLabel } from '../../helpers/optionLabel'
 import RootState from '@vue-storefront/core/types/RootState'
 import CategoryState from '../../types/CategoryState'
 import SearchQuery from '@vue-storefront/core/lib/search/searchQuery'
-import { currentStoreView } from '@vue-storefront/core/lib/multistore'
+import { currentStoreView, localizedDispatcherRoute } from '@vue-storefront/core/lib/multistore'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import { isServer } from '@vue-storefront/core/helpers'
 import config from 'config'
+import { formatCategoryLink } from 'core/modules/url/helpers'
 
 const actions: ActionTree<CategoryState, RootState> = {
   /**
@@ -70,7 +71,7 @@ const actions: ActionTree<CategoryState, RootState> = {
         for (let category of resp.items) {
           if (category.url_path && updateState) {
             rootStore.dispatch('url/registerMapping', {
-              url: category.url_path,
+              url: localizedDispatcherRoute('/' + category.url_path, currentStoreView().storeCode),
               routeData: {
                 params: {
                   'slug': category.slug

--- a/core/modules/catalog/store/product/actions.ts
+++ b/core/modules/catalog/store/product/actions.ts
@@ -2,7 +2,7 @@ import Vue from 'vue'
 import { ActionTree } from 'vuex'
 import * as types from './mutation-types'
 import { formatBreadCrumbRoutes, productThumbnailPath, isServer } from '@vue-storefront/core/helpers'
-import { currentStoreView } from '@vue-storefront/core/lib/multistore'
+import { currentStoreView, localizedDispatcherRoute } from '@vue-storefront/core/lib/multistore'
 import { configureProductAsync,
   doPlatformPricesSync,
   filterOutUnavailableVariants,
@@ -27,6 +27,7 @@ import { Logger } from '@vue-storefront/core/lib/logger';
 import { TaskQueue } from '@vue-storefront/core/lib/sync'
 import toString from 'lodash-es/toString'
 import config from 'config'
+import { formatProductLink } from 'core/modules/url/helpers'
 
 const PRODUCT_REENTER_TIMEOUT = 20000
 
@@ -310,7 +311,7 @@ const actions: ActionTree<ProductState, RootState> = {
           }
           if (product.url_path) {
             rootStore.dispatch('url/registerMapping', {
-              url: product.url_path,
+              url: localizedDispatcherRoute('/' + product.url_path, currentStoreView().storeCode),
               routeData: {
                 params: {
                   'parentSku': product.parentSku,

--- a/core/modules/catalog/store/product/actions.ts
+++ b/core/modules/catalog/store/product/actions.ts
@@ -311,7 +311,7 @@ const actions: ActionTree<ProductState, RootState> = {
           }
           if (product.url_path) {
             rootStore.dispatch('url/registerMapping', {
-              url: localizedDispatcherRoute('/' + product.url_path, currentStoreView().storeCode),
+              url: localizedDispatcherRoute(product.url_path, currentStoreView().storeCode),
               routeData: {
                 params: {
                   'parentSku': product.parentSku,

--- a/core/modules/url/helpers/index.ts
+++ b/core/modules/url/helpers/index.ts
@@ -19,7 +19,7 @@ function prepareDynamicRoutes (routeData: LocalizedRoute, fullPath: string): Rou
     const currentStoreCode = currentStoreView().storeCode
     const dynamicRouteName = (config.defaultStoreCode !== currentStoreCode) ? `urldispatcher-${fullPath}-${currentStoreView().storeCode}` : `urldispatcher-${fullPath}`
     const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + ((config.defaultStoreCode !== currentStoreCode) ? (currentStoreCode + '/') : '') + fullPath, name: dynamicRouteName })
-    return [dynamicRoute]    
+    return [dynamicRoute]
   } else {
     return null
   }

--- a/core/modules/url/helpers/index.ts
+++ b/core/modules/url/helpers/index.ts
@@ -13,34 +13,20 @@ export function parametrizeRouteData (routeData: LocalizedRoute, query: { [id: s
   return parametrizedRoute
 }
 
-function prepareDynamicRoute (routeData: LocalizedRoute, fullPath: string, addToRoutes: boolean = true): RouteConfig[] {
+function prepareDynamicRoutes (routeData: LocalizedRoute, fullPath: string): RouteConfig[] {
   const userRoute = RouterManager.findByName(routeData.name)
   if (userRoute) {
-    if (addToRoutes) {
-      const routes = []
-      const rootDynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + fullPath, name: `urldispatcher-${fullPath}` })
-      routes.push(rootDynamicRoute)
-      if (config.storeViews.mapStoreUrlsFor.length > 0 && config.storeViews.multistore === true) {
-        for (let storeCode of config.storeViews.mapStoreUrlsFor) {
-          if (storeCode) {
-            const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + ((config.defaultStoreCode !== storeCode) ? (storeCode + '/') : '') + fullPath, name: `urldispatcher-${fullPath}-${storeCode}` })
-            routes.push(dynamicRoute)
-          }
-        }
-      }
-      return routes
-    } else {
-      const dynamicRouteName = (config.defaultStoreCode !== currentStoreView().storeCode) ? `urldispatcher-${fullPath}-${currentStoreView().storeCode}` : `urldispatcher-${fullPath}` 
-      const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + fullPath, name: dynamicRouteName })
-      return [dynamicRoute]
-    }
+    const currentStoreCode = currentStoreView().storeCode
+    const dynamicRouteName = (config.defaultStoreCode !== currentStoreCode) ? `urldispatcher-${fullPath}-${currentStoreView().storeCode}` : `urldispatcher-${fullPath}`
+    const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + ((config.defaultStoreCode !== currentStoreCode) ? (currentStoreCode + '/') : '') + fullPath, name: dynamicRouteName })
+    return [dynamicRoute]    
   } else {
     return null
   }
 }
 
 export function processDynamicRoute (routeData: LocalizedRoute, fullPath: string, addToRoutes: boolean = true): LocalizedRoute[] {
-  const preparedRoutes = prepareDynamicRoute(routeData, fullPath, addToRoutes)
+  const preparedRoutes = prepareDynamicRoutes(routeData, fullPath)
   if (addToRoutes && preparedRoutes) {
     RouterManager.addRoutes(preparedRoutes, router)
   }
@@ -50,7 +36,7 @@ export function processDynamicRoute (routeData: LocalizedRoute, fullPath: string
 export function processMultipleDynamicRoutes (dispatcherMap: {}, addToRoutes: boolean = true): LocalizedRoute[] {
   const preparedRoutes = []
   for (const [url, routeData] of Object.entries(dispatcherMap)) {
-    preparedRoutes.push(...prepareDynamicRoute(routeData, url, true))
+    preparedRoutes.push(...prepareDynamicRoutes(routeData, url))
   }
   if (addToRoutes) {
     RouterManager.addRoutes(preparedRoutes, router)

--- a/core/modules/url/helpers/index.ts
+++ b/core/modules/url/helpers/index.ts
@@ -17,8 +17,8 @@ function prepareDynamicRoutes (routeData: LocalizedRoute, fullPath: string): Rou
   const userRoute = RouterManager.findByName(routeData.name)
   if (userRoute) {
     const currentStoreCode = currentStoreView().storeCode
-    const dynamicRouteName = (config.defaultStoreCode !== currentStoreCode) ? `urldispatcher-${fullPath}-${currentStoreView().storeCode}` : `urldispatcher-${fullPath}`
-    const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + ((config.defaultStoreCode !== currentStoreCode) ? (currentStoreCode + '/') : '') + fullPath, name: dynamicRouteName })
+    const dynamicRouteName = (config.defaultStoreCode !== currentStoreCode) ? `urldispatcher-${fullPath}-${currentStoreCode}` : `urldispatcher-${fullPath}`
+    const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + fullPath, name: dynamicRouteName })
     return [dynamicRoute]
   } else {
     return null
@@ -40,7 +40,6 @@ export function processMultipleDynamicRoutes (dispatcherMap: {}, addToRoutes: bo
   }
   if (addToRoutes) {
     RouterManager.addRoutes(preparedRoutes, router)
-    console.log(preparedRoutes)
   }
   return preparedRoutes
 }

--- a/core/modules/url/helpers/index.ts
+++ b/core/modules/url/helpers/index.ts
@@ -23,7 +23,7 @@ function prepareDynamicRoute (routeData: LocalizedRoute, fullPath: string, addTo
       if (config.storeViews.mapStoreUrlsFor.length > 0 && config.storeViews.multistore === true) {
         for (let storeCode of config.storeViews.mapStoreUrlsFor) {
           if (storeCode) {
-            const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + ((config.defaultStoreCode !== storeCode) ? (storeCode + '/') : '') + fullPath, name: `urldispatcher-${fullPath}-${storeCode}` })
+            const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + ((config.defaultStoreCode !== storeCode) ? (storeCode + '/') : '') + fullPath, name: `urldispatcher-${fullPath}` })
             routes.push(dynamicRoute)
           }
         }
@@ -49,10 +49,11 @@ export function processDynamicRoute (routeData: LocalizedRoute, fullPath: string
 export function processMultipleDynamicRoutes (dispatcherMap: {}, addToRoutes: boolean = true): LocalizedRoute[] {
   const preparedRoutes = []
   for (const [url, routeData] of Object.entries(dispatcherMap)) {
-    preparedRoutes.push(...prepareDynamicRoute(routeData, url, addToRoutes))
+    preparedRoutes.push(...prepareDynamicRoute(routeData, url, true))
   }
   if (addToRoutes) {
     RouterManager.addRoutes(preparedRoutes, router)
+    console.log(preparedRoutes)
   }
   return preparedRoutes
 }

--- a/core/modules/url/helpers/index.ts
+++ b/core/modules/url/helpers/index.ts
@@ -21,7 +21,7 @@ function prepareDynamicRoutes (routeData: LocalizedRoute, fullPath: string): Rou
     const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + fullPath, name: dynamicRouteName })
     return [dynamicRoute]
   } else {
-    return null
+    return []
   }
 }
 

--- a/core/modules/url/helpers/index.ts
+++ b/core/modules/url/helpers/index.ts
@@ -51,6 +51,7 @@ export function findRouteByPath (fullPath: string): RouteConfig {
 export function normalizeUrlPath (url: string): string {
   if (url && url.length > 0) {
     if (url[0] === '/') url = url.slice(1)
+    if (url.endsWith('/')) url = url.slice(0, -1)
     const queryPos = url.indexOf('?')
     if (queryPos > 0) url = url.slice(0, queryPos)
   }

--- a/core/modules/url/helpers/index.ts
+++ b/core/modules/url/helpers/index.ts
@@ -1,6 +1,6 @@
 import { router } from '@vue-storefront/core/app'
 import config from 'config'
-import { localizedDispatcherRoute, localizedRoute, LocalizedRoute } from '@vue-storefront/core/lib/multistore'
+import { localizedDispatcherRoute, localizedRoute, LocalizedRoute, currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { RouteConfig } from 'vue-router/types/router';
 import { RouterManager } from '@vue-storefront/core/lib/router-manager'
 
@@ -23,14 +23,15 @@ function prepareDynamicRoute (routeData: LocalizedRoute, fullPath: string, addTo
       if (config.storeViews.mapStoreUrlsFor.length > 0 && config.storeViews.multistore === true) {
         for (let storeCode of config.storeViews.mapStoreUrlsFor) {
           if (storeCode) {
-            const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + ((config.defaultStoreCode !== storeCode) ? (storeCode + '/') : '') + fullPath, name: `urldispatcher-${fullPath}` })
+            const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + ((config.defaultStoreCode !== storeCode) ? (storeCode + '/') : '') + fullPath, name: `urldispatcher-${fullPath}-${storeCode}` })
             routes.push(dynamicRoute)
           }
         }
       }
       return routes
     } else {
-      const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + fullPath, name: `urldispatcher-${fullPath}` })
+      const dynamicRouteName = (config.defaultStoreCode !== currentStoreView().storeCode) ? `urldispatcher-${fullPath}-${currentStoreView().storeCode}` : `urldispatcher-${fullPath}` 
+      const dynamicRoute = Object.assign({}, userRoute, routeData, { path: '/' + fullPath, name: dynamicRouteName })
       return [dynamicRoute]
     }
   } else {

--- a/core/modules/url/store/actions.ts
+++ b/core/modules/url/store/actions.ts
@@ -23,9 +23,11 @@ export const actions: ActionTree<UrlState, any> = {
   async registerDynamicRoutes ({ state, dispatch }) {
     if (state.dispatcherMap) {
       processMultipleDynamicRoutes(state.dispatcherMap) // check if we're to add routes to vue router
+      const registrationQueue = []
       for (const [url, routeData] of Object.entries(state.dispatcherMap)) {
-        await dispatch('registerMapping', { url, routeData })
+        registrationQueue.push(dispatch('registerMapping', { url, routeData }))
       }
+      Promise.all(registrationQueue)
     }
   },
   mapUrl ({ state, dispatch }, { url, query }: { url: string, query: string}) {

--- a/core/modules/url/store/actions.ts
+++ b/core/modules/url/store/actions.ts
@@ -23,7 +23,7 @@ export const actions: ActionTree<UrlState, any> = {
     if (state.dispatcherMap) {
       processMultipleDynamicRoutes(state.dispatcherMap)
       for (const [url, routeData] of Object.entries(state.dispatcherMap)) {
-        dispatch('registerMapping', { url, routeData })
+        await dispatch('registerMapping', { url, routeData })
       }
     }
   },

--- a/core/modules/url/store/actions.ts
+++ b/core/modules/url/store/actions.ts
@@ -7,13 +7,14 @@ import queryString from 'query-string'
 import SearchQuery from '@vue-storefront/core/lib/search/searchQuery'
 import { processMultipleDynamicRoutes, normalizeUrlPath, parametrizeRouteData } from '../helpers'
 import { storeCodeFromRoute, removeStoreCodeFromRoute } from '@vue-storefront/core/lib/multistore'
+import config from 'config'
 
 // it's a good practice for all actions to return Promises with effect of their execution
 export const actions: ActionTree<UrlState, any> = {
   // if you want to use cache in your module you can load cached data like this
   async registerMapping ({ commit }, { url, routeData }: { url: string, routeData: any}) {
     commit(types.REGISTER_MAPPING, { url, routeData })
-    await cacheStorage.setItem(url, routeData)
+    await cacheStorage.setItem(normalizeUrlPath(url), routeData)
     return routeData
   },
   /**
@@ -21,7 +22,7 @@ export const actions: ActionTree<UrlState, any> = {
    */
   async registerDynamicRoutes ({ state, dispatch }) {
     if (state.dispatcherMap) {
-      processMultipleDynamicRoutes(state.dispatcherMap)
+      processMultipleDynamicRoutes(state.dispatcherMap) // check if we're to add routes to vue router
       for (const [url, routeData] of Object.entries(state.dispatcherMap)) {
         await dispatch('registerMapping', { url, routeData })
       }

--- a/core/server-entry.ts
+++ b/core/server-entry.ts
@@ -2,13 +2,14 @@ import union from 'lodash-es/union'
 
 import { createApp } from '@vue-storefront/core/app'
 import { HttpError } from '@vue-storefront/core/helpers/exceptions'
-import { prepareStoreView, storeCodeFromRoute } from '@vue-storefront/core/lib/multistore'
+import { storeCodeFromRoute } from '@vue-storefront/core/lib/multistore'
 import omit from 'lodash-es/omit'
 import pick from 'lodash-es/pick'
 import buildTimeConfig from 'config'
 import { AsyncDataLoader } from '@vue-storefront/core/lib/async-data-loader'
 import config from 'config'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import queryString from 'query-string'
 
 function _commonErrorHandler (err, reject) {
   if (err.message.indexOf('query returned empty result') > 0) {
@@ -59,23 +60,21 @@ function _ssrHydrateSubcomponents (components, store, router, resolve, reject, a
 }
 
 export default async context => {
-  const { app, router, store } = await createApp(context, context.vs && context.vs.config ? context.vs.config : buildTimeConfig)
+  let storeCode = context.vs.storeCode
+  if (config.storeViews.multistore === true) {
+    if (storeCode === undefined) { // this is from url
+      const currentRoute = Object.assign({ path: queryString.parseUrl(context.url).url/* this gets just the url path part */, host: context.server.request.headers.host })
+      storeCode = storeCodeFromRoute(currentRoute)
+      console.log(storeCode, currentRoute)
+    }
+  }
+  const { app, router, store } = await createApp(context, context.vs && context.vs.config ? context.vs.config : buildTimeConfig, storeCode)
   return new Promise((resolve, reject) => {
     context.output.cacheTags = new Set<string>()
     const meta = (app as any).$meta()
     router.push(context.url)
     context.meta = meta
     router.onReady(() => {
-      if (config.storeViews.multistore === true) {
-        let storeCode = context.vs.storeCode // this is from http header or env variable
-        if (storeCode === undefined && router.currentRoute) { // this is from url
-          const currentRoute = Object.assign({}, router.currentRoute, {host: context.server.request.headers.host})
-          storeCode = storeCodeFromRoute(currentRoute)
-        }
-        if (storeCode !== '' && storeCode !== null) {
-          prepareStoreView(storeCode)
-        }
-      }
       const matchedComponents = router.getMatchedComponents()
       if (!matchedComponents.length) {
         return reject(new HttpError('No components matched', 404))

--- a/core/server-entry.ts
+++ b/core/server-entry.ts
@@ -62,7 +62,7 @@ function _ssrHydrateSubcomponents (components, store, router, resolve, reject, a
 export default async context => {
   let storeCode = context.vs.storeCode
   if (config.storeViews.multistore === true) {
-    if (storeCode === undefined) { // this is from url
+    if (!storeCode) { // this is from url
       const currentRoute = Object.assign({ path: queryString.parseUrl(context.url).url/* this gets just the url path part */, host: context.server.request.headers.host })
       storeCode = storeCodeFromRoute(currentRoute)
       console.log(storeCode, currentRoute)


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

It fixes `UrlDispatcher` issues with multistore routes. Few independent issues were introduced from 1.10.1 with the fixes provided for SSR hydration  + `router.addRoutes` optimization. 

There was also a change regarding `prepareStoreView` call which now has been moved before `router.onReady` and therefore we could removed the second call in url dispatcher


Reported issues that this fix is solving (were not raised by Github issues):

**Issue 2 - Default storeview bug**
This is only reproducible on 1.10.2.
When trying to force 404:s I can see the following pattern:https://dearsam.com/se/nonExistingPage => https://dearsam.com/se/page-not-foundhttps://dearsam.com/no/nonExistingPage => https://dearsam.com/page-not-foundhttps://dearsam.com/de/nonExistingPage => https://dearsam.com/page-not-foundhttps://dearsam.com/fr/nonExistingPage => https://dearsam.com/page-not-foundhttps://dearsam.com/en/nonExistingPage => https://dearsam.com/page-not-found

As you can see only the /se site redirects to a localized /se/page-not-found. That means the other sites redirect to /page-no-found and that means the header and footer are not loaded so the visitor can’t navigate away from the 404 page.

I thought it had something to do with that the default storeview in base.json is set to se. That is why it “works” for se. But it seems I was mistaken because this is what is in base.json: "defaultStoreCode": "". Alhough the se storeview is the first one in the storeViews.mapStoreUrlsFor array in base.json.

**Issue 3**
Reproducible on 1.10.2
Context: We have a category in Magento called Posters which has a url_key posters (default storeview). In the country specific storeviews this category has different url_key as described by the table below.Working VSF urls are:https://dearsam.com/se/postershttps://dearsam.com/no/posters

Non working urls are:https://dearsam.com/de/posterhttps://dearsam.com/fr/afficheshttps://dearsam.com/en/printshttps://dearsam.com/us/prints
Possible pattern: In a multistore setup; each localized category url that matches the url_path of the default storeview works.

Magento Storeview      url_key
default posters              se
posters                          no
posters                          de
affiches                         fr
prints                            en
prints                            us

**Issue 4**

Any returning client (with cache from prev. deploy?) has various problems even with the <router-link> links.If I (and others) go to dearsam.com/se on mobile and navigate to ‘menu->posters->alla posters' I do come to the /se/posters page but the resultset is empty. And the Newsletter component in footer is French (Fredrik got German). I’m thinking VSF somehow mixes up which storefront is used.    I cannot reproduce this on desktop/computer. Only on mobile. this tells med this issue has to do with client cache (since mobile cache/app data is way harder to clear than on desktop)