### PR TITLE
backport - invalid category links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.10.5] - 29.10.2019
+## [1.10.5] - unreleased
 
 ### Fixed
 - Render correct category links when multistore is active - @gibkigonzo (#3753)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.5] - 29.10.2019
+
+### Fixed
+- Render correct category links when multistore is active - @gibkigonzo (#3753)
+
 ## [1.10.4] - 18.10.2019
 
 ### Fixed

--- a/core/modules/url/helpers/index.ts
+++ b/core/modules/url/helpers/index.ts
@@ -59,8 +59,17 @@ export function normalizeUrlPath (url: string): string {
   return url
 }
 
-export function formatCategoryLink (category: { url_path: string, slug: string }): string {
-  return config.seo.useUrlDispatcher ? ('/' + category.url_path) : ('/c/' + category.slug)
+export function formatCategoryLink (category: Category, storeCode: string = currentStoreView().storeCode): string {
+  storeCode ? storeCode += '/' : storeCode = '';
+
+  if (currentStoreView().appendStoreCode === false) {
+    storeCode = ''
+  }
+
+  if (category) {
+    return config.seo.useUrlDispatcher ? ('/' + storeCode + category.url_path) : ('/' + storeCode + 'c/' + category.slug)
+  }
+  return '/' + storeCode;
 }
 
 export function formatProductLink (

--- a/core/modules/url/helpers/index.ts
+++ b/core/modules/url/helpers/index.ts
@@ -59,7 +59,7 @@ export function normalizeUrlPath (url: string): string {
   return url
 }
 
-export function formatCategoryLink (category: Category, storeCode: string = currentStoreView().storeCode): string {
+export function formatCategoryLink (category: { url_path: string, slug: string }, storeCode: string = currentStoreView().storeCode): string {
   storeCode ? storeCode += '/' : storeCode = '';
 
   if (currentStoreView().appendStoreCode === false) {

--- a/src/themes/default/components/core/Breadcrumbs.vue
+++ b/src/themes/default/components/core/Breadcrumbs.vue
@@ -1,20 +1,52 @@
 <template>
   <div class="breadcrumbs h5 cl-gray">
-    <span v-for="link in routes" :key="link.route_link">
-      <router-link :to="localizedRoute(link.route_link)">
+    <span v-for="link in paths" :key="link.route_link">
+      <router-link :to="link.route_link">
         {{ link.name | htmlDecode }}
       </router-link> /
     </span>
     <span class="cl-mine-shaft">
-      {{ activeRoute | htmlDecode }}
+      {{ current | htmlDecode }}
     </span>
   </div>
 </template>
 
 <script>
-import Breadcrumbs from '@vue-storefront/core/compatibility/components/Breadcrumbs'
+import { localizedRoute, currentStoreView } from '@vue-storefront/core/lib/multistore'
+import i18n from '@vue-storefront/i18n'
 
 export default {
-  mixins: [Breadcrumbs]
+  computed: {
+    paths () {
+      const routes = this.routes ? this.routes : this.$store.state.breadcrumbs.routes
+
+      if (this.withHomepage) {
+        return [
+          { name: i18n.t('Homepage'), route_link: localizedRoute('/', currentStoreView().storeCode) },
+          ...routes
+        ]
+      }
+
+      return routes
+    },
+    current () {
+      return this.activeRoute || this.$store.state.breadcrumbs.current
+    }
+  },
+  props: {
+    routes: {
+      type: Array,
+      required: false,
+      default: null
+    },
+    withHomepage: {
+      type: Boolean,
+      default: false
+    },
+    activeRoute: {
+      type: String,
+      default: ''
+    }
+  }
 }
 </script>

--- a/src/themes/default/components/core/blocks/Checkout/ThankYouPage.vue
+++ b/src/themes/default/components/core/blocks/Checkout/ThankYouPage.vue
@@ -3,6 +3,7 @@
     <header class="thank-you-title bg-cl-secondary py35 pl20">
       <div class="container">
         <breadcrumbs
+          :with-homepage="true"
           :routes="[{name: 'Homepage', route_link: '/'}]"
           :active-route="this.$t('Order confirmation')"
         />

--- a/src/themes/default/components/core/blocks/SidebarMenu/SidebarMenu.vue
+++ b/src/themes/default/components/core/blocks/SidebarMenu/SidebarMenu.vue
@@ -52,7 +52,7 @@
               <router-link
                 v-else
                 class="px25 py20 cl-accent no-underline col-xs"
-                :to="localizedRoute({ name: 'category', fullPath: category.url_path, params: { id: category.id, slug: category.slug }})"
+                :to="categoryLink(category)"
               >
                 {{ category.name }}
               </router-link>
@@ -140,6 +140,7 @@ import i18n from '@vue-storefront/i18n'
 import SidebarMenu from '@vue-storefront/core/compatibility/components/blocks/SidebarMenu/SidebarMenu'
 import SubBtn from 'theme/components/core/blocks/SidebarMenu/SubBtn'
 import SubCategory from 'theme/components/core/blocks/SidebarMenu/SubCategory'
+import { formatCategoryLink } from '@vue-storefront/core/modules/url/helpers'
 
 export default {
   components: {
@@ -218,6 +219,9 @@ export default {
           this.$router.push({ name: 'my-account' })
         })
       }
+    },
+    categoryLink (category) {
+      return formatCategoryLink(category)
     }
   }
 }

--- a/src/themes/default/components/core/blocks/SidebarMenu/SubCategory.vue
+++ b/src/themes/default/components/core/blocks/SidebarMenu/SubCategory.vue
@@ -11,7 +11,7 @@
       >
         <router-link
           class="px25 py20 cl-accent no-underline col-xs"
-          :to="localizedRoute({ name: 'category', fullPath: parentPath, params: { id: id, slug: parentSlug }})"
+          :to="categoryLink({ url_path: parentPath, slug: parentSlug })"
           data-testid="categoryLink"
         >
           {{ $t('View all') }}
@@ -35,7 +35,7 @@
           <router-link
             v-else
             class="px25 py20 cl-accent no-underline col-xs"
-            :to="localizedRoute({ name: 'category', fullPath: link.url_path, params: { id: link.id, slug: link.slug }})"
+            :to="categoryLink(link)"
           >
             {{ link.name }}
           </router-link>
@@ -84,6 +84,7 @@ import { mapState } from 'vuex'
 import SubBtn from './SubBtn.vue'
 import i18n from '@vue-storefront/i18n'
 import config from 'config'
+import { formatCategoryLink } from '@vue-storefront/core/modules/url/helpers'
 
 export default {
   name: 'SubCategory',
@@ -154,6 +155,9 @@ export default {
           action1: { label: i18n.t('OK') }
         })
       }
+    },
+    categoryLink (category) {
+      return formatCategoryLink(category)
     }
   }
 }

