### PR TITLE
Defense against incomplete config in ssr renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.11.0-rc.2] - 2019.10.31
 
+### Added
+- Add defense against incomplete config in ssr renderer
+
 ### Fixed
 - Fixed deprecated getter in cmsBlock store - @resubaka (#3683)
 - Fixed problem around dynamic urls when default storeView is set with appendStoreCode false and url set to / . @resubaka (#3685)

--- a/core/scripts/utils/ssr-renderer.js
+++ b/core/scripts/utils/ssr-renderer.js
@@ -22,7 +22,10 @@ function createRenderer (bundle, clientManifest, template) {
 }
 
 function getFieldsToFilter () {
-  const fields = [...config.ssr.initialStateFilter, ...config.ssr.lazyHydrateFor]
+  const fields = [
+    ...(config.ssr && config.ssr.initialStateFilter || []),
+    ...(config.ssr && config.ssr.lazyHydrateFor || [])
+  ]
 
   return fields
 }

--- a/core/scripts/utils/ssr-renderer.js
+++ b/core/scripts/utils/ssr-renderer.js
@@ -23,8 +23,8 @@ function createRenderer (bundle, clientManifest, template) {
 
 function getFieldsToFilter () {
   const fields = [
-    ...(config.ssr && config.ssr.initialStateFilter || []),
-    ...(config.ssr && config.ssr.lazyHydrateFor || [])
+    ...(config.ssr && (config.ssr.initialStateFilter || [])),
+    ...(config.ssr && (config.ssr.lazyHydrateFor || []))
   ]
 
   return fields


### PR DESCRIPTION
### Short description
Adds some defensive config fetching in SSR renderer. Protects against incomplete config, e.g. after update.

Relates to `develop` (test version).

No upgrade steps required.
