### PR TITLE
remove 'disabled' flag in storeViews config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change sku to string when checking products equality - @gibkigonzo (#3606)
 - Pass to `registerModule` all parameters as one object - @gibkigonzo (#3634)
 - Include shipping address data in request for shipping methods for more accurate filtering - @rain2o (#2515)
+- remove 'disabled' flag in storeViews config - @gibkigonzo (#3659)
 
 ## [1.10.3] - 2019.09.18
 

--- a/config/default.json
+++ b/config/default.json
@@ -115,7 +115,6 @@
     "mapStoreUrlsFor": ["de", "it"],
     "de": {
       "storeCode": "de",
-      "disabled": true,
       "storeId": 3,
       "name": "German Store",
       "url": "/de",
@@ -147,7 +146,6 @@
     "it": {
       "extend": "de",
       "storeCode": "it",
-      "disabled": true,
       "storeId": 4,
       "name": "Italian Store",
       "url": "/it",

--- a/core/i18n/scripts/translation.preprocessor.js
+++ b/core/i18n/scripts/translation.preprocessor.js
@@ -46,10 +46,8 @@ module.exports = function (csvDirectories, config = null) {
     bundledLanguages[config.i18n.defaultLocale] = messages[config.i18n.defaultLocale] // default locale
     Object.keys(config.storeViews).forEach((storeCode) => {
       const store = config.storeViews[storeCode]
-      if (store.hasOwnProperty('storeCode')) {
-        if (!store.disabled && store.i18n) {
-          bundledLanguages[store.i18n.defaultLocale] = messages[store.i18n.defaultLocale]
-        }
+      if (store && typeof store === 'object' && store.i18n) {
+        bundledLanguages[store.i18n.defaultLocale] = messages[store.i18n.defaultLocale]
       }
     })
     fs.writeFileSync(path.join(__dirname, '../resource/i18n', `multistoreLanguages.json`), JSON.stringify(bundledLanguages))

--- a/docs/guide/basics/configuration.md
+++ b/docs/guide/basics/configuration.md
@@ -179,12 +179,6 @@ You should add all the multistore codes to the `mapStoreUrlsFor` as this propert
 This attribute is not inherited through the "extend" mechanism.
 
 ```json
-    "disabled": true,
-```
-
-If the specific store is disabled, it won't be used to populate the routing table and won't be displayed in the `Language/Switcher.vue`.
-
-```json
     "storeId": 3,
 ```
 

--- a/docs/guide/cookbook/setup.md
+++ b/docs/guide/cookbook/setup.md
@@ -452,7 +452,6 @@ At [`vue-storefront-api/config/default.json`](https://github.com/DivanteLtd/vue-
     ],
     "de": {
       "storeCode": "de",
-      "disabled": true,
       "storeId": 3,
       "name": "German Store",
       "url": "/de",
@@ -479,7 +478,6 @@ At [`vue-storefront-api/config/default.json`](https://github.com/DivanteLtd/vue-
     },
     "it": {
       "storeCode": "it",
-      "disabled": true,
       "storeId": 4,
       "name": "Italian Store",
       "url": "/it",
@@ -512,7 +510,6 @@ At [`vue-storefront-api/config/default.json`](https://github.com/DivanteLtd/vue-
 - `mapStoreUrlsFor` is used for building url routes in frontend. [jump to code](https://github.com/DivanteLtd/vue-storefront/blob/master/core/lib/multistore.ts#L85)
 - `de` element contains detailed information of `de` store. You need to have this kind of element for all the additional stores you added to `availableStores` with `storeCode` as the key. `de` and `it` in the `default.json` exhibits an example you can copy & paste for other stores you need to add. 
   - `storeCode` denotes store code for the store. 
-  - `disabled` means if this store is disabled. 
   - `storeId` denotes store ID of the store.
   - `name` denotes the store name.
   - `url` denotes URL for the store.
@@ -954,7 +951,6 @@ At [`vue-storefront/config/default.json`](https://github.com/DivanteLtd/vue-stor
   "mapStoreUrlsFor": ["de", "it"],
   "de": {
     "storeCode": "de",
-    "disabled": true,
     "storeId": 3,
     "name": "German Store",
     "url": "/de",
@@ -981,7 +977,6 @@ At [`vue-storefront/config/default.json`](https://github.com/DivanteLtd/vue-stor
   },
   "it": {
     "storeCode": "it",
-    "disabled": true,
     "storeId": 4,
     "name": "Italian Store",
     "url": "/it",

--- a/docs/guide/installation/production-setup.md
+++ b/docs/guide/installation/production-setup.md
@@ -237,7 +237,6 @@ Please find the key sections of the `vue-storefront/config/local.json` file desc
     ],
     "multistore": true,
     "de": {
-        "disabled": false,
         "elasticsearch": {
             "httpAuth": "",
             "host": "https://prod.vuestorefront.io/api/catalog",
@@ -245,7 +244,6 @@ Please find the key sections of the `vue-storefront/config/local.json` file desc
         }
     },
     "it": {
-        "disabled": false,
         "elasticsearch": {
             "httpAuth": "",
             "host": "https://prod.vuestorefront.io/api/catalog",

--- a/docs/guide/installation/vue-storefront/config/local.json
+++ b/docs/guide/installation/vue-storefront/config/local.json
@@ -11,7 +11,6 @@
         ],
         "multistore": true,
         "de": {
-            "disabled": false,
             "elasticsearch": {
                 "httpAuth": "",
                 "host": "https://prod.vuestorefront.io/api/catalog",
@@ -19,7 +18,6 @@
             }
         },
         "it": {
-            "disabled": false,
             "elasticsearch": {
                 "httpAuth": "",
                 "host": "https://prod.vuestorefront.io/api/catalog",

--- a/docs/guide/integrations/multistore.md
+++ b/docs/guide/integrations/multistore.md
@@ -92,7 +92,6 @@ The last thing is to change the `vue-storefront/config/local.json` to configure 
       "mapStoreUrlsFor": ["de", "it"],
       "de": {
         "storeCode": "de",
-        "disabled": true,
         "storeId": 3,
         "name": "German Store",
         "url": "/de",
@@ -118,7 +117,6 @@ The last thing is to change the `vue-storefront/config/local.json` to configure 
       },
       "it": {
         "storeCode": "it",
-        "disabled": true,
         "storeId": 4,
         "name": "Italian Store",
         "url": "/it",

--- a/docs/guide/upgrade-notes/README.md
+++ b/docs/guide/upgrade-notes/README.md
@@ -86,6 +86,7 @@ If by some reasons you wan't to have the `localStorage` back on for `Products by
   - Delete the line `RouterManager.addRoutes(routes, router, true)`. This is now handled in `setupMultistoreRoutes`, including the default store.
   - Optionally give theme routes priority, to ensure they override module routes if there are any conflicts. For example `setupMultistoreRoutes(config, router, routes, 10)`.
   - See `/src/themes/default/index.js` for a complete example.
+- In `storeView` config there is no more `disabled` flag for specific language config. Links for other languages will be displayed if specific `storeView` config exist.
 
 ## 1.9 -> 1.10
 - Event `application-after-init` is now emitted by event bus instead of root Vue instance (app), so you need to listen to `Vue.prototype.$bus` (`EventBus.$on()`) now

--- a/src/themes/default/components/core/blocks/Switcher/Language.vue
+++ b/src/themes/default/components/core/blocks/Switcher/Language.vue
@@ -6,12 +6,12 @@
     <div slot="content">
       <div :class="{ 'columns': enableColumns }">
         <div class="country country-current">
-          <h3>{{ $t(config.i18n.fullCountryName) }}</h3>
+          <h3>{{ $t(fullCountryName) }}</h3>
           <ul>
-            <li><a href="/">{{ $t(config.i18n.fullLanguageName) }}</a></li>
+            <li><a href="/">{{ $t(fullLanguageName) }}</a></li>
           </ul>
         </div>
-        <div class="country country-available" v-for="(storeView, storeCode) in storeViews" :key="storeCode" v-if="!storeView.disabled && typeof storeView === 'object' && storeView.i18n">
+        <div class="country country-available" v-for="(storeView, storeCode) in storeViews" :key="storeCode">
           <h3>{{ $t(storeView.i18n.fullCountryName) }}</h3>
           <ul>
             <li><a :href="storeView.url">{{ $t(storeView.i18n.fullLanguageName) }}</a></li>
@@ -35,18 +35,23 @@ export default {
     }
   },
   computed: {
-    storeViews () {
-      return config.storeViews
+    fullCountryName () {
+      return config.i18n.fullCountryName
     },
-    config () {
-      return config
+    fullLanguageName () {
+      return config.i18n.fullLanguageName
     },
     enableColumns () {
-      var enableStoreViews = Object.keys(config.storeViews).filter((key) => {
-        var value = config.storeViews[key]
-        return (typeof value === 'object' && value.disabled === false)
-      })
+      const enableStoreViews = Object.keys(this.storeViews)
       return enableStoreViews.length > this.minCountryPerColumn
+    },
+    storeViews () {
+      return Object.keys(config.storeViews).reduce((storeViews, storeCode) => {
+        if (this.isValidStoreCode(storeCode)) {
+          storeViews[storeCode] = config.storeViews[storeCode]
+        }
+        return storeViews
+      }, {})
     }
   },
   mounted () {
@@ -58,6 +63,10 @@ export default {
   methods: {
     close () {
       this.$bus.$emit('modal-hide', 'modal-switcher')
+    },
+    isValidStoreCode (storeCode) {
+      const storeView = config.storeViews[storeCode]
+      return !!(storeView && typeof storeView === 'object' && storeView.i18n)
     }
   }
 }


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3659

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Removed `disabled` flag from storeView config. This flag is misleading because it's used only in language switcher and while building messages json. It's not used in multistore.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