--- a/src/themes/default/pages/Compare.vue
+++ b/src/themes/default/pages/Compare.vue
@@ -2,7 +2,7 @@
   <div class="compare">
     <div class="bg-cl-secondary py35 pl20">
       <div class="container">
-        <breadcrumbs :routes="[{name: 'Homepage', route_link: '/'}]" active-route="Compare" />
+        <breadcrumbs :with-homepage="true" :routes="[{name: 'Homepage', route_link: '/'}]" active-route="Compare" />
         <h2>{{ title }}</h2>
       </div>
     </div>

--- a/src/themes/default/pages/MyAccount.vue
+++ b/src/themes/default/pages/MyAccount.vue
@@ -3,6 +3,7 @@
     <div class="bg-cl-secondary py35 pl20">
       <div class="container">
         <breadcrumbs
+          :with-homepage="true"
           :routes="[{name: 'Homepage', route_link: '/'}]"
           active-route="My Account"
         />

--- a/src/themes/default/pages/Static.vue
+++ b/src/themes/default/pages/Static.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="bg-cl-secondary py35 pl20">
       <div class="container">
-        <breadcrumbs :routes="[{name: 'Homepage', route_link: '/'}]" :active-route="$props.title" />
+        <breadcrumbs :with-homepage="true" :routes="[{name: 'Homepage', route_link: '/'}]" :active-route="$props.title" />
         <h2 class="fs-big">
           {{ $props.title }}
         </h2>

--- a/src/themes/default/resource/banners/de_main-image.json
+++ b/src/themes/default/resource/banners/de_main-image.json
@@ -3,6 +3,6 @@
       "title": "Laufe den Lauf.",
       "subtitle": "Eine Mode kann zum vorherrschenden Stil im Verhalten werden oder die neuesten Kreationen von Designern, Technologen, Ingenieuren und Designmanagern manifestieren.",
       "image": "/assets/full_width_banner.jpg",
-      "link": "/c/frauen-20"
+      "link": "/women/frauen-20"
   }
 }

--- a/src/themes/default/resource/banners/de_promoted_offers.json
+++ b/src/themes/default/resource/banners/de_promoted_offers.json
@@ -4,7 +4,7 @@
 	    "title": "Büro lässig",
 	    "subtitle": "Kollektion",
 	    "image": "/assets/ban1.jpg",
