### PR TITLE
Fix: Dynamic urls name should only be prefixed when appendStoreCode is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0-rc.2] - unreleased
+
+### Fixed
+
+ - Fixed problem around dynamic urls when default storeView is set with appendStoreCode false and url set to / . @resubaka (#3685)
+
 ## [1.11.0-rc.1] - 2019.10.03
 
 ### Added

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -141,8 +141,11 @@ export function localizedDispatcherRoute (routeObj: LocalizedRoute | string, sto
   return routeObj
 }
 
-export function localizedDispatcherRouteName (routeName: string, storeCode: string): string {
-  return storeCode ? `${storeCode}-${routeName}` : routeName
+export function localizedDispatcherRouteName (routeName: string, storeCode: string, appendStoreCode: boolean = false): string {
+  if (appendStoreCode) {
+    return `${storeCode}-${routeName}`
+  }
+  return routeName
 }
 
 export function localizedRoute (routeObj: LocalizedRoute | string | RouteConfig | RawLocation, storeCode: string): any {
@@ -170,6 +173,7 @@ export function localizedRoute (routeObj: LocalizedRoute | string | RouteConfig 
 }
 
 export function setupMultistoreRoutes (config, router: VueRouter, routes: RouteConfig[], priority: number = 0): void {
+  debugger
   const allRoutes: RouteConfig[] = []
   const { storeCode, appendStoreCode } = currentStoreView()
   if (storeCode && appendStoreCode) {

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -173,7 +173,6 @@ export function localizedRoute (routeObj: LocalizedRoute | string | RouteConfig 
 }
 
 export function setupMultistoreRoutes (config, router: VueRouter, routes: RouteConfig[], priority: number = 0): void {
-  debugger
   const allRoutes: RouteConfig[] = []
   const { storeCode, appendStoreCode } = currentStoreView()
   if (storeCode && appendStoreCode) {

--- a/core/modules/catalog-next/store/category/actions.ts
+++ b/core/modules/catalog-next/store/category/actions.ts
@@ -109,14 +109,14 @@ const actions: ActionTree<CategoryState, RootState> = {
     })
   },
   async registerCategoryProductsMapping ({ dispatch }, products = []) {
-    const storeCode = currentStoreView().storeCode
+    const { storeCode, appendStoreCode } = currentStoreView()
     await Promise.all(products.map(product => {
       const { url_path, sku, slug, type_id } = product
       return dispatch('url/registerMapping', {
         url: localizedDispatcherRoute(url_path, storeCode),
         routeData: {
           params: { parentSku: product.sku, slug },
-          'name': localizedDispatcherRouteName(type_id + '-product', storeCode)
+          'name': localizedDispatcherRouteName(type_id + '-product', storeCode, appendStoreCode)
         }
       }, { root: true })
     }))

--- a/core/modules/catalog/store/category/actions.ts
+++ b/core/modules/catalog/store/category/actions.ts
@@ -63,7 +63,7 @@ const actions: ActionTree<CategoryState, RootState> = {
     return list
   },
   async registerCategoryMapping ({ dispatch }, { categories }) {
-    const storeCode = currentStoreView().storeCode
+    const { storeCode, appendStoreCode } = currentStoreView()
     for (let category of categories) {
       if (category.url_path) {
         await dispatch('url/registerMapping', {
@@ -72,7 +72,7 @@ const actions: ActionTree<CategoryState, RootState> = {
             params: {
               'slug': category.slug
             },
-            'name': localizedDispatcherRouteName('category', storeCode)
+            'name': localizedDispatcherRouteName('category', storeCode, appendStoreCode)
           }
         }, { root: true })
       }

--- a/core/modules/catalog/store/product/actions.ts
+++ b/core/modules/catalog/store/product/actions.ts
@@ -296,7 +296,7 @@ const actions: ActionTree<ProductState, RootState> = {
     return searchResult
   },
   preConfigureAssociated (context, { searchResult, prefetchGroupProducts }) {
-    const storeCode = currentStoreView().storeCode
+    const { storeCode, appendStoreCode } = currentStoreView()
     for (let product of searchResult.items) {
       if (product.url_path) {
         const { parentSku, slug } = product
@@ -305,7 +305,7 @@ const actions: ActionTree<ProductState, RootState> = {
           url: localizedDispatcherRoute(product.url_path, storeCode),
           routeData: {
             params: { parentSku, slug },
-            'name': localizedDispatcherRouteName(product.type_id + '-product', storeCode)
+            'name': localizedDispatcherRouteName(product.type_id + '-product', storeCode, appendStoreCode)
           }
         }, { root: true })
       }

--- a/core/modules/url/store/actions.ts
+++ b/core/modules/url/store/actions.ts
@@ -66,7 +66,7 @@ export const actions: ActionTree<UrlState, any> = {
    * This method could be overriden in custom module to provide custom URL mapping logic
    */
   async mappingFallback ({ dispatch }, { url, params }: { url: string, params: any}) {
-    const storeCode = currentStoreView().storeCode
+    const { storeCode, appendStoreCode } = currentStoreView()
     const productQuery = new SearchQuery()
     url = (removeStoreCodeFromRoute(url.startsWith('/') ? url.slice(1) : url) as string)
     productQuery.applyFilter({key: 'url_path', value: {'eq': url}}) // Tees category
@@ -74,7 +74,7 @@ export const actions: ActionTree<UrlState, any> = {
     if (products && products.items && products.items.length) {
       const product = products.items[0]
       return {
-        name: localizedDispatcherRouteName(product.type_id + '-product', storeCode),
+        name: localizedDispatcherRouteName(product.type_id + '-product', storeCode, appendStoreCode),
         params: {
           slug: product.slug,
           parentSku: product.sku,
@@ -85,7 +85,7 @@ export const actions: ActionTree<UrlState, any> = {
       const category = await dispatch('category/single', { key: 'url_path', value: url }, { root: true })
       if (category !== null) {
         return {
-          name: localizedDispatcherRouteName('category', storeCode),
+          name: localizedDispatcherRouteName('category', storeCode, appendStoreCode),
           params: {
             slug: category.slug
           }


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
This is a fix for when you have the defaultStoreCode set to an storeView
for example de and have appendStoreCode false and url as /. Then it
currently does not work when multistore is active.

With this is does work as the base url is now the de store with no prefix
in the dynamic url name.

You can still switch to to it store and there all urls work.

Testet against the https://next.storefrontcloud.io api.



### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

