### PR TITLE
Add unit testing on breadcrumbs feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add unit testing on breadcrumbs feature - @mattheo-geoffray (#3457)
 - HTML Minifier has been added, to enable it please switch the `config.server.useHtmlMinifier` - @pkarw (#2182)
 - Output compression module has been added; it's enabled by default on production builds; to disable it please switch the `src/modules/serrver.ts` configuration - @pkarw (#2182)
 - Sort CSV i18n files alphabetically in pre-commit Git hook - @defudef (#2657)

--- a/core/modules/breadcrumbs/test/unit/parseCategoryPath.spec.ts
+++ b/core/modules/breadcrumbs/test/unit/parseCategoryPath.spec.ts
@@ -1,0 +1,175 @@
+import { parseCategoryPath } from '@vue-storefront/core/modules/breadcrumbs/helpers';
+import { Category } from '@vue-storefront/core/modules/catalog-next/types/Category';
+import { currentStoreView } from '@vue-storefront/core/lib/multistore';
+
+jest.mock('@vue-storefront/core/app', () => jest.fn());
+jest.mock('@vue-storefront/core/lib/router-manager', () => jest.fn());
+jest.mock('@vue-storefront/core/lib/multistore', () => ({
+  currentStoreView: jest.fn(),
+  localizedDispatcherRoute: jest.fn(),
+  localizedRoute: jest.fn()
+}));
+jest.mock('@vue-storefront/core/helpers', () => ({
+  once: (str) => jest.fn()
+}))
+
+describe('parseCategoryPath method', () => {
+  describe('on category page', () => {
+    let categories: Category[];
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (currentStoreView as jest.Mock).mockImplementation(() => ({storeCode: ''}));
+      categories = [
+        {
+          path: '1/2',
+          is_active: true,
+          level: 1,
+          product_count: 1181,
+          children_count: '38',
+          parent_id: 1,
+          name: 'All',
+          id: 2,
+          url_key: 'all-2',
+          children_data: [],
+          url_path: 'all-2',
+          slug: 'all-2'
+        },
+        { path: '1/2/20',
+          is_active: true,
+          level: 2,
+          product_count: 0,
+          children_count: '8',
+          parent_id: 2,
+          name: 'Women',
+          id: 20,
+          url_path: 'women/women-20',
+          url_key: 'women-20',
+          children_data: [],
+          slug: 'women-20'
+        },
+        {
+          path: '1/2/20/21',
+          is_active: true,
+          level: 3,
+          product_count: 0,
+          children_count: '4',
+          parent_id: 20,
+          name: 'Tops',
+          id: 21,
+          url_path: 'women/tops-women/tops-21',
+          url_key: 'tops-21',
+          children_data: [],
+          slug: 'tops-21'
+        }
+      ];
+    });
+
+    it('should return formatted category path for breadcrumbs', () => {
+      const result = parseCategoryPath(categories);
+      const expected = [
+        {
+          name: 'All',
+          route_link: '/all-2'
+        },
+        {
+          name: 'Women',
+          route_link: '/women/women-20'
+        },
+        {
+          name: 'Tops',
+          route_link: '/women/tops-women/tops-21'
+        }
+      ];
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('on product page', () => {
+    let categories;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (currentStoreView as jest.Mock).mockImplementation(() => ({storeCode: ''}));
+      categories = [
+        {
+          path: '1/2',
+          is_active: true,
+          level: 1,
+          product_count: 1181,
+          children_count: '38',
+          parent_id: 1,
+          name: 'All',
+          id: 2,
+          url_key: 'all-2',
+          children_data: [],
+          url_path: 'all-2',
+          slug: 'all-2'
+        },
+        { path: '1/2/20',
+          is_active: true,
+          level: 2,
+          product_count: 0,
+          children_count: '8',
+          parent_id: 2,
+          name: 'Women',
+          id: 20,
+          url_path: 'women/women-20',
+          url_key: 'women-20',
+          children_data: [],
+          slug: 'women-20'
+        },
+        {
+          path: '1/2/20/21',
+          is_active: true,
+          level: 3,
+          product_count: 0,
+          children_count: '4',
+          parent_id: 20,
+          name: 'Tops',
+          id: 21,
+          url_path: 'women/tops-women/tops-21',
+          url_key: 'tops-21',
+          children_data: [],
+          slug: 'tops-21'
+        },
+        {
+          path: '1/2/20/21/23',
+          is_active: true,
+          level: 4,
+          product_count: 186,
+          children_count: '0',
+          parent_id: 21,
+          name: 'Jackets',
+          id: 23,
+          url_key: 'jackets-23',
+          url_path: 'women/tops-women/jackets-women/jackets-23',
+          slug: 'jackets-23'
+        }
+      ];
+    });
+
+    it('should return formatted category path for breadcrumbs', () => {
+      const result = parseCategoryPath(categories);
+      const expected = [
+        {
+          name: 'All',
+          route_link: '/all-2'
+        },
+        {
+          name: 'Women',
+          route_link: '/women/women-20'
+        },
+        {
+          name: 'Tops',
+          route_link: '/women/tops-women/tops-21'
+        },
+        {
+          name: 'Jackets',
+          route_link: '/women/tops-women/jackets-women/jackets-23'
+        }
+      ];
+      expect(result).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
### Related issues
https://github.com/DivanteLtd/vue-storefront/issues/3457

### Short description and why it's useful
Adding unit testing on breadcrumbs feature for category and product page



### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

