### PR TITLE
Allow to have access to the storeCode inside metaInfo()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed problem with extending storeView configuration - @andrzejewsky (#3655)
 - Removed infinite loop when changing checkbox in shipping details - @gibkigonzo (#3656)
 - Fixed displaying single order in the profile - @andrzejewsky (#3663)
+- Fixed missing storeCode in metaInfo - @andrzejewsky (#3674)
 
 ### Changed / Improved
 

--- a/core/helpers/initialStateFactory.ts
+++ b/core/helpers/initialStateFactory.ts
@@ -5,7 +5,11 @@ const initialStateFactory = (defaultState) => {
   // storing default values for the fields that will be set in createApp
   const defaultFields = pick(defaultState, ['version', 'config', '__DEMO_MODE__', 'storeView'])
 
-  const createInitialState = (currentState) => ({ ...cloneDeep(currentState), ...defaultFields })
+  const createInitialState = (currentState) => ({
+    ...cloneDeep(currentState),
+    ...defaultFields,
+    storeView: { storeCode: currentState.storeView.storeCode }
+  })
 
   return { createInitialState }
 }


### PR DESCRIPTION
### Related issues
closes #3674

### Which environment this relates to
- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature


### Contribution and currently important rules acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

