### PR TITLE
Show default CMS pages when current storeCode is not same as default one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove modifying config by reference in multistore - @gibkigonzo (#3617)
 - Add translation key for add review - @gibkigonzo (#3611)
 - Add product name prop to reviews component - @gibkigonzo (#3607)
-- Remove cms links when there is no translation loaded - @andrzejewsky (#3579)
+- Show default cms pages when current store code is not equals to default  - @andrzejewsky (#3579)
 
 ### Changed / Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove modifying config by reference in multistore - @gibkigonzo (#3617)
 - Add translation key for add review - @gibkigonzo (#3611)
 - Add product name prop to reviews component - @gibkigonzo (#3607)
+- Remove cms links when there is no translation loaded - @andrzejewsky (#3579)
 
 ### Changed / Improved
 

--- a/src/themes/default/components/core/blocks/Footer/Footer.vue
+++ b/src/themes/default/components/core/blocks/Footer/Footer.vue
@@ -50,7 +50,7 @@
                 </router-link>
               </div>
             </div>
-            <div class="start-md">
+            <div class="start-md" v-if="displayAboutSection">
               <h3 class="cl-accent weight-400">
                 {{ $t('About us') }}
               </h3>
@@ -158,6 +158,7 @@
 </template>
 
 <script>
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import CurrentPage from 'theme/mixins/currentPage'
 import LanguageSwitcher from '../../LanguageSwitcher.vue'
 import Newsletter from 'theme/components/core/blocks/Footer/Newsletter'
@@ -168,6 +169,9 @@ export default {
   mixins: [CurrentPage],
   name: 'MainFooter',
   computed: {
+    displayAboutSection () {
+      return currentStoreView().storeCode === config.defaultStoreCode
+    },
     multistoreEnabled () {
       return config.storeViews.multistore
     },

--- a/src/themes/default/components/core/blocks/Footer/Footer.vue
+++ b/src/themes/default/components/core/blocks/Footer/Footer.vue
@@ -50,22 +50,22 @@
                 </router-link>
               </div>
             </div>
-            <div class="start-md" v-if="displayAboutSection">
+            <div class="start-md">
               <h3 class="cl-accent weight-400">
                 {{ $t('About us') }}
               </h3>
               <div class="mt15">
-                <router-link class="cl-secondary" :to="localizedRoute('/i/about-us')" exact>
+                <router-link class="cl-secondary" :to="getLinkFor('/about-us')" exact>
                   {{ $t('About us (Magento CMS)') }}
                 </router-link>
               </div>
               <div class="mt15">
-                <router-link class="cl-secondary" :to="localizedRoute('/i/customer-service')" exact>
+                <router-link class="cl-secondary" :to="getLinkFor('/customer-service')" exact>
                   {{ $t('Customer service (Magento CMS)') }}
                 </router-link>
               </div>
               <div class="mt15">
-                <router-link class="cl-secondary" :to="localizedRoute('/store-locator')" exact>
+                <router-link class="cl-secondary" :to="getLinkFor('/store-locator')" exact>
                   {{ $t('Store locator') }}
                 </router-link>
               </div>
@@ -158,7 +158,7 @@
 </template>
 
 <script>
-import { currentStoreView } from '@vue-storefront/core/lib/multistore'
+import { currentStoreView, localizedRoute } from '@vue-storefront/core/lib/multistore'
 import CurrentPage from 'theme/mixins/currentPage'
 import LanguageSwitcher from '../../LanguageSwitcher.vue'
 import Newsletter from 'theme/components/core/blocks/Footer/Newsletter'
@@ -169,7 +169,7 @@ export default {
   mixins: [CurrentPage],
   name: 'MainFooter',
   computed: {
-    displayAboutSection () {
+    isStoreCodeEquals () {
       return currentStoreView().storeCode === config.defaultStoreCode
     },
     multistoreEnabled () {
@@ -177,6 +177,12 @@ export default {
     },
     getVersionInfo () {
       return `v${process.env.__APPVERSION__} ${process.env.__BUILDTIME__}`
+    }
+  },
+  methods: {
+    getLinkFor (path) {
+      const route = this.isStoreCodeEquals ? `/i${path}` : path
+      return localizedRoute(route)
     }
   },
   components: {


### PR DESCRIPTION
### Related issues
closes #3579

### Which environment this relates to
- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

