### PR TITLE
Use encodeURIComponent to encode get parameters in multimatch.js #3736

### DIFF
--- a/core/lib/search/adapter/api/elasticsearch/multimatch.js
+++ b/core/lib/search/adapter/api/elasticsearch/multimatch.js
@@ -2,12 +2,10 @@ import config from 'config'
 
 function getConfig (queryText) {
   let scoringConfig = config.elasticsearch.hasOwnProperty('searchScoring') ? config.elasticsearch.searchScoring : {}
-  let minimumShouldMatch = ''
+  let minimumShouldMatch = scoringConfig.hasOwnProperty('minimum_should_match') ? scoringConfig.minimum_should_match : '75%'
   if (config.elasticsearch.queryMethod === 'GET') {
     // minimum_should_match param must be have a "%" suffix, which is an illegal char while sending over query string
-    minimumShouldMatch = scoringConfig.hasOwnProperty('minimum_should_match') ? scoringConfig.minimum_should_match + '25' : '75%25'
-  } else {
-    minimumShouldMatch = scoringConfig.hasOwnProperty('minimum_should_match') ? scoringConfig.minimum_should_match : '75%'
+    minimumShouldMatch = encodeURIComponent(minimumShouldMatch)
   }
   // Create config for multi match query
   let multiMatchConfig = {


### PR DESCRIPTION


### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3736

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Instead of using hardcoded values we can use encodeURIComponent in
https://github.com/DivanteLtd/vue-storefront/blob/develop/core/lib/search/adapter/api/elasticsearch/multimatch.js#L8


### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

