### PR TITLE
keep product sku as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `filterMinimumShouldMatch` to ES queries in order to support ES7 - @pkarw (#1692)
 - Pass `RouteManager` as proxy for router.addRoutes - @gibkigonzo (#3479)
 - Added generic types to hooks - @gibkigonzo
+- Added mapping data as soon as it gets from api - @gibkigonzo (#3606)
 
 ## [1.10.3] - 2019.09.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,7 +169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `filterMinimumShouldMatch` to ES queries in order to support ES7 - @pkarw (#1692)
 - Pass `RouteManager` as proxy for router.addRoutes - @gibkigonzo (#3479)
 - Added generic types to hooks - @gibkigonzo
-- Added mapping data as soon as it gets from api - @gibkigonzo (#3606)
+- Change sku to string when checking products equality - @gibkigonzo (#3606)
 
 ## [1.10.3] - 2019.09.18
 

--- a/core/modules/cart/helpers/productsEquals.ts
+++ b/core/modules/cart/helpers/productsEquals.ts
@@ -33,7 +33,7 @@ const productsEquals = (product1: CartItem, product2: CartItem): boolean => {
     return isServerIdsEquals(product1, product2) || isChecksumEquals(product1, product2)
   }
 
-  return product1.sku === product2.sku
+  return String(product1.sku) === String(product2.sku)
 }
 
 export default productsEquals

--- a/core/modules/cart/store/actions/synchronizeActions.ts
+++ b/core/modules/cart/store/actions/synchronizeActions.ts
@@ -52,7 +52,8 @@ const synchronizeActions = {
     if (!canUpdateMethods || !isSyncRequired) return createDiffLog()
     commit(types.CART_SET_SYNC)
     const { result, resultCode } = await CartService.getItems()
-    const { serverItems, clientItems } = cartHooksExecutors.beforeSync({ clientItems: getCartItems, serverItems: result })
+    const mappedResult = result.map(r => ({...r, sku: String(r.sku)}))
+    const { serverItems, clientItems } = cartHooksExecutors.beforeSync({ clientItems: getCartItems, serverItems: mappedResult })
 
     if (resultCode === 200) {
       const diffLog = await dispatch('merge', {
@@ -71,8 +72,8 @@ const synchronizeActions = {
       await dispatch('connect', { guestCart: true })
     }
 
-    Logger.error(result, 'cart')
-    cartHooksExecutors.afterSync(result)
+    Logger.error(mappedResult, 'cart')
+    cartHooksExecutors.afterSync(mappedResult)
     return createDiffLog()
   },
   async stockSync ({ dispatch, commit }, stockTask) {

--- a/core/modules/cart/store/actions/synchronizeActions.ts
+++ b/core/modules/cart/store/actions/synchronizeActions.ts
@@ -52,8 +52,7 @@ const synchronizeActions = {
     if (!canUpdateMethods || !isSyncRequired) return createDiffLog()
     commit(types.CART_SET_SYNC)
     const { result, resultCode } = await CartService.getItems()
-    const mappedResult = result.map(r => ({...r, sku: String(r.sku)}))
-    const { serverItems, clientItems } = cartHooksExecutors.beforeSync({ clientItems: getCartItems, serverItems: mappedResult })
+    const { serverItems, clientItems } = cartHooksExecutors.beforeSync({ clientItems: getCartItems, serverItems: result })
 
     if (resultCode === 200) {
       const diffLog = await dispatch('merge', {
@@ -72,8 +71,8 @@ const synchronizeActions = {
       await dispatch('connect', { guestCart: true })
     }
 
-    Logger.error(mappedResult, 'cart')
-    cartHooksExecutors.afterSync(mappedResult)
+    Logger.error(result, 'cart')
+    cartHooksExecutors.afterSync(result)
     return createDiffLog()
   },
   async stockSync ({ dispatch, commit }, stockTask) {


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3606

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Added mapping `cartItem` as soon as it gets from api. However I didn't found line in code where we change sku to string. I mean what if someone want to keep all skus as numbers :thinking: ? I think backend api should keep data type consistent.  


### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

