### PR TITLE
Add defense for missing attributes config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.11.0-rc.2] - 2019.10.31
 
+### Added
+- Add defense for incomplete config in preferchCachedAttributes helper
+
 ### Fixed
 - Fixed deprecated getter in cmsBlock store - @resubaka (#3683)
 - Fixed problem around dynamic urls when default storeView is set with appendStoreCode false and url set to / . @resubaka (#3685)

--- a/core/modules/catalog/helpers/prefetchCachedAttributes.ts
+++ b/core/modules/catalog/helpers/prefetchCachedAttributes.ts
@@ -3,7 +3,7 @@ import { entityKeyName } from '@vue-storefront/core/lib/store/entities'
 import config from 'config'
 
 async function prefetchCachedAttributes (filterField, filterValues) {
-  if (!config.attributes.disablePersistentAttributesCache) {
+  if (!config.attributes || !config.attributes.disablePersistentAttributesCache) {
     const attrCollection = StorageManager.get('attributes')
     const cachedAttributes = filterValues.map(
       async filterValue => attrCollection.getItem(entityKeyName(filterField, filterValue.toLowerCase()))


### PR DESCRIPTION
Add defense for missing attributes config. Useful when updating VSF.

No related issues.

Applies to `develop` (test).

