### PR TITLE
Get rid of annoying i18n warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Remove annoying i18n fallback warning when using per component i18n messages - @oskar1233
+
 ## [1.10.3] - 2019.09.18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For an up-to-date list of supported browsers please see "browserslist" in packag
 
 ## Join the community on Slack
 
-If you have any questions or ideas feel free to join our slack: https://vuestorefront.slack.com via [invitation link](https://join.slack.com/t/vuestorefront/shared_invite/enQtMzA4MTM2NTE5NjM2LTI1M2RmOWIyOTk0MzFlMDU3YzJlYzcyYzNiNjUyZWJiMTZjZjc3MjRlYmE5ZWQ1YWRhNTQyM2ZjN2ZkMzZlNTg)
+If you have any questions or ideas feel free to join our slack: https://vuestorefront.slack.com via [invitation link](https://join.slack.com/t/vuestorefront/shared_invite/enQtNTAwODYzNzI3MjAzLWFkZjc0YjVjODA1Y2I2MTdlNmM0NThjY2M5MzgzN2U2NzE4YmE2YzA4YTM0MTY3OWQzZjBhMjBlZDhmYjAyNGI)
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -824,10 +824,10 @@ Vue Storefront is a Community effort brought to You by our great Core Team and s
         </a>
 </td>
    <td align="center" valign="middle"> 
-<a href="">
+<a href="https://kiwicommerce.co.uk/">
           <img
-            src=""
-            alt=""
+            src="https://divante.com/partners/Vue-Storefront/KiwiCommerce%20Logo.png"
+            alt="KiwiCommerce"
             height="40"
           >
         </a>

--- a/core/i18n/index.ts
+++ b/core/i18n/index.ts
@@ -10,6 +10,7 @@ once('__VUE_EXTEND_I18N__', () => {
 
 const loadedLanguages = ['en-US']
 const i18n = new VueI18n({
+  silentFallbackWarn: true,
   locale: config.i18n.bundleAllStoreviewLanguages ? config.i18n.defaultLocale : 'en-US', // set locale
   fallbackLocale: 'en-US',
   messages: config.i18n.bundleAllStoreviewLanguages ? require('./resource/i18n/multistoreLanguages.json') : {


### PR DESCRIPTION
### Related issues
None I'm aware of.

### Short description
Get rid of annoying warning about falling back from per-component i18n message to global message.

> To suppress these warnings (while keeping those which warn of the total absence of translation for the given key) set silentFallbackWarn: true when initializing the VueI18n instance.
https://kazupon.github.io/vue-i18n/guide/fallback.html

### Which environment this relates to
I'd go for stable as it's tiny PR.

No upgrade steps required.