-	    "link": "/c/frauen-20"
+	    "link": "/women/frauen-20"
 	  }
   ],
   "smallBanners": [
@@ -12,13 +12,13 @@
       "title": "Sheinen",
       "subtitle": "Zubehör",
       "image": "/assets/ban2.jpg",
-      "link": "/c/herren-11"
+      "link": "/men/herren-11"
     },
     {
       "title": "Der Frühling kommt",
       "subtitle": "Hüte",
       "image": "/assets/ban3.jpg",
-      "link": "/c/gerat-3"
+      "link": "/gear/gerat-3"
     }
   ],
   "productBanners": [
@@ -26,7 +26,7 @@
 	    "title": "Der Frühling kommt",
 	    "subtitle": "Hüte",
 	    "image": "/assets/ban3.jpg",
-	    "link": "/c/gerat-3"
+	    "link": "/gear/gerat-3"
 	  }
   ]
 }

--- a/src/themes/default/resource/banners/it_main-image.json
+++ b/src/themes/default/resource/banners/it_main-image.json
@@ -3,6 +3,6 @@
       "title": "Cammina la passeggiata.",
       "subtitle": "Una moda può diventare lo stile prevalente nel comportamento o manifestare le ultime creazioni di designer, tecnologi, ingegneri e responsabili del design.",
       "image": "/assets/full_width_banner.jpg",
-      "link": "/c/la-donne-20"
+      "link": "/women/la-donne-20"
   }
 }

--- a/src/themes/default/resource/banners/it_promoted_offers.json
+++ b/src/themes/default/resource/banners/it_promoted_offers.json
@@ -4,7 +4,7 @@
 	    "title": "Ufficio casual",
 	    "subtitle": "Collezione",
 	    "image": "/assets/ban1.jpg",
-	    "link": "/c/la-donne-20"
+	    "link": "/women/la-donne-20"
 	  }
   ],
   "smallBanners": [
@@ -12,13 +12,13 @@
       "title": "Brilla",
       "subtitle": "Accessori",
       "image": "/assets/ban2.jpg",
-      "link": "/c/signori-11"
+      "link": "/men/signori-11"
     },
     {
       "title": "La primavera sta arrivando",
       "subtitle": "Cappelli",
       "image": "/assets/ban3.jpg",
-      "link": "/c/equipaggiamento-3"
+      "link": "/gear/equipaggiamento-3"
     }
   ],
   "productBanners": [
@@ -26,7 +26,7 @@
 	    "title": "La primavera sta arrivando",
 	    "subtitle": "Cappelli",
 	    "image": "/assets/ban3.jpg",
-	    "link": "/c/equipaggiamento-3"
+	    "link": "/gear/equipaggiamento-3"
 	  }
   ]
 }

--- a/src/themes/default/resource/main-image.json
+++ b/src/themes/default/resource/main-image.json
@@ -3,6 +3,6 @@
       "title": "Walk the walk.",
       "subtitle": "A fashion can become the prevailing style in behaviour or manifest the newest creations of designers, technologists, engineers, and design managers.",
       "image": "/assets/full_width_banner.jpg",
-      "link": "/c/women-20"
+      "link": "/women/women-20"
   }
 }

--- a/src/themes/default/resource/promoted_offers.json
+++ b/src/themes/default/resource/promoted_offers.json
@@ -4,7 +4,7 @@
 	    "title": "Office casual",
 	    "subtitle": "Collection",
 	    "image": "/assets/ban1.jpg",
-	    "link": "/c/women-20"
+	    "link": "/women/women-20"
 	  }
   ],
   "smallBanners": [
@@ -12,13 +12,13 @@
       "title": "Shine on",
       "subtitle": "Accesories",
       "image": "/assets/ban2.jpg",
-      "link": "/c/men-11"
+      "link": "/men/men-11"
     },
     {
       "title": "Spring is coming",
       "subtitle": "Hats",
       "image": "/assets/ban3.jpg",
-      "link": "/c/gear-3"
+      "link": "/gear/gear-3"
     }
   ],
   "productBanners": [
@@ -26,7 +26,7 @@
 	    "title": "Spring is coming",
 	    "subtitle": "Hats",
 	    "image": "/assets/ban3.jpg",
-	    "link": "/c/gear-3"
+	    "link": "/gear/gear-3"
 	  }
   ]
 }

--- a/src/themes/default/resource/slider.json
+++ b/src/themes/default/resource/slider.json
@@ -5,21 +5,21 @@
       "subtitle": "New collection",
       "button_text": "Shop now",
       "image": "/assets/slide_01.jpg",
-      "link": "/c/women-20"
+      "link": "/women/women-20"
     },
     {
       "title": "Luma Fitness",
       "subtitle": "Collection",
       "button_text": "Shop now",
       "image": "/assets/slide_02.jpg",
-      "link": "/c/men-11"
+      "link": "/men/men-11"
     },
     {
       "title": "Luma Fitness",
       "subtitle": "What's new",
       "button_text": "Shop now",
       "image": "/assets/slide_03.jpg",
-      "link": "/c/training-9"
+      "link": "/training/training-9"
     }
   ],
   "total": "3"


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3753

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Backport fix for rendering correct category links in menu and breadcrumbs.
Changed links in `promoted_offers.json`

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

