### PR TITLE
ignore all .map files for service worker cache

### DIFF
--- a/core/build/webpack.prod.sw.config.ts
+++ b/core/build/webpack.prod.sw.config.ts
@@ -20,7 +20,9 @@ module.exports = merge(base, {
       filename: 'service-worker.js',
       staticFileGlobsIgnorePatterns: [/\.map$/],
       staticFileGlobs: [
-        'dist/**.*',
+        'dist/**.*.js',
+        'dist/**.*.json',
+        'dist/**.*.css',
         'assets/**.*',
         'assets/ig/**.*',
         'index.html',


### PR DESCRIPTION
### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
In service-worker webpack config there is regex which should filter `.map` files but It doesn't.
`staticFileGlobsIgnorePatterns: [/\.map$/]`
So we load for sw almost 2mb .map files in production (before gzip :P)
 
As I checked in `node_modules/sw-precache-webpack-plugin/src/index.js` this regex is used on current emited files and for `staticFileGlobs`. 
```
    // merge assetGlobs with provided staticFileGlobs and filter using staticFileGlobsIgnorePatterns
    const staticFileGlobs = assetGlobs.concat(this.options.staticFileGlobs || []).filter(text =>
      (!staticFileGlobsIgnorePatterns.some((regex) => regex.test(text)))
    );
```

So if sw is compiled in separate webpack then we filter only `core-service-worker.js.map`.
To fix this we can add more specific regex in `staticFileGlobs`.
```
      staticFileGlobs: [
        'dist/**.*.js',
        'dist/**.*.json',
        'dist/**.*.css',
```



### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

