### PR TITLE
Add Category filters on route change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Add Category filters on route change - @jakubmakielkowski (#3660)
 - Attributes loader, breadcrumbs loader fixes - @pkarw (#3636)
 - Fix for the product attribute labels displayedd on the PDP - @pkarw (#3530)
 - Fix the mix of informal and polite personal pronouns for German translations - @nhp (#3533)

--- a/core/modules/catalog-next/store/category/getters.ts
+++ b/core/modules/catalog-next/store/category/getters.ts
@@ -13,6 +13,7 @@ import { Category } from '../../types/Category'
 import { parseCategoryPath } from '@vue-storefront/core/modules/breadcrumbs/helpers'
 import { _prepareCategoryPathIds, getSearchOptionsFromRouteParams } from '../../helpers/categoryHelpers';
 import { removeStoreCodeFromRoute } from '@vue-storefront/core/lib/multistore'
+import rootStore from '@vue-storefront/core/store'
 
 const getters: GetterTree<CategoryState, RootState> = {
   getCategories: (state): Category[] => Object.values(state.categoriesMap),
@@ -98,7 +99,9 @@ const getters: GetterTree<CategoryState, RootState> = {
     return filters
   },
   getFiltersMap: state => state.filtersMap,
-  getAvailableFilters: (state, getters) => getters.getCurrentCategory ? state.filtersMap[getters.getCurrentCategory.id] : {},
+  getAvailableFilters: (state, getters) => {
+    return getters.getCurrentCategory && state.filtersMap[getters.getCurrentCategory.id] ? state.filtersMap[getters.getCurrentCategory.id] : state.filtersMap[rootStore.state.category.current.id]
+  },
   getCurrentFiltersFrom: (state, getters, rootState) => (filters) => {
     const currentQuery = filters || rootState.route[products.routerFiltersSource]
     return getFiltersFromQuery({availableFilters: getters.getAvailableFilters, filtersQuery: currentQuery})

--- a/core/store/index.ts
+++ b/core/store/index.ts
@@ -35,7 +35,8 @@ const state = {
     current_product_query: {},
     current: {
       slug: '',
-      name: ''
+      name: '',
+      id: 0
     },
     filters: {}
   },

--- a/core/types/RootState.ts
+++ b/core/types/RootState.ts
@@ -18,7 +18,8 @@ export default interface RootState {
     current_product_query: any,
     current: {
       slug: string,
-      name: string
+      name: string,
+      id: number
     },
     filters: any
   },


### PR DESCRIPTION
Bug was available when choosing color filter in category, then navigating to other page (eg. product) and then navigating backwards to category.
After this action color is selected in sidebar but filters are **NOT** applied.

### Short description and why it's useful
Removes bug

- [X] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

