### PR TITLE
added catch for fetching single product in cart synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Broken sidebar menu in mobile view - @przspa (#3549)
 - UrlDispatcher issues with multistore routes - @pkarw (#3568)
+- Added try/catch for fetching single product in cart synchronization - @gibkigonzo (#)
 
 ## [1.10.2] - 2019.09.06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.10.4] - 2019.09.27
+## [1.10.4] - UNRELEASED
 
 ### Fixed
-- Added try/catch for fetching single product in cart synchronization - @gibkigonzo (#)
+- Added try/catch for fetching single product in cart synchronization - @gibkigonzo (#3632)
 
 ## [1.10.3] - 2019.09.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.4] - 2019.09.27
+
+### Fixed
+- Added try/catch for fetching single product in cart synchronization - @gibkigonzo (#)
+
 ## [1.10.3] - 2019.09.18
 
 ### Fixed
 - Broken sidebar menu in mobile view - @przspa (#3549)
 - UrlDispatcher issues with multistore routes - @pkarw (#3568)
-- Added try/catch for fetching single product in cart synchronization - @gibkigonzo (#)
 
 ## [1.10.2] - 2019.09.06
 

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -699,22 +699,22 @@ const actions: ActionTree<CartState, RootState> = {
               })
               diffLog.serverResponses.push({ 'status': res.resultCode, 'sku': serverItem.sku, 'result': res })
             } else {
-              const getServerCartItem = new Promise(async resolve => {
+              const getServerCartItem = async () => {
                 try {
                   const actionOtions = await productActionOptions(serverItem)
 
                   if (!actionOtions) {
-                    resolve(null)
+                    return null
                   }
 
                   const product = await dispatch('product/single', { options: actionOtions, assignDefaultVariant: true, setCurrentProduct: false, selectDefaultVariant: false }, { root: true })
 
-                  resolve({ product: product, serverItem: serverItem })
+                  return { product: product, serverItem: serverItem }
                 } catch (err) {
-                  resolve(null)
+                  return null
                 }
-              })
-              clientCartAddItems.push(getServerCartItem)
+              }
+              clientCartAddItems.push(getServerCartItem())
             }
           }
         }

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -545,20 +545,16 @@ const actions: ActionTree<CartState, RootState> = {
     const clientCartAddItems = []
 
     /** helper to find the item to be added to the cart by sku */
-    let productActionOptions = (serverItem) => {
-      return new Promise(resolve => {
-        if (serverItem.product_type === 'configurable') {
-          let searchQuery = new SearchQuery()
-          searchQuery = searchQuery.applyFilter({key: 'configurable_children.sku', value: {'eq': serverItem.sku}})
-          dispatch('product/list', {query: searchQuery, start: 0, size: 1, updateState: false}, { root: true }).then((resp) => {
-            if (resp.items.length >= 1) {
-              resolve({ sku: resp.items[0].sku, childSku: serverItem.sku })
-            }
-          })
-        } else {
-          resolve({ sku: serverItem.sku })
-        }
-      })
+    const productActionOptions = async (serverItem) => {
+      if (serverItem.product_type === 'configurable') {
+        let query = new SearchQuery()
+        query = query.applyFilter({key: 'configurable_children.sku', value: {'eq': serverItem.sku}})
+
+        const { items } = await dispatch('product/list', { query, start: 0, size: 1, updateState: false }, { root: true })
+
+        return items.length >= 1 ? { sku: items[0].sku, childSku: serverItem.sku } : null
+      }
+      return { sku: serverItem.sku }
     }
     /** helper - sub method to update the item in the cart */
     const _updateClientItem = async function ({ dispatch }, event, clientItem) {
@@ -703,38 +699,48 @@ const actions: ActionTree<CartState, RootState> = {
               })
               diffLog.serverResponses.push({ 'status': res.resultCode, 'sku': serverItem.sku, 'result': res })
             } else {
-              clientCartAddItems.push(
-                new Promise(resolve => {
-                  productActionOptions(serverItem).then((actionOtions) => {
-                    dispatch('product/single', { options: actionOtions, assignDefaultVariant: true, setCurrentProduct: false, selectDefaultVariant: false }, { root: true }).then((product) => {
-                      resolve({ product: product, serverItem: serverItem })
-                    })
-                  })
-                })
-              )
+              const getServerCartItem = new Promise(async resolve => {
+                try {
+                  const actionOtions = await productActionOptions(serverItem)
+
+                  if (!actionOtions) {
+                    resolve(null)
+                  }
+
+                  const product = await dispatch('product/single', { options: actionOtions, assignDefaultVariant: true, setCurrentProduct: false, selectDefaultVariant: false }, { root: true })
+
+                  resolve({ product: product, serverItem: serverItem })
+                } catch (err) {
+                  resolve(null)
+                }
+              })
+              clientCartAddItems.push(getServerCartItem)
             }
           }
         }
       }
     }
-    if (clientCartAddItems.length) {
+
+    const resolvedCartItems = await Promise.all(clientCartAddItems)
+    const validCartItems = resolvedCartItems.filter(Boolean)
+
+    if (validCartItems.length) {
       totalsShouldBeRefreshed = true
       clientCartUpdateRequired = true
       cartHasItems = true
     }
     diffLog.items.push({ 'party': 'client', 'status': clientCartUpdateRequired ? 'update-required' : 'no-changes' })
     diffLog.items.push({ 'party': 'server', 'status': serverCartUpdateRequired ? 'update-required' : 'no-changes' })
-    Promise.all(clientCartAddItems).then((items) => {
-      items.map(({ product, serverItem }) => {
-        product.server_item_id = serverItem.item_id
-        product.qty = serverItem.qty
-        product.server_cart_id = serverItem.quote_id
-        if (serverItem.product_option) {
-          product.product_option = serverItem.product_option
-        }
-        dispatch('addItem', { productToAdd: product, forceServerSilence: true })
-      })
-    })
+
+    for (const { product, serverItem } of validCartItems) {
+      product.server_item_id = serverItem.item_id
+      product.qty = serverItem.qty
+      product.server_cart_id = serverItem.quote_id
+      if (serverItem.product_option) {
+        product.product_option = serverItem.product_option
+      }
+      dispatch('addItem', { productToAdd: product, forceServerSilence: true })
+    }
 
     if (!dryRun) {
       if (totalsShouldBeRefreshed && cartHasItems) {

--- a/core/modules/cart/store/actions.ts
+++ b/core/modules/cart/store/actions.ts
@@ -709,6 +709,10 @@ const actions: ActionTree<CartState, RootState> = {
 
                   const product = await dispatch('product/single', { options: actionOtions, assignDefaultVariant: true, setCurrentProduct: false, selectDefaultVariant: false }, { root: true })
 
+                  if (!product) {
+                    return null
+                  }
+
                   return { product: product, serverItem: serverItem }
                 } catch (err) {
                   return null


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3632

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
This allows to catch errors when user add product to cart in magento that not exist in elasticsearch.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

