### PR TITLE
Merge attribute and attributes config keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.11.0-rc.2] - UNRELEASED
 
 ### Added
+- Merge attribute and attributes config keys
 - Add unit test for \`core/modules/cms\` - @krskibin (#3738)
 
 ### Fixed

--- a/config/default.json
+++ b/config/default.json
@@ -183,7 +183,8 @@
       "validSearchOptionsFromRouteParams": ["url-key", "slug", "id"]
     },
     "attribute": {
-      "includeFields": [ "attribute_code", "id", "entity_type_id", "options", "default_value", "is_user_defined", "frontend_label", "attribute_id", "default_frontend_label", "is_visible_on_front", "is_visible", "is_comparable", "tier_prices", "frontend_input" ]
+      "includeFields": [ "attribute_code", "id", "entity_type_id", "options", "default_value", "is_user_defined", "frontend_label", "attribute_id", "default_frontend_label", "is_visible_on_front", "is_visible", "is_comparable", "tier_prices", "frontend_input" ],
+      "disablePersistentAttributesCache": false
     },
     "productList": {
       "sort": "updated_at:desc",
@@ -291,9 +292,6 @@
     "collecttotals_endpoint": "/api/cart/collect-totals?token={{token}}&cartId={{cartId}}",
     "deletecoupon_endpoint": "/api/cart/delete-coupon?token={{token}}&cartId={{cartId}}",
     "applycoupon_endpoint": "/api/cart/apply-coupon?token={{token}}&cartId={{cartId}}&coupon={{coupon}}"
-  },
-  "attributes": {
-    "disablePersistentAttributesCache": false
   },
   "products": {
     "disablePersistentProductsCache": true,

--- a/core/modules/catalog/helpers/prefetchCachedAttributes.ts
+++ b/core/modules/catalog/helpers/prefetchCachedAttributes.ts
@@ -3,7 +3,7 @@ import { entityKeyName } from '@vue-storefront/core/lib/store/entities'
 import config from 'config'
 
 async function prefetchCachedAttributes (filterField, filterValues) {
-  if (!config.attributes.disablePersistentAttributesCache) {
+  if (!config.attribute || !config.attribute.disablePersistentAttributesCache) {
     const attrCollection = StorageManager.get('attributes')
     const cachedAttributes = filterValues.map(
       async filterValue => attrCollection.getItem(entityKeyName(filterField, filterValue.toLowerCase()))


### PR DESCRIPTION
1. Merge very similar config keys.
2. Add a bit of defense against incomplete config in `prefetchCachedAttributes` helper. 

No related issues.

Relates to `develop` (test version).

