### PR TITLE
Reset nested menu after logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.11.0-rc.2] - unreleased
 
 ### Fixed
+- Reset nested menu after logout - @gibkigonzo (#3680)
 
  - Fixed deprecated getter in cmsBlock store - @resubaka (#3683)
  - Fixed problem around dynamic urls when default storeView is set with appendStoreCode false and url set to / . @resubaka (#3685)

--- a/src/themes/default/components/core/blocks/SidebarMenu/SubCategory.vue
+++ b/src/themes/default/components/core/blocks/SidebarMenu/SubCategory.vue
@@ -143,9 +143,10 @@ export default {
     }
   },
   methods: {
-    logout () {
-      this.$store.dispatch('user/logout', {})
+    async logout () {
+      await this.$store.dispatch('user/logout', {})
       this.$router.push(this.localizedRoute('/'))
+      this.$store.commit('ui/setSubmenu', { depth: false })
     },
     notify (title) {
       if (title === 'My loyalty card' || title === 'My product reviews') {


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3680

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
It clears nested menu after user logout. Also I've added await for logout action to be sure that user is logout before redirection.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

