### PR TITLE
Fix redirecting from profile when you are not logged in

### DIFF
--- a/core/pages/MyAccount.js
+++ b/core/pages/MyAccount.js
@@ -2,6 +2,7 @@ import i18n from '@vue-storefront/i18n'
 
 import Composite from '@vue-storefront/core/mixins/composite'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { currentStoreView, localizedRoute } from '@vue-storefront/core/lib/multistore'
 
 export default {
   name: 'MyAccount',
@@ -26,7 +27,7 @@ export default {
     await this.$store.dispatch('user/startSession')
     if (!this.$store.getters['user/isLoggedIn']) {
       localStorage.setItem('redirect', this.$route.path)
-      this.$router.push('/')
+      this.$router.push(localizedRoute('/', currentStoreView().storeCode))
     }
   },
   destroyed () {


### PR DESCRIPTION
### Short description and why it's useful
There was a problem with redirecting: when you are not logged in, and you go to different store than default (eg, `de`), then to the `my-account`, the redirect will lead you to the homepage with errors. This is simple fix for that.

### Which environment this relates to
- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature


### Contribution and currently important rules acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

