### PR TITLE
backport - disable product mutation when assigning product variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.5] - unreleased
+
+### Fixed
+- disable product mutation when assigning product variant - @gibkigonzo (#3735)
+
 ## [1.10.4] - 18.10.2019
 
 ### Fixed

--- a/core/modules/catalog/store/product/actions.ts
+++ b/core/modules/catalog/store/product/actions.ts
@@ -307,7 +307,7 @@ const actions: ActionTree<ProductState, RootState> = {
           }
           if (configuration) {
             let selectedVariant = configureProductAsync(context, { product: product, configuration: configuration, selectDefaultVariant: false })
-            Object.assign(product, omit(selectedVariant, ['visibility']))
+            product = Object.assign({}, product, omit(selectedVariant, ['visibility']))
           }
           if (product.url_path) {
             rootStore.dispatch('url/registerMapping', {
@@ -430,7 +430,7 @@ const actions: ActionTree<ProductState, RootState> = {
           // todo: probably a good idea is to change this [0] to specific id
           const selectedVariant = configureProductAsync(context, { product: prod, configuration: { sku: options.childSku }, selectDefaultVariant: selectDefaultVariant, setProductErorrs: true })
           if (selectedVariant && assignDefaultVariant) {
-            prod = Object.assign(prod, selectedVariant)
+            prod = Object.assign({}, prod, selectedVariant)
           }
         } else if (!skipCache || (prod.type_id === 'simple' || prod.type_id === 'downloadable')) {
           if (setCurrentProduct) context.dispatch('setCurrent', prod)


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3735

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
When user goes to the product page, reviews are taken with wrong product id. This change helps to cached valid product when user is on category page.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

