### PR TITLE
Check separatorIndex is > -1 instead of truthiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix invalid routes in ButtonOutline and ButtonFull - @lukeromanowicz (#3541, #3545)
 - Fix for the "add to cart" test
 - prevent caching storage instance in plugin module scope @gibkigonzo (#3571)
+- Fixed error with dayjs when locale is 2-digit (without a '-') @rain2o (#3581)
 
 ### Changed / Improved
 

--- a/core/filters/date.js
+++ b/core/filters/date.js
@@ -16,7 +16,7 @@ export function date (date, format) {
   const displayFormat = format || currentStoreView().i18n.dateFormat
   let storeLocale = currentStoreView().i18n.defaultLocale.toLocaleLowerCase()
   const separatorIndex = storeLocale.indexOf('-')
-  const languageCode = separatorIndex ? storeLocale.substr(0, separatorIndex) : storeLocale
+  const languageCode = (separatorIndex > -1) ? storeLocale.substr(0, separatorIndex) : storeLocale
 
   const isStoreLocale = dayjs().locale(storeLocale).locale()
   const isLanguageLocale = dayjs().locale(languageCode).locale()


### PR DESCRIPTION
### Related issues
Closes #3581 

### Short description and why it's useful
In the scenario where a locale is only 2-digits (e.g. 'en'), `separatorIndex` has a value of `-1`. The line `const languageCode = separatorIndex ? storeLocale.substr(0, separatorIndex) : storeLocale` checks the "truthiness" of that value, which according to [MDN](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), -1 is actually truthy. This resulted in a series of errors because `languageCode` was an empty value which caused dayjs to complain about `dayjs().locale().locale()`. This PR is to check that the index is greater than -1 as opposed to the truthiness of it.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

