### PR TITLE
Add unit tests for `core/modules/wishlist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.11.0-rc.2] - UNRELEASED
 
+### Added
+
+- Add unit test for `core/modules/wishlist` - @psmyrek (#3471)
+
 ### Fixed
 
 

--- a/core/modules/wishlist/test/unit/components/AddToWishlist.spec.ts
+++ b/core/modules/wishlist/test/unit/components/AddToWishlist.spec.ts
@@ -1,0 +1,61 @@
+import { mountMixin, mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import { registerModule } from '@vue-storefront/core/lib/modules';
+import { WishlistModule } from '@vue-storefront/core/modules/wishlist';
+import { AddToWishlist } from '@vue-storefront/core/modules/wishlist/components/AddToWishlist';
+
+jest.mock('@vue-storefront/core/lib/storage-manager', () => ({}));
+jest.mock('@vue-storefront/core/lib/modules', () => ({ registerModule: jest.fn() }));
+jest.mock('@vue-storefront/core/helpers', () => ({ once: () => ({}) }));
+jest.mock('@vue-storefront/core/modules/wishlist/store', () => ({}));
+jest.mock('@vue-storefront/core/modules/wishlist/store/whishListPersistPlugin', () => ({}));
+jest.mock('@vue-storefront/core/modules/wishlist/mixins/wishlistMountedMixin', () => ({}));
+
+describe('AddToWishlist', () => {
+  let product;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    product = {
+      sku: 'example_sku',
+      image: 'example_image'
+    };
+  });
+
+  it('creates a component', () => {
+    const wrapper = mountMixin(AddToWishlist, {
+      propsData: { product }
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('component has been registered in "created" hook', () => {
+    mountMixin(AddToWishlist, {
+      propsData: { product }
+    });
+
+    expect(registerModule).toHaveBeenCalledWith(WishlistModule);
+  });
+
+  it('addToWishList method dispatches wishlist/addItem action', () => {
+    const mockStore = {
+      modules: {
+        wishlist: {
+          actions: {
+            addItem: jest.fn()
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    const wrapper = mountMixinWithStore(AddToWishlist, mockStore, {
+      propsData: { product }
+    });
+
+    (wrapper.vm as any).addToWishlist(product);
+
+    expect(mockStore.modules.wishlist.actions.addItem).toHaveBeenCalledWith(expect.anything(), product, undefined);
+  });
+});

--- a/core/modules/wishlist/test/unit/components/IsOnWishlist.spec.ts
+++ b/core/modules/wishlist/test/unit/components/IsOnWishlist.spec.ts
@@ -1,0 +1,63 @@
+import { mountMixin, mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import { registerModule } from '@vue-storefront/core/lib/modules';
+import { WishlistModule } from '@vue-storefront/core/modules/wishlist';
+import { IsOnWishlist } from '@vue-storefront/core/modules/wishlist/components/IsOnWishlist';
+
+jest.mock('@vue-storefront/core/lib/storage-manager', () => ({}));
+jest.mock('@vue-storefront/core/lib/modules', () => ({ registerModule: jest.fn() }));
+jest.mock('@vue-storefront/core/helpers', () => ({ once: () => ({}) }));
+jest.mock('@vue-storefront/core/modules/wishlist/store', () => ({}));
+jest.mock('@vue-storefront/core/modules/wishlist/store/whishListPersistPlugin', () => ({}));
+jest.mock('@vue-storefront/core/modules/wishlist/mixins/wishlistMountedMixin', () => ({}));
+
+describe('IsOnWishlist', () => {
+  let product;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    product = {
+      sku: 'example_sku',
+      image: 'example_image'
+    };
+  });
+
+  it('creates a component', () => {
+    const wrapper = mountMixin(IsOnWishlist, {
+      propsData: { product }
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('component has been registered in "created" hook', () => {
+    mountMixin(IsOnWishlist, {
+      propsData: { product }
+    });
+
+    expect(registerModule).toHaveBeenCalledWith(WishlistModule);
+  });
+
+  it('isOnWishlist computed property calls wishlist/isOnWishlist getter with product from prop', () => {
+    const isOnWishlistGetter = jest.fn(() => true);
+    const mockStore = {
+      modules: {
+        wishlist: {
+          getters: {
+            isOnWishlist: () => isOnWishlistGetter
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    const wrapper = mountMixinWithStore(IsOnWishlist, mockStore, {
+      propsData: { product }
+    });
+
+    const isOnWishlist = (wrapper.vm as any).isOnWishlist;
+
+    expect(isOnWishlistGetter).toHaveBeenCalledWith(product);
+    expect(isOnWishlist).toBe(true);
+  });
+});

--- a/core/modules/wishlist/test/unit/components/Product.spec.ts
+++ b/core/modules/wishlist/test/unit/components/Product.spec.ts
@@ -1,0 +1,59 @@
+import { mountMixin, mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import { WishlistProduct } from '@vue-storefront/core/modules/wishlist/components/Product';
+
+jest.mock('@vue-storefront/core/modules/wishlist/mixins/wishlistMountedMixin', () => ({}));
+
+describe('Product', () => {
+  let product;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    product = {
+      sku: 'example_sku',
+      image: 'example_image'
+    };
+  });
+
+  it('creates a component', () => {
+    const wrapper = mountMixin(WishlistProduct, {
+      propsData: { product }
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('thumbnail computed property calls getThumbnail method', () => {
+    const getThumbnail = jest.fn(() => 'thumbnail');
+    const wrapper = mountMixin(WishlistProduct, {
+      propsData: { product },
+      methods: { getThumbnail }
+    });
+
+    const thumbnail = (wrapper.vm as any).thumbnail;
+
+    expect(getThumbnail).toHaveBeenCalledWith(product.image, 150, 150);
+    expect(thumbnail).toBe('thumbnail');
+  });
+
+  it('removeFromWishlist method dispatches wishlist/removeItem action', () => {
+    const mockStore = {
+      modules: {
+        wishlist: {
+          actions: {
+            removeItem: jest.fn()
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    const wrapper = mountMixinWithStore(WishlistProduct, mockStore, {
+      propsData: { product }
+    });
+
+    (wrapper.vm as any).removeFromWishlist(product);
+
+    expect(mockStore.modules.wishlist.actions.removeItem).toHaveBeenCalledWith(expect.anything(), product, undefined);
+  });
+});

--- a/core/modules/wishlist/test/unit/components/RemoveFromWishlist.spec.ts
+++ b/core/modules/wishlist/test/unit/components/RemoveFromWishlist.spec.ts
@@ -1,0 +1,54 @@
+import { mountMixin, mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import { registerModule } from '@vue-storefront/core/lib/modules';
+import { WishlistModule } from '@vue-storefront/core/modules/wishlist';
+import { RemoveFromWishlist } from '@vue-storefront/core/modules/wishlist/components/RemoveFromWishlist';
+
+jest.mock('@vue-storefront/core/lib/storage-manager', () => ({}));
+jest.mock('@vue-storefront/core/lib/modules', () => ({ registerModule: jest.fn() }));
+jest.mock('@vue-storefront/core/helpers', () => ({ once: () => ({}) }));
+jest.mock('@vue-storefront/core/modules/wishlist/store', () => ({}));
+jest.mock('@vue-storefront/core/modules/wishlist/store/whishListPersistPlugin', () => ({}));
+jest.mock('@vue-storefront/core/modules/wishlist/mixins/wishlistMountedMixin', () => ({}));
+
+describe('RemoveFromWishlist', () => {
+  let product;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    product = {
+      sku: 'example_sku',
+      image: 'example_image'
+    };
+  });
+
+  it('creates a component', () => {
+    const wrapper = mountMixin(RemoveFromWishlist, {
+      propsData: { product }
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('removeFromWishlist method registers component and dispatches wishlist/removeItem action', () => {
+    const mockStore = {
+      modules: {
+        wishlist: {
+          actions: {
+            removeItem: jest.fn()
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    const wrapper = mountMixinWithStore(RemoveFromWishlist, mockStore, {
+      propsData: { product }
+    });
+
+    (wrapper.vm as any).removeFromWishlist(product);
+
+    expect(registerModule).toHaveBeenCalledWith(WishlistModule);
+    expect(mockStore.modules.wishlist.actions.removeItem).toHaveBeenCalledWith(expect.anything(), product, undefined);
+  });
+});

--- a/core/modules/wishlist/test/unit/components/Wishlist.spec.ts
+++ b/core/modules/wishlist/test/unit/components/Wishlist.spec.ts
@@ -1,0 +1,104 @@
+import { mountMixin, mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import { registerModule } from '@vue-storefront/core/lib/modules';
+import { WishlistModule } from '@vue-storefront/core/modules/wishlist';
+import { Wishlist } from '@vue-storefront/core/modules/wishlist/components/Wishlist';
+
+jest.mock('@vue-storefront/core/lib/storage-manager', () => ({}));
+jest.mock('@vue-storefront/core/lib/modules', () => ({ registerModule: jest.fn() }));
+jest.mock('@vue-storefront/core/helpers', () => ({ once: () => ({}) }));
+jest.mock('@vue-storefront/core/modules/wishlist/store', () => ({}));
+jest.mock('@vue-storefront/core/modules/wishlist/store/whishListPersistPlugin', () => ({}));
+jest.mock('@vue-storefront/core/modules/wishlist/mixins/wishlistMountedMixin', () => ({}));
+
+describe('Wishlist', () => {
+  let product;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    product = {
+      sku: 'example_sku',
+      image: 'example_image'
+    };
+  });
+
+  it('creates a component', () => {
+    const wrapper = mountMixin(Wishlist, {
+      propsData: { product }
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('component has been registered in "created" hook', () => {
+    mountMixin(Wishlist, {
+      propsData: { product }
+    });
+
+    expect(registerModule).toHaveBeenCalledWith(WishlistModule);
+  });
+
+  it('isWishlistOpen computed property returns ui/wishlist state', () => {
+    const mockStore = {
+      modules: {
+        ui: {
+          state: {
+            wishlist: true
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    const wrapper = mountMixinWithStore(Wishlist, mockStore, {
+      propsData: { product }
+    });
+
+    const result = (wrapper.vm as any).isWishlistOpen;
+
+    expect(result).toBe(true);
+  });
+
+  it('productsInWishlist computed property returns wishlist/items state', () => {
+    const wishlistItems = [{ sku: 1 }, { sku: 2 }, { sku: 3 }];
+    const mockStore = {
+      modules: {
+        wishlist: {
+          state: {
+            items: wishlistItems
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    const wrapper = mountMixinWithStore(Wishlist, mockStore, {
+      propsData: { product }
+    });
+
+    const result = (wrapper.vm as any).productsInWishlist;
+
+    expect(result).toBe(wishlistItems);
+  });
+
+  it('closeWishlist method dispatches ui/toggleWishlist action', () => {
+    const mockStore = {
+      modules: {
+        ui: {
+          actions: {
+            toggleWishlist: jest.fn()
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    const wrapper = mountMixinWithStore(Wishlist, mockStore, {
+      propsData: { product }
+    });
+
+    (wrapper.vm as any).closeWishlist();
+
+    expect(mockStore.modules.ui.actions.toggleWishlist).toHaveBeenCalled();
+  });
+});

--- a/core/modules/wishlist/test/unit/components/WishlistButton.spec.ts
+++ b/core/modules/wishlist/test/unit/components/WishlistButton.spec.ts
@@ -1,0 +1,57 @@
+import { mountMixin, mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import { WishlistButton } from '@vue-storefront/core/modules/wishlist/components/WishlistButton';
+
+jest.mock('@vue-storefront/core/modules/wishlist/mixins/wishlistMountedMixin', () => ({}));
+
+describe('WishlistButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a component', () => {
+    const wrapper = mountMixin(WishlistButton);
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('getWishlistItemsCount computed property calls wishlist/getWishlistItemsCount getter', () => {
+    const getWishlistItemsCountGetter = jest.fn(() => 42);
+    const mockStore = {
+      modules: {
+        wishlist: {
+          getters: {
+            getWishlistItemsCount: getWishlistItemsCountGetter
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    const wrapper = mountMixinWithStore(WishlistButton, mockStore);
+
+    const getWishlistItemsCount = (wrapper.vm as any).getWishlistItemsCount;
+
+    expect(getWishlistItemsCountGetter).toHaveBeenCalled();
+    expect(getWishlistItemsCount).toBe(42);
+  });
+
+  it('toggleWishlist method dispatches ui/toggleWishlist action', () => {
+    const mockStore = {
+      modules: {
+        ui: {
+          actions: {
+            toggleWishlist: jest.fn()
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    const wrapper = mountMixinWithStore(WishlistButton, mockStore);
+
+    (wrapper.vm as any).toggleWishlist();
+
+    expect(mockStore.modules.ui.actions.toggleWishlist).toHaveBeenCalled();
+  });
+});

--- a/core/modules/wishlist/test/unit/mixins/wishlistMountedMixin.spec.ts
+++ b/core/modules/wishlist/test/unit/mixins/wishlistMountedMixin.spec.ts
@@ -1,0 +1,25 @@
+import { mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import wishlistMountedMixin from '@vue-storefront/core/modules/wishlist/mixins/wishlistMountedMixin';
+
+describe('wishlistMountedMixin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dispatches wishlist/load action on mount', () => {
+    const mockStore = {
+      modules: {
+        wishlist: {
+          actions: {
+            load: jest.fn()
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    mountMixinWithStore(wishlistMountedMixin, mockStore);
+
+    expect(mockStore.modules.wishlist.actions.load).toHaveBeenCalled();
+  });
+});

--- a/core/modules/wishlist/test/unit/store/actions.spec.ts
+++ b/core/modules/wishlist/test/unit/store/actions.spec.ts
@@ -1,0 +1,130 @@
+import * as types from '@vue-storefront/core/modules/wishlist/store/mutation-types';
+import wishlistActions from '@vue-storefront/core/modules/wishlist/store/actions';
+import { StorageManager } from '@vue-storefront/core/lib/storage-manager';
+
+jest.mock('@vue-storefront/core/lib/storage-manager', () => ({
+  StorageManager: {
+    get: jest.fn()
+  }
+}));
+
+describe('Wishlist actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('clear', () => {
+    it('should delete all items', () => {
+      const mockContext = {
+        commit: jest.fn()
+      };
+
+      (wishlistActions as any).clear(mockContext);
+
+      expect(mockContext.commit).toHaveBeenCalledWith(types.WISH_DEL_ALL_ITEMS, []);
+    });
+  });
+
+  describe('load', () => {
+    let wishlist;
+
+    beforeEach(() => {
+      wishlist = [{ sku: 1 }, { sku: 2 }, { sku: 3 }];
+    });
+
+    it('should not load wishlist if it is already loaded', () => {
+      const mockContext = {
+        commit: jest.fn(),
+        dispatch: jest.fn(),
+        getters: {
+          isWishlistLoaded: true
+        }
+      };
+
+      (wishlistActions as any).load(mockContext);
+
+      expect(mockContext.commit).not.toHaveBeenCalled();
+      expect(mockContext.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('should load wishlist if it is not loaded', async () => {
+      const mockContext = {
+        commit: jest.fn(),
+        dispatch: jest.fn(() => {
+          return new Promise(resolve => resolve(wishlist));
+        }),
+        getters: {
+          isWishlistLoaded: false
+        }
+      };
+
+      await (wishlistActions as any).load(mockContext);
+
+      expect(mockContext.commit).toHaveBeenCalledTimes(2);
+      expect(mockContext.commit).toHaveBeenNthCalledWith(1, types.SET_WISHLIST_LOADED);
+      expect(mockContext.commit).toHaveBeenNthCalledWith(2, types.WISH_LOAD_WISH, wishlist);
+      expect(mockContext.dispatch).toHaveBeenCalledWith('loadFromCache');
+    });
+
+    it('should load wishlist with "force" argument even if it is already loaded', async () => {
+      const mockContext = {
+        commit: jest.fn(),
+        dispatch: jest.fn(() => {
+          return new Promise(resolve => resolve(wishlist));
+        }),
+        getters: {
+          isWishlistLoaded: true
+        }
+      };
+
+      await (wishlistActions as any).load(mockContext, true);
+
+      expect(mockContext.commit).toHaveBeenCalledTimes(2);
+      expect(mockContext.commit).toHaveBeenNthCalledWith(1, types.SET_WISHLIST_LOADED);
+      expect(mockContext.commit).toHaveBeenNthCalledWith(2, types.WISH_LOAD_WISH, wishlist);
+      expect(mockContext.dispatch).toHaveBeenCalledWith('loadFromCache');
+    });
+  });
+
+  describe('loadFromCache', () => {
+    it('should load wishlist from cache', () => {
+      const mockGetItem = jest.fn(() => ({}));
+
+      (StorageManager.get as jest.Mock).mockImplementation(() => ({
+        getItem: mockGetItem
+      }));
+
+      const wishlistStorage = (wishlistActions as any).loadFromCache();
+
+      expect(StorageManager.get).toHaveBeenCalledWith('wishlist');
+      expect(mockGetItem).toHaveBeenCalledWith('current-wishlist');
+      expect(wishlistStorage).toEqual({});
+    });
+  });
+
+  describe('addItem', () => {
+    it('should add product to wishlist', () => {
+      const product = { sku: 1 };
+      const mockContext = {
+        commit: jest.fn()
+      };
+
+      (wishlistActions as any).addItem(mockContext, product);
+
+      expect(mockContext.commit).toHaveBeenCalledWith(types.WISH_ADD_ITEM, { product });
+    });
+  });
+
+  describe('removeItem', () => {
+    it('should remove product from wishlist', () => {
+      const product = { sku: 1 };
+      const mockContext = {
+        commit: jest.fn()
+      };
+
+      (wishlistActions as any).removeItem(mockContext, product);
+
+      expect(mockContext.commit).toHaveBeenCalledWith(types.WISH_DEL_ITEM, { product });
+    });
+  });
+});

--- a/core/modules/wishlist/test/unit/store/getters.spec.ts
+++ b/core/modules/wishlist/test/unit/store/getters.spec.ts
@@ -1,0 +1,37 @@
+import wishlistGetters from '@vue-storefront/core/modules/wishlist/store/getters';
+
+describe('Wishlist getters', () => {
+  it('should inform if given product is on wishlist', () => {
+    const mockState = {
+      items: [
+        { sku: 1 }, { sku: 2 }, { sku: 3 }
+      ]
+    };
+
+    const productExists = (wishlistGetters as any).isOnWishlist(mockState)({ sku: 1 });
+    const productDoesNotExist = (wishlistGetters as any).isOnWishlist(mockState)({ sku: 123 });
+
+    expect(productExists).toBe(true);
+    expect(productDoesNotExist).toBe(false);
+  });
+
+  it('should inform if wishlist is loaded', () => {
+    const wishlistIsLoaded = (wishlistGetters as any).isWishlistLoaded({ loaded: true });
+    const wishlistIsNotLoaded = (wishlistGetters as any).isWishlistLoaded({ loaded: false });
+
+    expect(wishlistIsLoaded).toBe(true);
+    expect(wishlistIsNotLoaded).toBe(false);
+  });
+
+  it('should return number of products in wishlist', () => {
+    const mockState = {
+      items: [
+        { sku: 1 }, { sku: 2 }, { sku: 3 }
+      ]
+    };
+
+    const numberOfProducts = (wishlistGetters as any).getWishlistItemsCount(mockState);
+
+    expect(numberOfProducts).toBe(mockState.items.length);
+  });
+});

--- a/core/modules/wishlist/test/unit/store/mutations.spec.ts
+++ b/core/modules/wishlist/test/unit/store/mutations.spec.ts
@@ -1,0 +1,147 @@
+import * as types from '../../../store/mutation-types';
+import wishlistMutations from '../../../store/mutations'
+
+describe('Wishlist mutations', () => {
+  let product1;
+  let product2;
+  let product3;
+
+  beforeEach(() => {
+    product1 = {
+      sku: 'example-product-id1',
+      qty: 123
+    };
+
+    product2 = {
+      sku: 'example-product-id2',
+      qty: 456
+    };
+
+    product3 = {
+      sku: 'example-product-id3',
+      qty: 789
+    };
+  });
+
+  describe('WISH_ADD_ITEM', () => {
+    it('should add exactly one product to wishlist if it does not exist there', () => {
+      const mockState = {
+        items: []
+      };
+
+      const expectedState = {
+        items: [{ ...product1, qty: 1 }]
+      };
+
+      (wishlistMutations as any)[types.WISH_ADD_ITEM](mockState, { product: product1 });
+
+      expect(mockState).toEqual(expectedState);
+    });
+
+    it('should not add product to wishlist if it exists there', () => {
+      const mockState = {
+        items: [{ ...product1 }]
+      };
+
+      const expectedState = {
+        items: [{ ...product1 }]
+      };
+
+      (wishlistMutations as any)[types.WISH_ADD_ITEM](mockState, { product: product1 });
+
+      expect(mockState).toEqual(expectedState);
+    });
+  });
+
+  describe('WISH_DEL_ITEM', () => {
+    it('should remove existing product from wishlist', () => {
+      const mockState = {
+        items: [{ ...product1 }, { ...product2 }, { ...product3 }]
+      };
+
+      const expectedState = {
+        items: [{ ...product1 }, { ...product2 }]
+      };
+
+      (wishlistMutations as any)[types.WISH_DEL_ITEM](mockState, { product: product3 });
+
+      expect(mockState).toEqual(expectedState);
+    });
+
+    it('should not modify wishlist if product does not exist there', () => {
+      const mockState = {
+        items: [{ ...product1 }, { ...product2 }]
+      };
+
+      const expectedState = {
+        items: [{ ...product1 }, { ...product2 }]
+      };
+
+      (wishlistMutations as any)[types.WISH_DEL_ITEM](mockState, { product: product3 });
+
+      expect(mockState).toEqual(expectedState);
+    });
+  });
+
+  describe('WISH_LOAD_WISH', () => {
+    it('should init wishlist', () => {
+      const mockState = {
+        items: [{ ...product1 }]
+      };
+
+      const expectedState = {
+        items: [{ ...product2 }, { ...product3 }]
+      };
+
+      (wishlistMutations as any)[types.WISH_LOAD_WISH](mockState, [{ ...product2 }, { ...product3 }]);
+
+      expect(mockState).toEqual(expectedState);
+    });
+
+    it('should init wishlist with empty array if loaded wishlist is falsy', () => {
+      const mockState = {
+        items: [{ ...product1 }]
+      };
+
+      const expectedState = {
+        items: []
+      };
+
+      (wishlistMutations as any)[types.WISH_LOAD_WISH](mockState, null);
+
+      expect(mockState).toEqual(expectedState);
+    });
+  });
+
+  describe('WISH_DEL_ALL_ITEMS', () => {
+    it('should delete all products from wishlist', () => {
+      const mockState = {
+        items: [{ ...product1 }, { ...product2 }, { ...product3 }]
+      };
+
+      const expectedState = {
+        items: []
+      };
+
+      (wishlistMutations as any)[types.WISH_DEL_ALL_ITEMS](mockState);
+
+      expect(mockState).toEqual(expectedState);
+    });
+  });
+
+  describe('SET_WISHLIST_LOADED', () => {
+    it('should set loaded state for wishlist', () => {
+      const mockState = {
+        loaded: false
+      };
+
+      const expectedState = {
+        loaded: true
+      };
+
+      (wishlistMutations as any)[types.SET_WISHLIST_LOADED](mockState);
+
+      expect(mockState).toEqual(expectedState);
+    });
+  });
+});

--- a/core/modules/wishlist/test/unit/store/whishListPersistPlugin.spec.ts
+++ b/core/modules/wishlist/test/unit/store/whishListPersistPlugin.spec.ts
@@ -1,0 +1,64 @@
+import * as types from '@vue-storefront/core/modules/wishlist/store/mutation-types';
+import whishListPersistPlugin from '@vue-storefront/core/modules/wishlist/store/whishListPersistPlugin';
+import { StorageManager } from '@vue-storefront/core/lib/storage-manager';
+
+jest.mock('@vue-storefront/core/lib/storage-manager', () => ({
+  StorageManager: {
+    get: jest.fn()
+  }
+}));
+
+describe('whishListPersistPlugin', () => {
+  let mockSetItem;
+  let mockState;
+
+  beforeEach(() => {
+    mockSetItem = jest.fn();
+
+    (StorageManager.get as jest.Mock).mockImplementation(() => ({
+      setItem: mockSetItem
+    }));
+
+    mockState = {
+      wishlist: {
+        items: [
+          { sku: 1 }, { sku: 2 }, { sku: 3 }
+        ]
+      }
+    };
+
+    jest.clearAllMocks();
+  });
+
+  it('should store wishlist in cache for supported mutations', () => {
+    const mutations = [
+      { type: `wishlist/${types.WISH_ADD_ITEM}` },
+      { type: `wishlist/${types.WISH_DEL_ITEM}` },
+      { type: `wishlist/${types.WISH_DEL_ALL_ITEMS}` }
+    ];
+
+    mutations.forEach(mutation => whishListPersistPlugin(mutation, mockState));
+
+    expect(StorageManager.get).toHaveBeenCalledTimes(mutations.length);
+    expect(StorageManager.get).toHaveBeenCalledWith('wishlist');
+    expect(mockSetItem).toHaveBeenCalledTimes(mutations.length);
+    expect(mockSetItem).toHaveBeenCalledWith('current-wishlist', mockState.wishlist.items);
+  });
+
+  it('should not store wishlist in cache for unsupported mutations', () => {
+    const mutations = [
+      { type: 'a/b/c' },
+      { type: types.WISH_ADD_ITEM },
+      { type: types.WISH_DEL_ITEM },
+      { type: types.WISH_DEL_ALL_ITEMS },
+      { type: `wishlist/${types.WISH_LOAD_WISH}` },
+      { type: `wishlist/${types.SET_WISHLIST_LOADED}` }
+    ];
+
+    mutations.forEach(mutation => whishListPersistPlugin(mutation, mockState));
+
+    expect(StorageManager.get).toHaveBeenCalledTimes(mutations.length);
+    expect(StorageManager.get).toHaveBeenCalledWith('wishlist');
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Related issues
Closes #3471

### Short description and why it's useful
Added unit tests for `wishlist` core module: components, mixin, store actions, mutations, getters and plugin.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

