### PR TITLE
Get Shipping Methods with Shipping Address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added generic types to hooks - @gibkigonzo
 - Change sku to string when checking products equality - @gibkigonzo (#3606)
 - Pass to `registerModule` all parameters as one object - @gibkigonzo (#3634)
+- Include shipping address data in request for shipping methods for more accurate filtering - @rain2o (#2515)
 
 ## [1.10.3] - 2019.09.18
 

--- a/core/modules/cart/store/actions/methodsActions.ts
+++ b/core/modules/cart/store/actions/methodsActions.ts
@@ -47,9 +47,20 @@ const methodsActions = {
     if (getters.canUpdateMethods && (getters.isTotalsSyncRequired || forceServerSync)) {
       const storeView = currentStoreView()
       Logger.debug('Refreshing shipping methods', 'cart')()
-      const { result } = await CartService.getShippingMethods({
-        country_id: rootGetters['checkout/getShippingDetails'].country || storeView.tax.defaultCountry
-      })
+      const shippingDetails = rootGetters['checkout/getShippingDetails']
+
+      // build address data with what we have
+      const address = (shippingDetails) ? {
+        region: shippingDetails.state,
+        region_id: shippingDetails.region_id ? shippingDetails.region_id : 0,
+        country_id: shippingDetails.country,
+        street: [shippingDetails.streetAddress1, shippingDetails.streetAddress2],
+        postcode: shippingDetails.zipCode,
+        city: shippingDetails.city,
+        region_code: shippingDetails.region_code ? shippingDetails.region_code : ''
+      } : {country_id: storeView.tax.defaultCountry}
+
+      const { result } = await CartService.getShippingMethods(address)
       await dispatch('updateShippingMethods', { shippingMethods: result })
     } else {
       Logger.debug('Shipping methods does not need to be updated', 'cart')()


### PR DESCRIPTION
### Related issues
closes #2515

### Short description and why it's useful
The original request of this issue was to have the shipping methods request called after the user switches their country in shipping address, I believe. This has already been introduced as part of the refactoring. This PR includes more data than just country as some shipping providers need more information to accurately calculate the price or availability. It checks if we have any shipping data and provides it as we have it.

Personally I think it would be better to send a copy of the shippingDetails getter result, and build the address object in the api layer within the platform-specific classes. I didn't do this because currently there doesn't seem to be any sort of logic in these files. However, building objects to send in the API seems to be platform-specific and could cause issues for anyone not integrating with Magento. I might be wrong about this though, but that's just my thought. For now I build the address object before sending to API.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

