### PR TITLE
fix login errors with mailchimp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove modifying config by reference in multistore - @gibkigonzo (#3617)
 - Add translation key for add review - @gibkigonzo (#3611)
 - Add product name prop to reviews component - @gibkigonzo (#3607)
+- Fix login errors with mailchimp - @gibkigonzo (#3612)
 
 ### Changed / Improved
 

--- a/core/data-resolver/NewsletterService.ts
+++ b/core/data-resolver/NewsletterService.ts
@@ -10,7 +10,8 @@ const isSubscribed = (email: string): Promise<boolean> =>
       method: 'GET',
       headers: { 'Content-Type': 'application/json' },
       mode: 'cors'
-    }
+    },
+    silent: true
   }).then(({ result }) => result === 'subscribed')
 
 const subscribe = (email: string): Promise<boolean> =>

--- a/core/lib/sync/task.ts
+++ b/core/lib/sync/task.ts
@@ -33,7 +33,7 @@ function _sleep (time) {
 }
 
 function _internalExecute (resolve, reject, task: Task, currentToken, currentCartId) {
-  if (currentToken !== null && rootStore.state.userTokenInvalidateLock > 0) { // invalidate lock set
+  if (currentToken && rootStore.state.userTokenInvalidateLock > 0) { // invalidate lock set
     Logger.log('Waiting for rootStore.state.userTokenInvalidateLock to release for ' + task.url, 'sync')()
     _sleep(1000).then(() => {
       Logger.log('Another try for rootStore.state.userTokenInvalidateLock for ' + task.url, 'sync')()
@@ -75,7 +75,7 @@ function _internalExecute (resolve, reject, task: Task, currentToken, currentCar
     if (jsonResponse) {
       const responseCode = parseInt(jsonResponse.code)
       if (responseCode !== 200) {
-        if (responseCode === 401 /** unauthorized */ && currentToken !== null) { // the token is no longer valid, try to invalidate it
+        if (responseCode === 401 /** unauthorized */ && currentToken) { // the token is no longer valid, try to invalidate it
           Logger.error('Invalid token - need to be revalidated' + currentToken + task.url + rootStore.state.userTokenInvalidateLock, 'sync')()
           if (isNaN(rootStore.state.userTokenInvalidateAttemptsCount) || isUndefined(rootStore.state.userTokenInvalidateAttemptsCount)) rootStore.state.userTokenInvalidateAttemptsCount = 0
           if (isNaN(rootStore.state.userTokenInvalidateLock) || isUndefined(rootStore.state.userTokenInvalidateLock)) rootStore.state.userTokenInvalidateLock = 0

--- a/core/lib/sync/task.ts
+++ b/core/lib/sync/task.ts
@@ -42,7 +42,7 @@ function _internalExecute (resolve, reject, task: Task, currentToken, currentCar
     return // return but not resolve
   } else if (rootStore.state.userTokenInvalidateLock < 0) {
     Logger.error('Aborting the network task' + task.url + rootStore.state.userTokenInvalidateLock, 'sync')()
-    resolve({ code: 401, message: i18n.t('Error refreshing user token. User is not authorized to access the resource') })()
+    resolve({ code: 401, result: i18n.t('Error refreshing user token. User is not authorized to access the resource') })()
     return
   } else {
     if (rootStore.state.userTokenInvalidated) {

--- a/core/modules/cart/store/actions/index.ts
+++ b/core/modules/cart/store/actions/index.ts
@@ -9,7 +9,7 @@ import mergeActions from './mergeActions';
 import methodsActions from './methodsActions'
 import productActions from './productActions'
 import quantityActions from './quantityActions'
-import synchronizeActions from './syncrhonizeActions'
+import synchronizeActions from './synchronizeActions'
 import totalsActions from './totalsActions'
 
 const actions: ActionTree<CartState, RootState> = {

--- a/core/modules/cart/store/actions/synchronizeActions.ts
+++ b/core/modules/cart/store/actions/synchronizeActions.ts
@@ -7,7 +7,7 @@ import { CartService } from '@vue-storefront/core/data-resolver'
 import { createDiffLog } from '@vue-storefront/core/modules/cart/helpers'
 import i18n from '@vue-storefront/i18n'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
-import { cartHooksExecutors } from './../../hooks'
+import { cartHooksExecutors } from '../../hooks'
 
 const synchronizeActions = {
   async load ({ commit, dispatch }, { forceClientState = false }: {forceClientState?: boolean} = {}) {

--- a/core/modules/catalog/index.ts
+++ b/core/modules/catalog/index.ts
@@ -35,8 +35,8 @@ export const CatalogModule: StorefrontModule = async function (app, store, route
     EventBus.$on('product-after-bundleoptions', payload => productAfterBundleoptions(payload, store))
 
     if (config.usePriceTiers || store.getters['tax/getIsUserGroupedTaxActive']) {
-      EventBus.$on('user-after-loggedin', onUserPricesRefreshed(store, router))
-      EventBus.$on('user-after-logout', onUserPricesRefreshed(store, router))
+      EventBus.$on('user-after-loggedin', onUserPricesRefreshed.bind(null, store, router))
+      EventBus.$on('user-after-logout', onUserPricesRefreshed.bind(null, store, router))
     }
   }
 }

--- a/core/modules/user/store/actions.ts
+++ b/core/modules/user/store/actions.ts
@@ -109,7 +109,7 @@ const actions: ActionTree<UserState, RootState> = {
       commit(types.USER_INFO_LOADED, currentUser)
       await dispatch('setUserGroup', currentUser)
       EventBus.$emit('user-after-loggedin', currentUser)
-      await dispatch('cart/authorize', {}, { root: true })
+      dispatch('cart/authorize', {}, { root: true })
 
       return currentUser
     }
@@ -126,7 +126,7 @@ const actions: ActionTree<UserState, RootState> = {
 
     if (!resolvedFromCache && resp.resultCode === 200) {
       EventBus.$emit('user-after-loggedin', resp.result)
-      await dispatch('cart/authorize', {}, { root: true })
+      dispatch('cart/authorize', {}, { root: true })
       return resp
     }
   },


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3612

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Added silent mode for GET subscription request. Fixed function apply to event listener on 'user-after-loggedin' event (`onUserPricesRefreshed` didn't return function). Added checking if `currentToken` is falsy value, because it can be initially as empty string (this caused running `user/refresh` request with empty `token`). Also allow to synchronize cart in the background.


### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

