### PR TITLE
Add unit tests for `core/modules/checkout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0-rc.3] - UNRELEASED
+- Add unit test for `core/modules/checkout` - @psmyrek (#3460)
+
 ## [1.11.0-rc.2] - 2019.10.31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.11.0] - UNRELEASED
+### Added
 - Add unit test for `core/modules/checkout` - @psmyrek (#3460)
 
 ## [1.11.0-rc.2] - 2019.10.31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.11.0-rc.3] - UNRELEASED
+## [1.11.0] - UNRELEASED
 - Add unit test for `core/modules/checkout` - @psmyrek (#3460)
 
 ## [1.11.0-rc.2] - 2019.10.31

--- a/core/modules/checkout/test/unit/components/CartSummary.spec.ts
+++ b/core/modules/checkout/test/unit/components/CartSummary.spec.ts
@@ -1,16 +1,32 @@
-import {shallowMount} from '@vue/test-utils'
-
-import { CartSummary } from '../../../components/CartSummary'
+import { mountMixin, mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import { CartSummary } from '../../../components/CartSummary';
 
 jest.mock('@vue-storefront/core/compatibility/components/blocks/Microcart/Microcart');
 
 describe('CartSummary', () => {
   it('can be initialized', () => {
-    const wrapper = shallowMount({
-      template: '<div />',
-      mixins: [CartSummary]
-    });
+    const wrapper = mountMixin(CartSummary);
 
+    expect(wrapper.exists()).toBe(true);
     expect(wrapper.isVueInstance()).toBe(true);
-  })
+  });
+
+  it('exposes computed properties', () => {
+    const mockStore = {
+      modules: {
+        cart: {
+          getters: {
+            getTotals: jest.fn(() => 1),
+            isVirtualCart: jest.fn(() => true)
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    const wrapper = mountMixinWithStore(CartSummary, mockStore);
+
+    expect((wrapper.vm as any).totals).toBeDefined();
+    expect((wrapper.vm as any).isVirtualCart).toBeDefined();
+  });
 });

--- a/core/modules/checkout/test/unit/components/OrderReview.spec.ts
+++ b/core/modules/checkout/test/unit/components/OrderReview.spec.ts
@@ -1,0 +1,292 @@
+import { mountMixin, mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import { OrderReview } from '../../../components/OrderReview';
+
+jest.mock('@vue-storefront/i18n', () => ({
+  t: jest.fn(t => t)
+}));
+
+jest.mock('@vue-storefront/core/lib/logger', () => ({
+  Logger: {
+    error: jest.fn(() => jest.fn())
+  }
+}));
+
+describe('OrderReview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('can be initialized', () => {
+    const wrapper = mountMixin(OrderReview, {
+      propsData: {
+        isActive: true
+      }
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('exposes computed properties', () => {
+    const mockStore = {
+      modules: {
+        cart: {
+          getters: {
+            isVirtualCart: jest.fn(() => true)
+          },
+          namespaced: true
+        },
+        checkout: {
+          getters: {
+            getShippingDetails: jest.fn(() => ([])),
+            getPersonalDetails: jest.fn(() => ([]))
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    const wrapper = mountMixinWithStore(OrderReview, mockStore, {
+      propsData: {
+        isActive: true
+      }
+    });
+
+    expect((wrapper.vm as any).isVirtualCart).toBeDefined();
+    expect((wrapper.vm as any).getShippingDetails).toBeDefined();
+    expect((wrapper.vm as any).getPersonalDetails).toBeDefined();
+  });
+
+  describe('placeOrder method', () => {
+    let wrapper;
+    const mockGetPersonalDetails = jest.fn();
+    const mockRegisterFn = jest.fn();
+    const mockEmitFn = jest.fn();
+
+    beforeEach(() => {
+      wrapper = mountMixin(OrderReview, {
+        propsData: {
+          isActive: true
+        },
+        computed: {
+          getPersonalDetails: mockGetPersonalDetails
+        },
+        methods: {
+          register: mockRegisterFn
+        },
+        mocks: {
+          $bus: {
+            $emit: mockEmitFn
+          }
+        }
+      });
+    });
+
+    it('registers an account if it is not created yet', () => {
+      mockGetPersonalDetails.mockImplementation(() => ({
+        createAccount: true
+      }));
+
+      (wrapper.vm as any).placeOrder();
+
+      expect(mockRegisterFn).toHaveBeenCalled();
+      expect(mockEmitFn).not.toHaveBeenCalled();
+    });
+
+    it('emits an event if account is already created', () => {
+      mockGetPersonalDetails.mockImplementation(() => ({
+        createAccount: false
+      }));
+
+      (wrapper.vm as any).placeOrder();
+
+      expect(mockRegisterFn).not.toHaveBeenCalled();
+      expect(mockEmitFn).toHaveBeenCalledWith('checkout-before-placeOrder');
+    });
+  });
+
+  describe('register method', () => {
+    let wrapper;
+
+    const mockGetPersonalDetails = jest.fn(() => ({
+      emailAddress: 'example email address',
+      password: 'example password',
+      firstName: 'example first name',
+      lastName: 'example last name'
+    }));
+
+    const mockGetShippingDetails = jest.fn(() => ({
+      firstName: 'example first name',
+      lastName: 'example last name',
+      streetAddress: 'example street address',
+      apartmentNumber: 'example apartment number',
+      city: 'example city',
+      state: 'example state',
+      region: 'example region',
+      country: 'example country',
+      zipCode: 'example zip code',
+      phoneNumber: 'example phone number'
+    }));
+
+    const mockOnSuccessFn = jest.fn();
+    const mockOnFailureFn = jest.fn();
+    const mockEmitFn = jest.fn();
+
+    const mockStore = {
+      modules: {
+        user: {
+          actions: {
+            login: jest.fn(),
+            register: jest.fn()
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    beforeEach(() => {
+      wrapper = mountMixinWithStore(OrderReview, mockStore, {
+        propsData: {
+          isActive: true
+        },
+        computed: {
+          getPersonalDetails: mockGetPersonalDetails,
+          getShippingDetails: mockGetShippingDetails
+        },
+        methods: {
+          onSuccess: mockOnSuccessFn,
+          onFailure: mockOnFailureFn
+        },
+        mocks: {
+          $bus: {
+            $emit: mockEmitFn
+          }
+        }
+      });
+    });
+
+    it('dispatches user/register action with proper payload', () => {
+      (wrapper.vm as any).register();
+
+      expect(mockStore.modules.user.actions.register).toHaveBeenCalledWith(expect.anything(), {
+        email: 'example email address',
+        password: 'example password',
+        firstname: 'example first name',
+        lastname: 'example last name',
+        addresses: [{
+          firstname: 'example first name',
+          lastname: 'example last name',
+          street: ['example street address', 'example apartment number'],
+          city: 'example city',
+          region: {
+            region: 'example state'
+          },
+          country_id: 'example country',
+          postcode: 'example zip code',
+          telephone: 'example phone number',
+          default_shipping: true
+        }]
+      }, undefined);
+    });
+
+    it('emits events about start and stop of notification progress', async () => {
+      const result = {
+        code: 500,
+        result: 'example error message'
+      };
+
+      mockStore.modules.user.actions.register.mockImplementation(() => Promise.resolve(result));
+
+      await (wrapper.vm as any).register();
+
+      expect(mockEmitFn).toHaveBeenCalledTimes(2);
+      expect(mockEmitFn).toHaveBeenNthCalledWith(1, 'notification-progress-start', 'Registering the account ...');
+      expect(mockEmitFn).toHaveBeenNthCalledWith(2, 'notification-progress-stop');
+    });
+
+    it('catches thrown error and sends event about stop of notification progress', async () => {
+      mockStore.modules.user.actions.register.mockImplementation(() => { throw Error('Error') });
+
+      await (wrapper.vm as any).register();
+
+      expect(mockEmitFn).toHaveBeenCalledWith('notification-progress-stop');
+    });
+
+    describe('failed result if return code is other than 200', () => {
+      it('calls onFailure callback', async () => {
+        const result = {
+          code: 500,
+          result: 'example error message'
+        };
+
+        mockStore.modules.user.actions.register.mockImplementation(() => Promise.resolve(result));
+
+        await (wrapper.vm as any).register();
+
+        expect(mockOnFailureFn).toHaveBeenCalledWith(result);
+        expect(mockOnSuccessFn).not.toHaveBeenCalled();
+        expect(mockEmitFn).not.toHaveBeenCalledWith('checkout-before-placeOrder', expect.anything());
+      });
+
+      it('emits event to indicate validation error with password if error includes a word "password"', async () => {
+        const result = {
+          code: 500,
+          result: 'example error message with password'
+        };
+
+        mockStore.modules.user.actions.register.mockImplementation(() => Promise.resolve(result));
+
+        await (wrapper.vm as any).register();
+
+        expect(mockEmitFn).toHaveBeenCalledWith('checkout-after-validationError', 'password');
+      });
+
+      it('emits event to indicate validation error with email address if error includes a word "email"', async () => {
+        const result = {
+          code: 500,
+          result: 'example error message with email'
+        };
+
+        mockStore.modules.user.actions.register.mockImplementation(() => Promise.resolve(result));
+
+        await (wrapper.vm as any).register();
+
+        expect(mockEmitFn).toHaveBeenCalledWith('checkout-after-validationError', 'email-address');
+      });
+    });
+
+    describe('successful result if return code is 200', () => {
+      it('calls onSuccess callback and emits proper events', async () => {
+        const result = {
+          code: 200,
+          result: { id: 42 }
+        };
+
+        mockStore.modules.user.actions.register.mockImplementation(() => Promise.resolve(result));
+
+        await (wrapper.vm as any).register();
+
+        expect(mockOnSuccessFn).toHaveBeenCalled();
+        expect(mockOnFailureFn).not.toHaveBeenCalled();
+        expect(mockEmitFn).toHaveBeenCalledWith('modal-hide', 'modal-signup');
+        expect(mockEmitFn).toHaveBeenCalledWith('checkout-before-placeOrder', 42);
+      });
+
+      it('dispatches user/login action', async () => {
+        const result = {
+          code: 200,
+          result: { id: 42 }
+        };
+
+        mockStore.modules.user.actions.register.mockImplementation(() => Promise.resolve(result));
+
+        await (wrapper.vm as any).register();
+
+        expect(mockStore.modules.user.actions.login).toHaveBeenCalledWith(expect.anything(), {
+          username: 'example email address',
+          password: 'example password'
+        }, undefined);
+      });
+    });
+  });
+});

--- a/core/modules/checkout/test/unit/components/Payment.spec.ts
+++ b/core/modules/checkout/test/unit/components/Payment.spec.ts
@@ -1,0 +1,599 @@
+import { mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import { Payment } from '../../../components/Payment';
+
+describe('Payment', () => {
+  let mockStore;
+  let mockMountingOptions;
+  let mockMethods;
+  let mockHooks;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockStore = {
+      modules: {
+        cart: {
+          getters: {
+            isVirtualCart: jest.fn(() => true)
+          },
+          namespaced: true
+        },
+        checkout: {
+          state: {
+            shippingDetails: {}
+          },
+          getters: {
+            getPaymentMethods: jest.fn(() => ([])),
+            getPaymentDetails: jest.fn(() => ({
+              paymentMethod: '',
+              firstName: '',
+              company: '',
+              country: ''
+            }))
+          },
+          namespaced: true
+        },
+        user: {
+          state: {
+            current: {}
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    mockMountingOptions = {
+      propsData: {
+        isActive: true
+      },
+      mocks: {
+        $bus: {
+          $emit: jest.fn()
+        }
+      }
+    };
+
+    mockMethods = Object.entries(Payment.methods)
+      .reduce((result, [methodName]) => {
+        result[methodName] = jest.spyOn(Payment.methods, methodName as keyof typeof Payment.methods)
+          .mockImplementation(jest.fn());
+
+        return result;
+      }, {});
+
+    mockHooks = ['beforeCreate', 'created', 'beforeMount', 'mounted', 'beforeUpdate', 'updated', 'beforeDestroy', 'destroyed']
+      .reduce((result, hookName) => {
+        if (Payment[hookName]) {
+          result[hookName] = jest.spyOn(Payment, hookName as any)
+            .mockImplementation(jest.fn());
+        }
+
+        return result;
+      }, {});
+  });
+
+  it('can be initialized', () => {
+    const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('exposes computed properties', () => {
+    const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+    expect((wrapper.vm as any).currentUser).toBeDefined();
+    expect((wrapper.vm as any).shippingDetails).toBeDefined();
+    expect((wrapper.vm as any).paymentMethods).toBeDefined();
+    expect((wrapper.vm as any).paymentDetails).toBeDefined();
+    expect((wrapper.vm as any).isVirtualCart).toBeDefined();
+  });
+
+  describe('hooks', () => {
+    describe('created hook', () => {
+      beforeEach(() => {
+        mockHooks['created'].mockRestore();
+      });
+
+      it('should initialize payment method as "cashondelivery" if payment method is not configured', () => {
+        mockMethods['notInMethods'].mockReturnValue(false);
+        mockStore.modules.checkout.getters.getPaymentMethods.mockImplementation(() => ([]));
+        mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => ({
+          paymentMethod: ''
+        }));
+
+        const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+        expect((wrapper.vm as any).payment.paymentMethod).toBe('cashondelivery');
+      });
+
+      it('should initialize payment method as "cashondelivery" if payment method is not supported', () => {
+        mockMethods['notInMethods'].mockReturnValue(true);
+        mockStore.modules.checkout.getters.getPaymentMethods.mockImplementation(() => ([]));
+        mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => ({
+          paymentMethod: 'not supported payment method'
+        }));
+
+        const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+        expect((wrapper.vm as any).payment.paymentMethod).toBe('cashondelivery');
+      });
+
+      it('should initialize payment method as first one from all payment methods if it is not configured', () => {
+        mockMethods['notInMethods'].mockReturnValue(true);
+        mockStore.modules.checkout.getters.getPaymentMethods.mockImplementation(() => ([
+          { code: 'first payment method' }, { code: 'second payment method' }
+        ]));
+        mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => ({
+          paymentMethod: 'not supported payment method'
+        }));
+
+        const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+        expect((wrapper.vm as any).payment.paymentMethod).toBe('first payment method');
+      });
+    });
+
+    describe('mounted hook', () => {
+      beforeEach(() => {
+        mockHooks['mounted'].mockRestore();
+      });
+
+      it('should initialize billing address if payment is from individual customer and then change payment method', () => {
+        mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => ({
+          firstName: 'example first name',
+          company: ''
+        }));
+
+        mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+        expect(mockMethods['initializeBillingAddress']).toHaveBeenCalled();
+        expect(mockMethods['changePaymentMethod']).toHaveBeenCalled();
+      });
+
+      it('should mark invoice generation and do not initialize billing address if payment is from company and then change payment method', () => {
+        mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => ({
+          firstName: '',
+          company: 'example company'
+        }));
+
+        const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+        expect(mockMethods['initializeBillingAddress']).not.toHaveBeenCalled();
+        expect(mockMethods['changePaymentMethod']).toHaveBeenCalled();
+        expect((wrapper.vm as any).generateInvoice).toBeTruthy();
+      });
+    });
+  });
+
+  describe('watchers', () => {
+    it('should call copyShippingToBillingAddress method if "send to shipping address" flag is configured', () => {
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      wrapper.setData({ sendToShippingAddress: true });
+      (wrapper.vm as any).$options.watch.shippingDetails.handler.call(wrapper.vm);
+
+      expect(mockMethods['copyShippingToBillingAddress']).toHaveBeenCalled();
+    });
+
+    it('should not call copyShippingToBillingAddress method if "send to shipping address" flag is not configured', () => {
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      wrapper.setData({ sendToShippingAddress: false });
+      (wrapper.vm as any).$options.watch.shippingDetails.handler.call(wrapper.vm);
+
+      expect(mockMethods['copyShippingToBillingAddress']).not.toHaveBeenCalled();
+    });
+
+    it('should call useShippingAddress method if "send to shipping address" flag is changed', () => {
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      (wrapper.vm as any).$options.watch.sendToShippingAddress.handler.call(wrapper.vm);
+
+      expect(mockMethods['useShippingAddress']).toHaveBeenCalled();
+    });
+
+    it('should call useBillingAddress method if "send to billing address" flag is changed', () => {
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      (wrapper.vm as any).$options.watch.sendToBillingAddress.handler.call(wrapper.vm);
+
+      expect(mockMethods['useBillingAddress']).toHaveBeenCalled();
+    });
+
+    it('should call useGenerateInvoice method if "generate invoice" flag is changed', () => {
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      (wrapper.vm as any).$options.watch.generateInvoice.handler.call(wrapper.vm);
+
+      expect(mockMethods['useGenerateInvoice']).toHaveBeenCalled();
+    });
+  });
+
+  describe('methods', () => {
+    it('sendDataToCheckout method should emit an event and set flag', () => {
+      mockMethods['sendDataToCheckout'].mockRestore();
+
+      const paymentDetails = {
+        firstName: 'example first name',
+        company: 'example company',
+        country: 'example country'
+      };
+
+      mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => paymentDetails);
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      (wrapper.vm as any).sendDataToCheckout();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).toHaveBeenCalledWith('checkout-after-paymentDetails', paymentDetails, undefined);
+      expect((wrapper.vm as any).isFilled).toBe(true);
+    });
+
+    it('edit method should emit event if flag is set', () => {
+      mockMethods['edit'].mockRestore();
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      wrapper.setData({ isFilled: true });
+      (wrapper.vm as any).edit();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).toHaveBeenCalledWith('checkout-before-edit', 'payment');
+    });
+
+    it('edit method should not emit event if flag is not set', () => {
+      mockMethods['edit'].mockRestore();
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      wrapper.setData({ isFilled: false });
+      (wrapper.vm as any).edit();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).not.toHaveBeenCalled();
+    });
+
+    it('hasBillingData method should inform if current user has default_billing own property', () => {
+      mockMethods['hasBillingData'].mockRestore();
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      mockStore.modules.user.state.current = { default_billing: true };
+      expect((wrapper.vm as any).hasBillingData()).toBe(true);
+
+      mockStore.modules.user.state.current = {};
+      expect((wrapper.vm as any).hasBillingData()).toBe(false);
+    });
+
+    it('initializeBillingAddress method should init payment properties with empty strings if current user and payment details are not set', () => {
+      mockMethods['initializeBillingAddress'].mockRestore();
+      mockMountingOptions.computed = {
+        currentUser: jest.fn(),
+        paymentDetails: jest.fn()
+      };
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+      (wrapper.vm as any).initializeBillingAddress();
+
+      expect((wrapper.vm as any).payment).toEqual({
+        firstName: '',
+        lastName: '',
+        company: '',
+        country: '',
+        state: '',
+        city: '',
+        streetAddress: '',
+        apartmentNumber: '',
+        postcode: '',
+        zipCode: '',
+        phoneNumber: '',
+        taxId: '',
+        paymentMethod: ''
+      });
+    });
+
+    it('initializeBillingAddress method should copy billing address from address id from current user', () => {
+      mockMethods['initializeBillingAddress'].mockRestore();
+      mockMountingOptions.computed = {
+        currentUser: jest.fn(() => ({
+          default_billing: 123,
+          addresses: [
+            {
+              id: 123,
+              firstname: 'example first name',
+              lastname: 'example last name',
+              company: 'example company',
+              country_id: 'example country',
+              region: { region: 'example region' },
+              city: 'example city',
+              street: ['example street', 'example apartment number'],
+              postcode: 'example post code',
+              vat_id: 'example vat id',
+              telephone: 'example telephone'
+            }
+          ]
+        })),
+        paymentMethods: jest.fn(() => ([{ code: 'example payment method' }])),
+        paymentDetails: jest.fn()
+      };
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+      (wrapper.vm as any).initializeBillingAddress();
+
+      expect((wrapper.vm as any).payment).toEqual({
+        firstName: 'example first name',
+        lastName: 'example last name',
+        company: 'example company',
+        country: 'example country',
+        state: 'example region',
+        city: 'example city',
+        streetAddress: 'example street',
+        apartmentNumber: 'example apartment number',
+        zipCode: 'example post code',
+        phoneNumber: 'example telephone',
+        taxId: 'example vat id',
+        paymentMethod: 'example payment method'
+      });
+      expect((wrapper.vm as any).generateInvoice).toBe(true);
+      expect((wrapper.vm as any).sendToBillingAddress).toBe(true);
+    });
+
+    it('useShippingAddress method should call copyShippingToBillingAddress if shipping address is set', () => {
+      mockMethods['useShippingAddress'].mockRestore();
+      mockMountingOptions.methods = {
+        copyShippingToBillingAddress: jest.fn()
+      };
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      wrapper.setData({ sendToShippingAddress: true });
+      (wrapper.vm as any).useShippingAddress();
+
+      expect(mockMountingOptions.methods.copyShippingToBillingAddress).toHaveBeenCalled();
+      expect((wrapper.vm as any).sendToBillingAddress).toBe(false);
+    });
+
+    it('useShippingAddress method should not call copyShippingToBillingAddress if shipping address is not set', () => {
+      mockMethods['useShippingAddress'].mockRestore();
+
+      const paymentDetails = {
+        firstName: 'example first name',
+        lastName: 'example last name',
+        company: 'example company',
+        country: 'example country',
+        state: 'example region',
+        city: 'example city',
+        streetAddress: 'example street',
+        apartmentNumber: 'example apartment number',
+        zipCode: 'example post code',
+        phoneNumber: 'example telephone',
+        taxId: 'example vat id',
+        paymentMethod: 'example payment method'
+      };
+
+      mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => paymentDetails);
+      mockMountingOptions.methods = {
+        copyShippingToBillingAddress: jest.fn()
+      };
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      wrapper.setData({ sendToBillingAddress: false, sendToShippingAddress: false });
+      (wrapper.vm as any).useShippingAddress();
+
+      expect(mockMountingOptions.methods.copyShippingToBillingAddress).not.toHaveBeenCalled();
+      expect((wrapper.vm as any).payment).toEqual(paymentDetails);
+    });
+
+    it('copyShippingToBillingAddress method should copy data from shipping address', () => {
+      mockMethods['copyShippingToBillingAddress'].mockRestore();
+
+      const paymentDetails = {
+        firstName: 'example first name',
+        lastName: 'example last name',
+        country: 'example country',
+        state: 'example region',
+        city: 'example city',
+        streetAddress: 'example street',
+        apartmentNumber: 'example apartment number',
+        zipCode: 'example post code',
+        phoneNumber: 'example telephone'
+      };
+
+      mockStore.modules.checkout.state.shippingDetails = paymentDetails;
+      mockStore.modules.checkout.getters.getPaymentMethods.mockImplementation(() => ([
+        { code: 'first payment method' }, { code: 'second payment method' }
+      ]));
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+      (wrapper.vm as any).copyShippingToBillingAddress();
+
+      expect((wrapper.vm as any).payment).toEqual({
+        ...paymentDetails,
+        paymentMethod: 'first payment method'
+      });
+    });
+
+    it('useBillingAddress method should copy billing address from address id from current user', () => {
+      mockMethods['useBillingAddress'].mockRestore();
+      mockMountingOptions.computed = {
+        currentUser: jest.fn(() => ({
+          default_billing: 123,
+          addresses: [
+            {
+              id: 123,
+              firstname: 'example first name',
+              lastname: 'example last name',
+              company: 'example company',
+              country_id: 'example country',
+              region: { region: 'example region' },
+              city: 'example city',
+              street: ['example street', 'example apartment number'],
+              postcode: 'example post code',
+              vat_id: 'example vat id',
+              telephone: 'example telephone'
+            }
+          ]
+        })),
+        paymentMethods: jest.fn(() => ([{ code: 'example payment method' }]))
+      };
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      wrapper.setData({ sendToBillingAddress: true });
+      (wrapper.vm as any).useBillingAddress();
+
+      expect((wrapper.vm as any).payment).toEqual({
+        firstName: 'example first name',
+        lastName: 'example last name',
+        company: 'example company',
+        country: 'example country',
+        state: 'example region',
+        city: 'example city',
+        streetAddress: 'example street',
+        apartmentNumber: 'example apartment number',
+        zipCode: 'example post code',
+        phoneNumber: 'example telephone',
+        taxId: 'example vat id',
+        paymentMethod: 'example payment method'
+      });
+      expect((wrapper.vm as any).generateInvoice).toBe(true);
+      expect((wrapper.vm as any).sendToShippingAddress).toBe(false);
+    });
+
+    it('useBillingAddress method should copy billing address from payment details if address is not set', () => {
+      mockMethods['useBillingAddress'].mockRestore();
+
+      const paymentDetails = {
+        firstName: 'example first name',
+        lastName: 'example last name',
+        company: 'example company',
+        country: 'example country',
+        state: 'example region',
+        city: 'example city',
+        streetAddress: 'example street',
+        apartmentNumber: 'example apartment number',
+        zipCode: 'example post code',
+        phoneNumber: 'example telephone',
+        taxId: 'example vat id',
+        paymentMethod: 'example payment method'
+      };
+
+      mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => paymentDetails);
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      wrapper.setData({ sendToBillingAddress: false, sendToShippingAddress: false });
+      (wrapper.vm as any).useBillingAddress();
+
+      expect((wrapper.vm as any).payment).toEqual(paymentDetails);
+      expect((wrapper.vm as any).generateInvoice).toBe(false);
+    });
+
+    it('useGenerateInvoice method should clear company and taxId fields if generateInvoice is not set', () => {
+      mockMethods['useGenerateInvoice'].mockRestore();
+      mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => ({
+        company: 'example company',
+        taxId: 'example taxId'
+      }));
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      wrapper.setData({ generateInvoice: false });
+      (wrapper.vm as any).useGenerateInvoice();
+
+      expect((wrapper.vm as any).payment.company).toBe('');
+      expect((wrapper.vm as any).payment.taxId).toBe('');
+    });
+
+    it('useGenerateInvoice method should not clear company and taxId fields if generateInvoice is set', () => {
+      mockMethods['useGenerateInvoice'].mockRestore();
+      mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => ({
+        company: 'example company',
+        taxId: 'example taxId'
+      }));
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      wrapper.setData({ generateInvoice: true });
+      (wrapper.vm as any).useGenerateInvoice();
+
+      expect((wrapper.vm as any).payment.company).toBe('example company');
+      expect((wrapper.vm as any).payment.taxId).toBe('example taxId');
+    });
+
+    it('getCountryName method should return country name from payment', () => {
+      mockMethods['getCountryName'].mockRestore();
+      mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => ({
+        country: 'PL'
+      }));
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+      const countryName = (wrapper.vm as any).getCountryName();
+
+      expect(countryName).toBe('Poland');
+    });
+
+    it('getCountryName method should return empty string if country has not been found', () => {
+      mockMethods['getCountryName'].mockRestore();
+      mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => ({
+        country: 'invalid country code'
+      }));
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+      const countryName = (wrapper.vm as any).getCountryName();
+
+      expect(countryName).toBe('');
+    });
+
+    it('getPaymentMethod method should return payment name', () => {
+      mockMethods['getPaymentMethod'].mockRestore();
+      mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => ({
+        paymentMethod: 'second payment method'
+      }));
+      mockStore.modules.checkout.getters.getPaymentMethods.mockImplementation(() => ([
+        { code: 'first payment method', name: 'payment 1' }, { code: 'second payment method', name: 'payment 2' }
+      ]));
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+      const paymentMethod = (wrapper.vm as any).getPaymentMethod();
+
+      expect(paymentMethod).toEqual({ title: 'payment 2' });
+    });
+
+    it('getPaymentMethod method should return empty name if it is not found', () => {
+      mockMethods['getPaymentMethod'].mockRestore();
+      mockStore.modules.checkout.getters.getPaymentDetails.mockImplementation(() => ({
+        paymentMethod: 'invalid payment method'
+      }));
+      mockStore.modules.checkout.getters.getPaymentMethods.mockImplementation(() => ([
+        { code: 'first payment method', name: 'payment 1' }, { code: 'second payment method', name: 'payment 2' }
+      ]));
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+      const paymentMethod = (wrapper.vm as any).getPaymentMethod();
+
+      expect(paymentMethod).toEqual({ name: '' });
+    });
+
+    it('notInMethods method should inform if given payment method is not supported', () => {
+      mockMethods['notInMethods'].mockRestore();
+      mockStore.modules.checkout.getters.getPaymentMethods.mockImplementation(() => ([
+        { code: 'first payment method', name: 'payment 1' }, { code: 'second payment method', name: 'payment 2' }
+      ]));
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+
+      expect((wrapper.vm as any).notInMethods('second payment method')).toBe(false);
+      expect((wrapper.vm as any).notInMethods('invalid payment method')).toBe(true);
+    });
+
+    it('changePaymentMethod method should emit an event', () => {
+      mockMethods['changePaymentMethod'].mockRestore();
+
+      const wrapper = mountMixinWithStore(Payment, mockStore, mockMountingOptions);
+      (wrapper.vm as any).changePaymentMethod();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).toHaveBeenCalledWith('checkout-payment-method-changed', expect.anything());
+    });
+  });
+});

--- a/core/modules/checkout/test/unit/components/PersonalDetails.spec.ts
+++ b/core/modules/checkout/test/unit/components/PersonalDetails.spec.ts
@@ -1,0 +1,170 @@
+import { mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import { PersonalDetails } from '../../../components/PersonalDetails';
+
+describe('PersonalDetails', () => {
+  let mockStore;
+  let mockMountingOptions;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockStore = {
+      modules: {
+        cart: {
+          getters: {
+            isVirtualCart: jest.fn(() => true)
+          },
+          namespaced: true
+        },
+        checkout: {
+          state: {
+            personalDetails: {}
+          },
+          namespaced: true
+        },
+        user: {
+          state: {
+            current: {}
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    mockMountingOptions = {
+      propsData: {
+        isActive: true
+      },
+      mocks: {
+        $bus: {
+          $emit: jest.fn(),
+          $on: jest.fn(),
+          $off: jest.fn()
+        }
+      }
+    };
+  });
+
+  it('can be initialized', () => {
+    const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('exposes computed properties', () => {
+    const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+
+    expect((wrapper.vm as any).currentUser).toBeDefined();
+    expect((wrapper.vm as any).isVirtualCart).toBeDefined();
+  });
+
+  describe('hooks', () => {
+    it('beforeMount hook should start subscription for user-after-loggedin event', () => {
+      const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+
+      expect(mockMountingOptions.mocks.$bus.$on).toHaveBeenCalledWith('user-after-loggedin', (wrapper.vm as any).onLoggedIn);
+    });
+
+    it('destroyed hook should stop subscription for user-after-loggedin event', () => {
+      const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+
+      wrapper.destroy();
+
+      expect(mockMountingOptions.mocks.$bus.$off).toHaveBeenCalledWith('user-after-loggedin', (wrapper.vm as any).onLoggedIn);
+    });
+
+    it('updated hook should set focus on password field', () => {
+      const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+      (wrapper.vm as any).$refs.password = { setFocus: jest.fn() };
+
+      wrapper.setData({ isValidationError: false });
+      wrapper.setProps({ focusedField: 'password' });
+
+      expect((wrapper.vm as any).isValidationError).toBe(true);
+      expect((wrapper.vm as any).password).toBe('');
+      expect((wrapper.vm as any).rPassword).toBe('');
+      expect((wrapper.vm as any).$refs.password.setFocus).toHaveBeenCalledWith('password');
+    });
+  });
+
+  describe('methods', () => {
+    it('onLoggedIn method should set names and email', () => {
+      const personalDetails = {
+        firstname: 'example first name',
+        lastname: 'example last name',
+        email: 'example email'
+      };
+      const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+
+      (wrapper.vm as any).onLoggedIn(personalDetails);
+
+      expect((wrapper.vm as any).personalDetails).toEqual({
+        firstName: personalDetails.firstname,
+        lastName: personalDetails.lastname,
+        emailAddress: personalDetails.email
+      });
+    });
+
+    it('sendDataToCheckout method should create new account if flag is set', () => {
+      const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+
+      wrapper.setData({
+        createAccount: true,
+        password: 'example password'
+      });
+      (wrapper.vm as any).sendDataToCheckout();
+
+      expect((wrapper.vm as any).personalDetails).toEqual({
+        password: 'example password',
+        createAccount: true
+      });
+    });
+
+    it('sendDataToCheckout method should not create new account if flag is not set', () => {
+      const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+
+      wrapper.setData({ createAccount: false });
+      (wrapper.vm as any).sendDataToCheckout();
+
+      expect((wrapper.vm as any).personalDetails).toEqual({ createAccount: false });
+    });
+
+    it('sendDataToCheckout method should emit event and init `filled` and `validation error` flags', () => {
+      const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+
+      wrapper.setData({ createAccount: false });
+      (wrapper.vm as any).sendDataToCheckout();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).toHaveBeenCalledWith('checkout-after-personalDetails', { createAccount: false }, undefined);
+      expect((wrapper.vm as any).isFilled).toBe(true);
+      expect((wrapper.vm as any).isValidationError).toBe(false);
+    });
+
+    it('edit method should emit event if flag is set', () => {
+      const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+
+      wrapper.setData({ isFilled: true });
+      (wrapper.vm as any).edit();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).toHaveBeenCalledWith('checkout-before-edit', 'personalDetails');
+    });
+
+    it('edit method should not emit event if flag is not set', () => {
+      const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+
+      wrapper.setData({ isFilled: false });
+      (wrapper.vm as any).edit();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).not.toHaveBeenCalled();
+    });
+
+    it('gotoAccount method should emit event', () => {
+      const wrapper = mountMixinWithStore(PersonalDetails, mockStore, mockMountingOptions);
+
+      (wrapper.vm as any).gotoAccount();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).toHaveBeenCalledWith('modal-show', 'modal-signup');
+    });
+  });
+});

--- a/core/modules/checkout/test/unit/components/Product.spec.ts
+++ b/core/modules/checkout/test/unit/components/Product.spec.ts
@@ -1,0 +1,73 @@
+import { mountMixin } from '@vue-storefront/unit-tests/utils';
+import { Product } from '../../../components/Product';
+
+describe('Product', () => {
+  let mockMountingOptions;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockMountingOptions = {
+      propsData: {
+        product: {
+          image: 'example image',
+          sku: 'example sku'
+        }
+      },
+      mocks: {
+        $bus: {
+          $emit: jest.fn(),
+          $on: jest.fn(),
+          $off: jest.fn()
+        }
+      },
+      methods: {
+        getThumbnail: jest.fn(() => '')
+      }
+    };
+  });
+
+  it('can be initialized', () => {
+    const wrapper = mountMixin(Product, mockMountingOptions);
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('exposes computed properties', () => {
+    const wrapper = mountMixin(Product, mockMountingOptions);
+
+    expect((wrapper.vm as any).thumbnail).toBeDefined();
+  });
+
+  describe('hooks', () => {
+    it('beforeMount hook should start subscription for cart-after-itemchanged event', () => {
+      const wrapper = mountMixin(Product, mockMountingOptions);
+
+      expect(mockMountingOptions.mocks.$bus.$on).toHaveBeenCalledWith('cart-after-itemchanged', (wrapper.vm as any).onProductChanged);
+    });
+
+    it('beforeDestroy hook should stop subscription for user-after-itemchanged event', () => {
+      const wrapper = mountMixin(Product, mockMountingOptions);
+
+      wrapper.destroy();
+
+      expect(mockMountingOptions.mocks.$bus.$off).toHaveBeenCalledWith('cart-after-itemchanged', (wrapper.vm as any).onProductChanged);
+    });
+  });
+
+  describe('methods', () => {
+    it('onProductChanged method should update component only if product has changed', () => {
+      const wrapper = mountMixin(Product, mockMountingOptions);
+      const mockForceUpdateFn = jest.spyOn((wrapper.vm as any), '$forceUpdate');
+
+      mockForceUpdateFn.mockClear();
+      (wrapper.vm as any).onProductChanged({ item: { sku: 'example sku' } });
+      expect(mockForceUpdateFn).toHaveBeenCalled();
+
+      mockForceUpdateFn.mockClear();
+      (wrapper.vm as any).onProductChanged({ item: { sku: 'another sku' } });
+      expect(mockForceUpdateFn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/core/modules/checkout/test/unit/components/Shipping.spec.ts
+++ b/core/modules/checkout/test/unit/components/Shipping.spec.ts
@@ -1,0 +1,470 @@
+import { mountMixinWithStore } from '@vue-storefront/unit-tests/utils';
+import { Shipping } from '../../../components/Shipping';
+
+describe('Shipping', () => {
+  let mockStore;
+  let mockMountingOptions;
+  let mockMethods;
+  let mockHooks;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockStore = {
+      modules: {
+        checkout: {
+          state: {
+            shippingDetails: {}
+          },
+          getters: {
+            getShippingMethods: jest.fn(() => ([])),
+            getPaymentMethods: jest.fn(() => ([]))
+          },
+          actions: {
+            updatePropValue: jest.fn()
+          },
+          namespaced: true
+        },
+        user: {
+          state: {
+            current: {}
+          },
+          namespaced: true
+        }
+      }
+    };
+
+    mockMountingOptions = {
+      propsData: {
+        isActive: true
+      },
+      mocks: {
+        $bus: {
+          $emit: jest.fn(),
+          $on: jest.fn(),
+          $off: jest.fn()
+        }
+      }
+    };
+
+    mockMethods = Object.entries(Shipping.methods)
+      .reduce((result, [methodName]) => {
+        result[methodName] = jest.spyOn(Shipping.methods, methodName as keyof typeof Shipping.methods)
+          .mockImplementation(jest.fn());
+
+        return result;
+      }, {});
+
+    mockHooks = ['beforeCreate', 'created', 'beforeMount', 'mounted', 'beforeUpdate', 'updated', 'beforeDestroy', 'destroyed']
+      .reduce((result, hookName) => {
+        if (Shipping[hookName]) {
+          result[hookName] = jest.spyOn(Shipping, hookName as any)
+            .mockImplementation(jest.fn());
+        }
+
+        return result;
+      }, {});
+  });
+
+  it('can be initialized', () => {
+    const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.isVueInstance()).toBe(true);
+  });
+
+  it('exposes computed properties', () => {
+    const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+    expect((wrapper.vm as any).currentUser).toBeDefined();
+    expect((wrapper.vm as any).shippingMethods).toBeDefined();
+    expect((wrapper.vm as any).checkoutShippingDetails).toBeDefined();
+    expect((wrapper.vm as any).paymentMethod).toBeDefined();
+  });
+
+  describe('hooks', () => {
+    it('beforeMount hook should start subscription for checkout-after-personalDetails and checkout-after-shippingset events', () => {
+      mockHooks['beforeMount'].mockRestore();
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      expect(mockMountingOptions.mocks.$bus.$on)
+        .toHaveBeenCalledWith('checkout-after-personalDetails', (wrapper.vm as any).onAfterPersonalDetails);
+      expect(mockMountingOptions.mocks.$bus.$on)
+        .toHaveBeenCalledWith('checkout-after-shippingset', (wrapper.vm as any).onAfterShippingSet);
+    });
+
+    it('beforeDestroy hook should stop subscription for checkout-after-personalDetails and checkout-after-shippingset events', () => {
+      mockHooks['beforeDestroy'].mockRestore();
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      wrapper.destroy();
+
+      expect(mockMountingOptions.mocks.$bus.$off)
+        .toHaveBeenCalledWith('checkout-after-personalDetails', (wrapper.vm as any).onAfterPersonalDetails);
+      expect(mockMountingOptions.mocks.$bus.$off)
+        .toHaveBeenCalledWith('checkout-after-shippingset', (wrapper.vm as any).onAfterShippingSet);
+    });
+
+    it('mounted hook should call shipping details methods', () => {
+      mockHooks['mounted'].mockRestore();
+
+      mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      expect(mockMethods['checkDefaultShippingAddress']).toHaveBeenCalled();
+      expect(mockMethods['checkDefaultShippingMethod']).toHaveBeenCalled();
+      expect(mockMethods['changeShippingMethod']).toHaveBeenCalled();
+    });
+  });
+
+  describe('watchers', () => {
+    it('should call checkDefaultShippingMethod method if shipping methods have changed', () => {
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      (wrapper.vm as any).$options.watch.shippingMethods.handler.call(wrapper.vm);
+
+      expect(mockMethods['checkDefaultShippingMethod']).toHaveBeenCalled();
+    });
+
+    it('should call useMyAddress method if shipping address has changed', () => {
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      (wrapper.vm as any).$options.watch.shipToMyAddress.handler.call(wrapper.vm);
+
+      expect(mockMethods['useMyAddress']).toHaveBeenCalled();
+    });
+  });
+
+  describe('methods', () => {
+    it('checkDefaultShippingAddress should check if default shipping address is configured', () => {
+      mockMethods['checkDefaultShippingAddress'].mockRestore();
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      mockMethods['hasShippingDetails'].mockClear();
+      mockMethods['hasShippingDetails'].mockReturnValue(false);
+      (wrapper.vm as any).checkDefaultShippingAddress();
+
+      expect(mockMethods['hasShippingDetails']).toHaveBeenCalled();
+      expect((wrapper.vm as any).shipToMyAddress).toBe(false);
+
+      mockMethods['hasShippingDetails'].mockClear();
+      mockMethods['hasShippingDetails'].mockReturnValue(true);
+      (wrapper.vm as any).checkDefaultShippingAddress();
+
+      expect(mockMethods['hasShippingDetails']).toHaveBeenCalled();
+      expect((wrapper.vm as any).shipToMyAddress).toBe(true);
+    });
+
+    it('checkDefaultShippingMethod should configure default shipping method and carrier if current shipping method is falsy', () => {
+      mockMethods['checkDefaultShippingMethod'].mockRestore();
+      mockStore.modules.checkout.state.shippingDetails.shippingMethod = '';
+      mockStore.modules.checkout.getters.getShippingMethods.mockImplementation(() => ([
+        { method_code: 'method code 1', carrier_code: 'carrier code 1' },
+        { method_code: 'method code 2', carrier_code: 'carrier code 2' },
+        { method_code: 'method code 3', carrier_code: 'carrier code 3', default: true }
+      ]));
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      mockMethods['notInMethods'].mockClear();
+      mockMethods['notInMethods'].mockReturnValue(true);
+      (wrapper.vm as any).checkDefaultShippingMethod();
+
+      expect(mockMethods['notInMethods']).not.toHaveBeenCalled();
+      expect((wrapper.vm as any).shipping).toEqual({ shippingMethod: 'method code 3', shippingCarrier: 'carrier code 3' });
+    });
+
+    it('checkDefaultShippingMethod should configure default shipping method and carrier if current shipping method is not supported', () => {
+      mockMethods['checkDefaultShippingMethod'].mockRestore();
+      mockStore.modules.checkout.state.shippingDetails.shippingMethod = 'not supported shipping method';
+      mockStore.modules.checkout.getters.getShippingMethods.mockImplementation(() => ([
+        { method_code: 'method code 1', carrier_code: 'carrier code 1' },
+        { method_code: 'method code 2', carrier_code: 'carrier code 2' },
+        { method_code: 'method code 3', carrier_code: 'carrier code 3', default: true }
+      ]));
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      mockMethods['notInMethods'].mockClear();
+      mockMethods['notInMethods'].mockReturnValue(true);
+      (wrapper.vm as any).checkDefaultShippingMethod();
+
+      expect(mockMethods['notInMethods']).toHaveBeenCalledWith('not supported shipping method');
+      expect((wrapper.vm as any).shipping).toEqual({ shippingMethod: 'method code 3', shippingCarrier: 'carrier code 3' });
+    });
+
+    it('onAfterShippingSet should configure shipping data', () => {
+      mockMethods['onAfterShippingSet'].mockRestore();
+
+      const shippingData = { shippingMethod: 'method code 3', shippingCarrier: 'carrier code 3' };
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      (wrapper.vm as any).onAfterShippingSet(shippingData);
+
+      expect((wrapper.vm as any).shipping).toEqual(shippingData);
+      expect((wrapper.vm as any).isFilled).toBe(true);
+    });
+
+    it('onAfterPersonalDetails should configure personal data by dispatching actions', () => {
+      mockMethods['onAfterPersonalDetails'].mockRestore();
+
+      const personalData = { firstName: 'example first name', lastName: 'example last name' };
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      wrapper.setData({ isFilled: false });
+      (wrapper.vm as any).onAfterPersonalDetails(personalData);
+
+      expect(mockStore.modules.checkout.actions.updatePropValue)
+        .toHaveBeenCalledWith(expect.anything(), ['firstName', 'example first name'], undefined);
+      expect(mockStore.modules.checkout.actions.updatePropValue)
+        .toHaveBeenCalledWith(expect.anything(), ['lastName', 'example last name'], undefined);
+    });
+
+    it('sendDataToCheckout should emit event', () => {
+      mockMethods['sendDataToCheckout'].mockRestore();
+
+      const shippingData = { shippingMethod: 'method code 3', shippingCarrier: 'carrier code 3' };
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      wrapper.setData({ shipping: shippingData });
+      (wrapper.vm as any).sendDataToCheckout();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).toHaveBeenCalledWith('checkout-after-shippingDetails', shippingData, undefined);
+      expect((wrapper.vm as any).isFilled).toBe(true);
+    });
+
+    it('edit should emit event only if form is filled', () => {
+      mockMethods['edit'].mockRestore();
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      mockMountingOptions.mocks.$bus.$emit.mockClear();
+      wrapper.setData({ isFilled: true });
+      (wrapper.vm as any).edit();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).toHaveBeenCalledWith('checkout-before-edit', 'shipping');
+
+      mockMountingOptions.mocks.$bus.$emit.mockClear();
+      wrapper.setData({ isFilled: false });
+      (wrapper.vm as any).edit();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).not.toHaveBeenCalled();
+    });
+
+    it('hasShippingDetails should check if shipping address is configured', () => {
+      mockMethods['hasShippingDetails'].mockRestore();
+      mockStore.modules.user.state.current = {};
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      const hasShippingDetails = (wrapper.vm as any).hasShippingDetails();
+
+      expect(hasShippingDetails).toBe(false);
+    });
+
+    it('hasShippingDetails should init default shipping address only if it is configured', () => {
+      mockMethods['hasShippingDetails'].mockRestore();
+
+      const defaultAddress = { id: 123, city: 'example city', street: 'example street' };
+
+      mockStore.modules.user.state.current = {
+        default_shipping: 123,
+        addresses: [defaultAddress]
+      };
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      const hasShippingDetails = (wrapper.vm as any).hasShippingDetails();
+
+      expect(hasShippingDetails).toBe(true);
+      expect((wrapper.vm as any).myAddressDetails).toEqual(defaultAddress);
+    });
+
+    it('useMyAddress should init shipping address from myAddressDetails if shipToMyAddress is set', () => {
+      mockMethods['useMyAddress'].mockRestore();
+      mockStore.modules.checkout.state.shippingDetails = {
+        shippingMethod: 'example shipping method',
+        shippingCarrier: 'example shipping carrier'
+      };
+
+      const myAddressDetails = {
+        firstname: 'example first name',
+        lastname: 'example last name',
+        country_id: 'example country',
+        region: { region: 'example region' },
+        city: 'example city',
+        street: ['example street', 'example apartment number'],
+        postcode: 'example zip code',
+        telephone: 'example phone number'
+      };
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      wrapper.setData({ shipToMyAddress: true });
+      wrapper.setData({ myAddressDetails });
+      (wrapper.vm as any).useMyAddress();
+
+      expect((wrapper.vm as any).shipping).toEqual({
+        firstName: 'example first name',
+        lastName: 'example last name',
+        country: 'example country',
+        state: 'example region',
+        city: 'example city',
+        streetAddress: 'example street',
+        apartmentNumber: 'example apartment number',
+        zipCode: 'example zip code',
+        phoneNumber: 'example phone number',
+        shippingMethod: 'example shipping method',
+        shippingCarrier: 'example shipping carrier'
+      });
+    });
+
+    it('useMyAddress should init shipping address from shippingDetails if shipToMyAddress is not set', () => {
+      mockMethods['useMyAddress'].mockRestore();
+      mockStore.modules.checkout.state.shippingDetails = {
+        shippingMethod: 'example shipping method',
+        shippingCarrier: 'example shipping carrier'
+      };
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      wrapper.setData({ shipToMyAddress: false });
+      (wrapper.vm as any).useMyAddress();
+
+      expect((wrapper.vm as any).shipping).toEqual(mockStore.modules.checkout.state.shippingDetails);
+    });
+
+    it('useMyAddress should call changeCountry method', () => {
+      mockMethods['useMyAddress'].mockRestore();
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      (wrapper.vm as any).useMyAddress();
+
+      expect(mockMethods['changeCountry']).toHaveBeenCalled();
+    });
+
+    it('getShippingMethod should return empty method_title and amount if shipping method is different than current one', () => {
+      mockMethods['getShippingMethod'].mockRestore();
+      mockStore.modules.checkout.state.shippingDetails.shippingMethod = 'not supported shipping method';
+      mockStore.modules.checkout.getters.getShippingMethods.mockImplementation(() => ([
+        { method_code: 'method code 1', method_title: 'method title 1', amount: 'amount 1' },
+        { method_code: 'method code 2', method_title: 'method title 2', amount: 'amount 2' },
+        { method_code: 'method code 3', method_title: 'method title 3', amount: 'amount 3' }
+      ]));
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      const shippingMethod = (wrapper.vm as any).getShippingMethod();
+
+      expect(shippingMethod).toEqual({ method_title: '', amount: '' });
+    });
+
+    it('getShippingMethod should return method_title and amount if it is supported', () => {
+      mockMethods['getShippingMethod'].mockRestore();
+      mockStore.modules.checkout.state.shippingDetails.shippingMethod = 'method code 2';
+      mockStore.modules.checkout.getters.getShippingMethods.mockImplementation(() => ([
+        { method_code: 'method code 1', method_title: 'method title 1', amount: 'amount 1' },
+        { method_code: 'method code 2', method_title: 'method title 2', amount: 'amount 2' },
+        { method_code: 'method code 3', method_title: 'method title 3', amount: 'amount 3' }
+      ]));
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      const shippingMethod = (wrapper.vm as any).getShippingMethod();
+
+      expect(shippingMethod).toEqual({ method_title: 'method title 2', amount: 'amount 2' });
+    });
+
+    it('getCountryName method should return country name from shipping', () => {
+      mockMethods['getCountryName'].mockRestore();
+      mockStore.modules.checkout.state.shippingDetails.country = 'PL';
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      const countryName = (wrapper.vm as any).getCountryName();
+
+      expect(countryName).toBe('Poland');
+    });
+
+    it('getCountryName method should return empty string if country has not been found', () => {
+      mockMethods['getCountryName'].mockRestore();
+      mockStore.modules.checkout.state.shippingDetails.country = 'invalid country code';
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      const countryName = (wrapper.vm as any).getCountryName();
+
+      expect(countryName).toBe('');
+    });
+
+    it('changeCountry should emit event', () => {
+      mockMethods['changeCountry'].mockRestore();
+      mockStore.modules.checkout.state.shippingDetails.country = 'PL';
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      (wrapper.vm as any).changeCountry();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).toHaveBeenCalledWith('checkout-before-shippingMethods', 'PL');
+    });
+
+    it('getCurrentShippingMethod should return undefined if there are no supported methods', () => {
+      mockMethods['getCurrentShippingMethod'].mockRestore();
+      mockStore.modules.checkout.state.shippingDetails.shippingMethod = 'not supported shipping method';
+      mockStore.modules.checkout.getters.getShippingMethods.mockImplementation(() => ([]));
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      const shippingMethod = (wrapper.vm as any).getCurrentShippingMethod();
+
+      expect(shippingMethod).toBeUndefined();
+    });
+
+    it('getCurrentShippingMethod should return shipping method details if it is supported', () => {
+      mockMethods['getCurrentShippingMethod'].mockRestore();
+      mockStore.modules.checkout.state.shippingDetails.shippingMethod = 'method code 2';
+      mockStore.modules.checkout.getters.getShippingMethods.mockImplementation(() => ([
+        { method_code: 'method code 1', method_title: 'method title 1', amount: 'amount 1' },
+        { method_code: 'method code 2', method_title: 'method title 2', amount: 'amount 2' },
+        { method_code: 'method code 3', method_title: 'method title 3', amount: 'amount 3' }
+      ]));
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      const shippingMethod = (wrapper.vm as any).getCurrentShippingMethod();
+
+      expect(shippingMethod).toEqual({ method_code: 'method code 2', method_title: 'method title 2', amount: 'amount 2' });
+    });
+
+    it('changeShippingMethod should not emit event if there is no current shipping method', () => {
+      mockMethods['changeShippingMethod'].mockRestore();
+      mockMethods['getCurrentShippingMethod'].mockReturnValue();
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      (wrapper.vm as any).changeShippingMethod();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).not.toHaveBeenCalled();
+    });
+
+    it('changeShippingMethod should emit event with current shipping method if it is configured', () => {
+      mockMethods['changeShippingMethod'].mockRestore();
+      mockMethods['getCurrentShippingMethod'].mockReturnValue({ method_code: 'method code', carrier_code: 'carrier code' });
+      mockStore.modules.checkout.state.shippingDetails.country = 'PL';
+      mockStore.modules.checkout.getters.getPaymentMethods.mockImplementation(() => ([{ code: 'payment code' }]));
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+      (wrapper.vm as any).changeShippingMethod();
+
+      expect(mockMountingOptions.mocks.$bus.$emit).toHaveBeenCalledWith('checkout-after-shippingMethodChanged', {
+        country: 'PL',
+        method_code: 'method code',
+        carrier_code: 'carrier code',
+        payment_method: 'payment code'
+      });
+    });
+
+    it('notInMethods method should inform if given shipping method is not supported', () => {
+      mockMethods['notInMethods'].mockRestore();
+      mockStore.modules.checkout.getters.getShippingMethods.mockImplementation(() => ([
+        { method_code: 'method code 1' },
+        { method_code: 'method code 2' },
+        { method_code: 'method code 3' }
+      ]));
+
+      const wrapper = mountMixinWithStore(Shipping, mockStore, mockMountingOptions);
+
+      expect((wrapper.vm as any).notInMethods('method code 2')).toBe(false);
+      expect((wrapper.vm as any).notInMethods('invalid method code')).toBe(true);
+    });
+  });
+});

--- a/core/modules/checkout/test/unit/index.spec.ts
+++ b/core/modules/checkout/test/unit/index.spec.ts
@@ -1,0 +1,101 @@
+import { StorageManager } from '@vue-storefront/core/lib/storage-manager';
+import { CheckoutModule } from '@vue-storefront/core/modules/checkout';
+import { checkoutModule } from '@vue-storefront/core/modules/checkout/store/checkout';
+import { paymentModule } from '@vue-storefront/core/modules/checkout/store/payment';
+import { shippingModule } from '@vue-storefront/core/modules/checkout/store/shipping';
+import * as types from '@vue-storefront/core/modules/checkout/store/checkout/mutation-types';
+
+jest.mock('@vue-storefront/core/helpers', () => ({
+  once: () => jest.fn()
+}));
+
+jest.mock('@vue-storefront/core/lib/storage-manager', () => ({
+  StorageManager: {
+    init: jest.fn(),
+    get: jest.fn()
+  }
+}));
+
+describe('CheckoutModule', () => {
+  let store;
+  let subscription;
+  let mockSetItem;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    store = {
+      registerModule: jest.fn(),
+      subscribe: jest.fn(fn => {
+        subscription = fn;
+      })
+    };
+
+    mockSetItem = jest.fn().mockResolvedValue({});
+
+    (StorageManager.get as jest.Mock).mockImplementation(() => ({
+      setItem: mockSetItem
+    }));
+  });
+
+  it('should init and register modules', () => {
+    CheckoutModule({ store } as any);
+
+    expect(StorageManager.init).toHaveBeenCalledWith('checkout');
+    expect(store.registerModule).toHaveBeenCalledWith('shipping', shippingModule);
+    expect(store.registerModule).toHaveBeenCalledWith('payment', paymentModule);
+    expect(store.registerModule).toHaveBeenCalledWith('checkout', checkoutModule);
+    expect(store.subscribe).toHaveBeenCalled();
+  });
+
+  it('should subscribe and set personal details on updates', () => {
+    const mockState = {
+      checkout: {
+        personalDetails: {
+          firstName: 'example first name',
+          lastName: 'example last name'
+        }
+      }
+    };
+
+    CheckoutModule({ store } as any);
+    subscription({ type: types.CHECKOUT_SAVE_PERSONAL_DETAILS }, mockState);
+
+    expect(StorageManager.get).toHaveBeenCalledWith('checkout');
+    expect(mockSetItem).toHaveBeenCalledWith('personal-details', mockState.checkout.personalDetails);
+  });
+
+  it('should subscribe and set shipping details on updates', () => {
+    const mockState = {
+      checkout: {
+        shippingDetails: {
+          firstName: 'example first name',
+          lastName: 'example last name'
+        }
+      }
+    };
+
+    CheckoutModule({ store } as any);
+    subscription({ type: types.CHECKOUT_SAVE_SHIPPING_DETAILS }, mockState);
+
+    expect(StorageManager.get).toHaveBeenCalledWith('checkout');
+    expect(mockSetItem).toHaveBeenCalledWith('shipping-details', mockState.checkout.shippingDetails);
+  });
+
+  it('should subscribe and set payment details on updates', () => {
+    const mockState = {
+      checkout: {
+        paymentDetails: {
+          firstName: 'example first name',
+          lastName: 'example last name'
+        }
+      }
+    };
+
+    CheckoutModule({ store } as any);
+    subscription({ type: types.CHECKOUT_SAVE_PAYMENT_DETAILS }, mockState);
+
+    expect(StorageManager.get).toHaveBeenCalledWith('checkout');
+    expect(mockSetItem).toHaveBeenCalledWith('payment-details', mockState.checkout.paymentDetails);
+  });
+});

--- a/core/modules/checkout/test/unit/store/checkout/actions.spec.ts
+++ b/core/modules/checkout/test/unit/store/checkout/actions.spec.ts
@@ -1,0 +1,235 @@
+import * as types from '@vue-storefront/core/modules/checkout/store/checkout/mutation-types';
+import checkoutActions from '@vue-storefront/core/modules/checkout/store/checkout/actions';
+import { StorageManager } from '@vue-storefront/core/lib/storage-manager';
+import { Logger } from '@vue-storefront/core/lib/logger';
+
+jest.mock('@vue-storefront/core/lib/storage-manager', () => ({
+  StorageManager: {
+    get: jest.fn()
+  }
+}));
+
+jest.mock('@vue-storefront/core/lib/logger', () => ({
+  Logger: {
+    error: jest.fn(() => jest.fn())
+  }
+}));
+
+describe('Checkout actions', () => {
+  let mockContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockContext = {
+      commit: jest.fn(),
+      dispatch: jest.fn()
+    };
+  });
+
+  describe('placeOrder', () => {
+    let order;
+
+    beforeEach(() => {
+      order = {
+        sku: 123456789
+      };
+    });
+
+    it('should place order if return code is successful', async () => {
+      mockContext.dispatch.mockResolvedValue({ resultCode: 200 });
+      await (checkoutActions as any).placeOrder(mockContext, { order });
+
+      expect(mockContext.dispatch).toHaveBeenCalledTimes(4);
+      expect(mockContext.dispatch).toHaveBeenNthCalledWith(1, 'order/placeOrder', order, { root: true });
+      expect(mockContext.dispatch).toHaveBeenNthCalledWith(2, 'updateOrderTimestamp');
+      expect(mockContext.dispatch).toHaveBeenNthCalledWith(3, 'cart/clear', { recreateAndSyncCart: true }, { root: true });
+      expect(mockContext.dispatch).toHaveBeenNthCalledWith(4, 'dropPassword');
+    });
+
+    it('should place order if return code is missing', async () => {
+      mockContext.dispatch.mockResolvedValue({ resultCode: undefined });
+      await (checkoutActions as any).placeOrder(mockContext, { order });
+
+      expect(mockContext.dispatch).toHaveBeenCalledTimes(4);
+      expect(mockContext.dispatch).toHaveBeenNthCalledWith(1, 'order/placeOrder', order, { root: true });
+      expect(mockContext.dispatch).toHaveBeenNthCalledWith(2, 'updateOrderTimestamp');
+      expect(mockContext.dispatch).toHaveBeenNthCalledWith(3, 'cart/clear', { recreateAndSyncCart: true }, { root: true });
+      expect(mockContext.dispatch).toHaveBeenNthCalledWith(4, 'dropPassword');
+    });
+
+    it('should not place order if return code is not successful', async () => {
+      mockContext.dispatch.mockResolvedValue({ resultCode: 500 });
+      await (checkoutActions as any).placeOrder(mockContext, { order });
+
+      expect(mockContext.dispatch).toHaveBeenCalledTimes(1);
+      expect(mockContext.dispatch).toHaveBeenNthCalledWith(1, 'order/placeOrder', order, { root: true });
+      expect(mockContext.dispatch).not.toHaveBeenNthCalledWith(2, 'updateOrderTimestamp');
+      expect(mockContext.dispatch).not.toHaveBeenNthCalledWith(3, 'cart/clear', { recreateAndSyncCart: true }, { root: true });
+      expect(mockContext.dispatch).not.toHaveBeenNthCalledWith(4, 'dropPassword');
+    });
+
+    it('should log thrown error', async () => {
+      mockContext.dispatch.mockImplementation(() => { throw new Error(); });
+      await (checkoutActions as any).placeOrder(mockContext, { order });
+
+      expect(mockContext.dispatch).toHaveBeenCalledTimes(1);
+      expect(mockContext.dispatch).toHaveBeenNthCalledWith(1, 'order/placeOrder', order, { root: true });
+      expect(mockContext.dispatch).not.toHaveBeenNthCalledWith(2, 'updateOrderTimestamp');
+      expect(mockContext.dispatch).not.toHaveBeenNthCalledWith(3, 'cart/clear', { recreateAndSyncCart: true }, { root: true });
+      expect(mockContext.dispatch).not.toHaveBeenNthCalledWith(4, 'dropPassword');
+      expect(Logger.error).toHaveBeenCalled();
+    });
+  });
+
+  it('updateOrderTimestamp should update timestamp of order in cache', async () => {
+    const mockSetItem = jest.fn(() => ({}));
+
+    (StorageManager.get as jest.Mock).mockImplementation(() => ({
+      setItem: mockSetItem
+    }));
+
+    await (checkoutActions as any).updateOrderTimestamp();
+
+    expect(StorageManager.get).toHaveBeenCalledWith('user');
+    expect(mockSetItem).toHaveBeenCalledWith('last-cart-bypass-ts', expect.any(Number));
+  });
+
+  describe('dropPassword', () => {
+    it('should drop password for account creation', async () => {
+      mockContext.state = {
+        personalDetails: {
+          createAccount: true
+        }
+      };
+      await (checkoutActions as any).dropPassword(mockContext);
+
+      expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_DROP_PASSWORD);
+    });
+
+    it('should not drop password if account is not created', async () => {
+      mockContext.state = {
+        personalDetails: {
+          createAccount: false
+        }
+      };
+      await (checkoutActions as any).dropPassword(mockContext);
+
+      expect(mockContext.commit).not.toHaveBeenCalled();
+    });
+  });
+
+  it('setModifiedAt should configure modified at date', async () => {
+    const timestamp = 1234567890;
+    await (checkoutActions as any).setModifiedAt(mockContext, timestamp);
+
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_SET_MODIFIED_AT, timestamp);
+  });
+
+  it('savePersonalDetails should configure personal details', async () => {
+    const personalDetails = {
+      firstName: 'example first name',
+      lastName: 'example last name'
+    };
+    await (checkoutActions as any).savePersonalDetails(mockContext, personalDetails);
+
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_SAVE_PERSONAL_DETAILS, personalDetails);
+  });
+
+  it('saveShippingDetails should configure shipping details', async () => {
+    const shippingDetails = {
+      firstName: 'example first name',
+      lastName: 'example last name'
+    };
+    await (checkoutActions as any).saveShippingDetails(mockContext, shippingDetails);
+
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_SAVE_SHIPPING_DETAILS, shippingDetails);
+  });
+
+  it('savePaymentDetails should configure payment details', async () => {
+    const paymentDetails = {
+      paymentMethod: 'example payment method'
+    };
+    await (checkoutActions as any).savePaymentDetails(mockContext, paymentDetails);
+
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_SAVE_PAYMENT_DETAILS, paymentDetails);
+  });
+
+  it('load personal, shipping and payment details from cache', async () => {
+    const personalDetails = {
+      firstName: 'example personal first name',
+      lastName: 'example personal last name'
+    };
+    const shippingDetails = {
+      firstName: 'example shipping first name',
+      lastName: 'example shipping last name'
+    };
+    const paymentDetails = {
+      paymentMethod: 'example payment method'
+    };
+    const mockGetItem = jest.fn()
+      .mockResolvedValueOnce(personalDetails)
+      .mockResolvedValueOnce(shippingDetails)
+      .mockResolvedValueOnce(paymentDetails);
+
+    (StorageManager.get as jest.Mock).mockImplementation(() => ({
+      getItem: mockGetItem
+    }));
+
+    await (checkoutActions as any).load(mockContext);
+
+    expect(StorageManager.get).toHaveBeenCalledWith('checkout');
+    expect(mockGetItem).toHaveBeenCalledWith('personal-details');
+    expect(mockGetItem).toHaveBeenCalledWith('shipping-details');
+    expect(mockGetItem).toHaveBeenCalledWith('payment-details');
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_LOAD_PERSONAL_DETAILS, personalDetails);
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_LOAD_SHIPPING_DETAILS, shippingDetails);
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_LOAD_PAYMENT_DETAILS, paymentDetails);
+  });
+
+  it('updatePropValue should configure prop value', async () => {
+    const payload = {
+      data: 'example data'
+    };
+    await (checkoutActions as any).updatePropValue(mockContext, payload);
+
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_UPDATE_PROP_VALUE, payload);
+  });
+
+  it('setThankYouPage should configure thank you page', async () => {
+    const payload = {
+      data: 'example data'
+    };
+    await (checkoutActions as any).setThankYouPage(mockContext, payload);
+
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_SET_THANKYOU, payload);
+  });
+
+  it('addPaymentMethod should configure add payment method', async () => {
+    const paymentMethod = 'example payment method';
+    await (checkoutActions as any).addPaymentMethod(mockContext, paymentMethod);
+
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_ADD_PAYMENT_METHOD, paymentMethod);
+  });
+
+  it('replacePaymentMethods should replace payment method', async () => {
+    const paymentMethod = 'example payment method';
+    await (checkoutActions as any).replacePaymentMethods(mockContext, paymentMethod);
+
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_SET_PAYMENT_METHODS, paymentMethod);
+  });
+
+  it('addShippingMethod should add shipping method', async () => {
+    const shippingMethod = 'example shipping method';
+    await (checkoutActions as any).addShippingMethod(mockContext, shippingMethod);
+
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_ADD_SHIPPING_METHOD, shippingMethod);
+  });
+
+  it('replaceShippingMethods should replace shipping method', async () => {
+    const shippingMethod = 'example shipping method';
+    await (checkoutActions as any).replaceShippingMethods(mockContext, shippingMethod);
+
+    expect(mockContext.commit).toHaveBeenCalledWith(types.CHECKOUT_SET_SHIPPING_METHODS, shippingMethod);
+  });
+});

--- a/core/modules/checkout/test/unit/store/checkout/getters.spec.ts
+++ b/core/modules/checkout/test/unit/store/checkout/getters.spec.ts
@@ -1,0 +1,172 @@
+import checkoutGetters from '@vue-storefront/core/modules/checkout/store/checkout/getters';
+
+describe('Checkout getters', () => {
+  it('getShippingDetails should return shipping details with default country from rootState if country is missing in shipping details', () => {
+    const mockState = {
+      shippingDetails: {
+        firstName: 'example first name',
+        lastName: 'example last name',
+        country: ''
+      }
+    };
+
+    const mockRootState = {
+      storeView: {
+        tax: {
+          defaultCountry: 'Poland'
+        }
+      }
+    };
+
+    const shippingDetails = (checkoutGetters as any).getShippingDetails(mockState, null, mockRootState);
+
+    expect(shippingDetails).toEqual({ ...mockState.shippingDetails, country: mockRootState.storeView.tax.defaultCountry });
+  });
+
+  it('getShippingDetails should return shipping details with shipping country if it exists', () => {
+    const mockState = {
+      shippingDetails: {
+        firstName: 'example first name',
+        lastName: 'example last name',
+        country: 'USA'
+      }
+    };
+
+    const mockRootState = {
+      storeView: {
+        tax: {
+          defaultCountry: 'Poland'
+        }
+      }
+    };
+
+    const shippingDetails = (checkoutGetters as any).getShippingDetails(mockState, null, mockRootState);
+
+    expect(shippingDetails).toEqual({ ...mockState.shippingDetails });
+  });
+
+  it('getPersonalDetails should return personal details', () => {
+    const mockState = {
+      personalDetails: {
+        firstName: 'example first name',
+        lastName: 'example last name'
+      }
+    };
+
+    const personalDetails = (checkoutGetters as any).getPersonalDetails(mockState);
+
+    expect(personalDetails).toEqual({ ...mockState.personalDetails });
+  });
+
+  it('getPaymentDetails should return personal details', () => {
+    const mockState = {
+      paymentDetails: {
+        paymentMethod: 'example payment method'
+      }
+    };
+
+    const paymentDetails = (checkoutGetters as any).getPaymentDetails(mockState);
+
+    expect(paymentDetails).toEqual({ ...mockState.paymentDetails });
+  });
+
+  it('isThankYouPage should inform if thank you page must be shown', () => {
+    const isThankYouPage = (checkoutGetters as any).isThankYouPage({ isThankYouPage: true });
+    const isNotThankYouPage = (checkoutGetters as any).isThankYouPage({ isThankYouPage: false });
+
+    expect(isThankYouPage).toBe(true);
+    expect(isNotThankYouPage).toBe(false);
+  });
+
+  it('getModifiedAt should return modified at time', () => {
+    const modifiedAt = (checkoutGetters as any).getModifiedAt({ modifiedAt: 1234567890 });
+
+    expect(modifiedAt).toBe(1234567890);
+  });
+
+  it('isUserInCheckout should inform if user is in checkout if it has been modified less than 30 minutes ago', () => {
+    const isUserInCheckout = (checkoutGetters as any).isUserInCheckout({ modifiedAt: Date.now() - (1000 * 60 * 29) });
+    const isUserNotInCheckout = (checkoutGetters as any).isUserInCheckout({ modifiedAt: Date.now() - (1000 * 60 * 31) });
+
+    expect(isUserInCheckout).toBe(true);
+    expect(isUserNotInCheckout).toBe(false);
+  });
+
+  it('getPaymentMethods should return all configured payment methods if virtual cart is not set', () => {
+    const mockState = {
+      paymentMethods: [
+        { code: 'example method 1' }, { code: 'example method 2' }, { code: 'cashondelivery' }
+      ]
+    };
+    const rootGetters = {
+      'cart/isVirtualCart': false
+    };
+
+    const paymentMethods = (checkoutGetters as any).getPaymentMethods(mockState, null, null, rootGetters);
+
+    expect(paymentMethods).toEqual([{ code: 'example method 1' }, { code: 'example method 2' }, { code: 'cashondelivery' }]);
+  });
+
+  it('getPaymentMethods should return all configured payment methods except cashondelivery if virtual cart is set', () => {
+    const mockState = {
+      paymentMethods: [
+        { code: 'example method 1' }, { code: 'example method 2' }, { code: 'cashondelivery' }
+      ]
+    };
+    const rootGetters = {
+      'cart/isVirtualCart': true
+    };
+
+    const paymentMethods = (checkoutGetters as any).getPaymentMethods(mockState, null, null, rootGetters);
+
+    expect(paymentMethods).toEqual([{ code: 'example method 1' }, { code: 'example method 2' }]);
+  });
+
+  it('getDefaultPaymentMethod should return default payment method', () => {
+    const mockGetters = {
+      getPaymentMethods: [
+        { code: 'example method 1' }, { code: 'example method 2', default: true }, { code: 'cashondelivery' }
+      ]
+    };
+
+    const paymentMethod = (checkoutGetters as any).getDefaultPaymentMethod(null, mockGetters);
+
+    expect(paymentMethod).toEqual({ code: 'example method 2', default: true });
+  });
+
+  it('getNotServerPaymentMethods should return methods not for server', () => {
+    const mockGetters = {
+      getPaymentMethods: [
+        { code: 'example method 1' }, { code: 'example method 2', is_server_method: true }
+      ]
+    };
+
+    const paymentMethods = (checkoutGetters as any).getNotServerPaymentMethods(null, mockGetters);
+
+    expect(paymentMethods).toEqual([{ code: 'example method 1' }]);
+  });
+
+  it('getShippingMethods should return shipping methods', () => {
+    const mockState = {
+      shippingMethods: [
+        { code: 'example method 1' }, { code: 'example method 2' }
+      ]
+    };
+
+    const shippingMethods = (checkoutGetters as any).getShippingMethods(mockState);
+
+    expect(shippingMethods).toEqual([{ code: 'example method 1' }, { code: 'example method 2' }]);
+  });
+
+  it('getDefaultShippingMethod should return default shipping method', () => {
+    const mockState = {
+      shippingMethods: [
+        { code: 'example method 1' }, { code: 'example method 2', default: true }
+      ]
+    };
+
+    const shippingMethod = (checkoutGetters as any).getDefaultShippingMethod(mockState);
+
+    expect(shippingMethod).toEqual({ code: 'example method 2', default: true });
+  });
+});

--- a/core/modules/checkout/test/unit/store/checkout/mutations.spec.ts
+++ b/core/modules/checkout/test/unit/store/checkout/mutations.spec.ts
@@ -1,0 +1,217 @@
+import * as types from '@vue-storefront/core/modules/checkout/store/checkout/mutation-types';
+import checkoutMutations from '@vue-storefront/core/modules/checkout/store/checkout/mutations'
+
+describe('Checkout mutations', () => {
+  it('CHECKOUT_PLACE_ORDER should set order', () => {
+    const order = { id: 1234567890 };
+    const mockState = {
+      order: null
+    };
+    const expectedState = {
+      order: { ...order }
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_PLACE_ORDER](mockState, order);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_SET_MODIFIED_AT should set modified at time', () => {
+    const mockState = {
+      modifiedAt: 1
+    };
+    const expectedState = {
+      modifiedAt: 1234567890
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_SET_MODIFIED_AT](mockState, 1234567890);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_SAVE_PERSONAL_DETAILS should set personal details', () => {
+    const personalDetails = { id: 1234567890 };
+    const mockState = {
+      personalDetails: null
+    };
+    const expectedState = {
+      personalDetails: { ...personalDetails }
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_SAVE_PERSONAL_DETAILS](mockState, personalDetails);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_SAVE_SHIPPING_DETAILS should set shipping details', () => {
+    const shippingDetails = { id: 1234567890 };
+    const mockState = {
+      shippingDetails: null
+    };
+    const expectedState = {
+      shippingDetails: { ...shippingDetails }
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_SAVE_SHIPPING_DETAILS](mockState, shippingDetails);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_SAVE_PAYMENT_DETAILS should set payment details', () => {
+    const paymentDetails = { id: 1234567890 };
+    const mockState = {
+      paymentDetails: null
+    };
+    const expectedState = {
+      paymentDetails: { ...paymentDetails }
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_SAVE_PAYMENT_DETAILS](mockState, paymentDetails);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_LOAD_PERSONAL_DETAILS should load personal details', () => {
+    const personalDetails = { id: 1234567890 };
+    const mockState = {
+      personalDetails: null
+    };
+    const expectedState = {
+      personalDetails: { ...personalDetails }
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_LOAD_PERSONAL_DETAILS](mockState, personalDetails);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_LOAD_SHIPPING_DETAILS should load personal details', () => {
+    const shippingDetails = { id: 1234567890 };
+    const mockState = {
+      shippingDetails: null
+    };
+    const expectedState = {
+      shippingDetails: { ...shippingDetails }
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_LOAD_SHIPPING_DETAILS](mockState, shippingDetails);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_LOAD_PAYMENT_DETAILS should load payment details', () => {
+    const paymentDetails = { id: 1234567890 };
+    const mockState = {
+      paymentDetails: null
+    };
+    const expectedState = {
+      paymentDetails: { ...paymentDetails }
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_LOAD_PAYMENT_DETAILS](mockState, paymentDetails);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_UPDATE_PROP_VALUE should update shipping property', () => {
+    const payload = ['prop', 'value'];
+    const mockState = {
+      shippingDetails: {
+        prop: null
+      }
+    };
+    const expectedState = {
+      shippingDetails: {
+        prop: 'value'
+      }
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_UPDATE_PROP_VALUE](mockState, payload);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_DROP_PASSWORD should init password and create account flag', () => {
+    const mockState = {
+      personalDetails: {
+        password: 'example password',
+        createAccount: true
+      }
+    };
+    const expectedState = {
+      personalDetails: {
+        password: '',
+        createAccount: false
+      }
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_DROP_PASSWORD](mockState);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_SET_THANKYOU should init thank you page', () => {
+    const mockState = {
+      isThankYouPage: false
+    };
+    const expectedState = {
+      isThankYouPage: true
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_SET_THANKYOU](mockState, true);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_ADD_PAYMENT_METHOD should add payment method', () => {
+    const mockState = {
+      paymentMethods: []
+    };
+    const expectedState = {
+      paymentMethods: [{ code: 'example payment method' }]
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_ADD_PAYMENT_METHOD](mockState, { code: 'example payment method' });
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_SET_PAYMENT_METHODS should set payment methods', () => {
+    const mockState = {
+      paymentMethods: [{ code: 'previous example payment method' }]
+    };
+    const expectedState = {
+      paymentMethods: [{ code: 'example payment method' }]
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_SET_PAYMENT_METHODS](mockState, [{ code: 'example payment method' }]);
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_ADD_SHIPPING_METHOD should add shipping method', () => {
+    const mockState = {
+      shippingMethods: []
+    };
+    const expectedState = {
+      shippingMethods: [{ code: 'example shipping method' }]
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_ADD_SHIPPING_METHOD](mockState, { code: 'example shipping method' });
+
+    expect(mockState).toEqual(expectedState);
+  });
+
+  it('CHECKOUT_SET_SHIPPING_METHODS should set shipping methods', () => {
+    const mockState = {
+      shippingMethods: [{ code: 'previous example shipping method' }]
+    };
+    const expectedState = {
+      shippingMethods: [{ code: 'example shipping method' }]
+    };
+
+    (checkoutMutations as any)[types.CHECKOUT_SET_SHIPPING_METHODS](mockState, [{ code: 'example shipping method' }]);
+
+    expect(mockState).toEqual(expectedState);
+  });
+});

--- a/core/modules/checkout/test/unit/store/payment/index.spec.ts
+++ b/core/modules/checkout/test/unit/store/payment/index.spec.ts
@@ -1,0 +1,65 @@
+import { paymentModule } from '@vue-storefront/core/modules/checkout/store/payment';
+
+jest.mock('@vue-storefront/core/lib/logger', () => ({
+  Logger: {
+    error: jest.fn(() => jest.fn())
+  }
+}));
+
+describe('Payment actions', () => {
+  let mockContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockContext = {
+      dispatch: jest.fn()
+    };
+  });
+
+  it('addMethod should configure new payment method', async () => {
+    await (paymentModule.actions as any).addMethod(mockContext, 'example payment method');
+
+    expect(mockContext.dispatch).toHaveBeenCalledWith('checkout/addPaymentMethod', 'example payment method', { root: true });
+  });
+
+  it('replaceMethods should replace payment method', async () => {
+    await (paymentModule.actions as any).replaceMethods(mockContext, 'example payment method');
+
+    expect(mockContext.dispatch).toHaveBeenCalledWith('checkout/replacePaymentMethods', 'example payment method', { root: true });
+  });
+});
+
+describe('Payment getters', () => {
+  it('paymentMethods should return payment methods from rootStore', () => {
+    const rootGetters = {
+      'checkout/getPaymentMethods': [
+        { code: 'example payment method' }
+      ]
+    };
+
+    const personalDetails = (paymentModule.getters as any).paymentMethods(null, null, null, rootGetters);
+
+    expect(personalDetails).toEqual([{ code: 'example payment method' }]);
+  });
+
+  it('getDefaultPaymentMethod should return default payment method from rootStore', () => {
+    const rootGetters = {
+      'checkout/getDefaultPaymentMethod': { code: 'example payment method' }
+    };
+
+    const personalDetails = (paymentModule.getters as any).getDefaultPaymentMethod(null, null, null, rootGetters);
+
+    expect(personalDetails).toEqual({ code: 'example payment method' });
+  });
+
+  it('getNotServerPaymentMethods should return not server methods from rootStore', () => {
+    const rootGetters = {
+      'checkout/getNotServerPaymentMethods': { code: 'example payment method' }
+    };
+
+    const personalDetails = (paymentModule.getters as any).getNotServerPaymentMethods(null, null, null, rootGetters);
+
+    expect(personalDetails).toEqual({ code: 'example payment method' });
+  });
+});

--- a/core/modules/checkout/test/unit/store/shipping/index.spec.ts
+++ b/core/modules/checkout/test/unit/store/shipping/index.spec.ts
@@ -1,0 +1,67 @@
+import { shippingModule } from '@vue-storefront/core/modules/checkout/store/shipping';
+
+jest.mock('@vue-storefront/core/lib/logger', () => ({
+  Logger: {
+    error: jest.fn(() => jest.fn())
+  }
+}));
+
+describe('Payment actions', () => {
+  let mockContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockContext = {
+      dispatch: jest.fn()
+    };
+  });
+
+  it('addMethod should configure new shipping method', async () => {
+    await (shippingModule.actions as any).addMethod(mockContext, 'example shipping method');
+
+    expect(mockContext.dispatch).toHaveBeenCalledWith('checkout/addShippingMethod', 'example shipping method', { root: true });
+  });
+
+  it('replaceMethods should replace shipping method', async () => {
+    await (shippingModule.actions as any).replaceMethods(mockContext, 'example shipping method');
+
+    expect(mockContext.dispatch).toHaveBeenCalledWith('checkout/replaceShippingMethods', 'example shipping method', { root: true });
+  });
+});
+
+describe('Shipping getters', () => {
+  it('shippingMethods should return shipping methods from rootStore', () => {
+    const rootGetters = {
+      'checkout/getShippingMethods': [
+        { code: 'example shipping method' }
+      ]
+    };
+
+    const shippingDetails = (shippingModule.getters as any).shippingMethods(null, null, null, rootGetters);
+
+    expect(shippingDetails).toEqual([{ code: 'example shipping method' }]);
+  });
+
+  it('getShippingMethods should return shipping methods from rootStore', () => {
+    const rootGetters = {
+      'checkout/getShippingMethods': [
+        { code: 'example shipping method' }
+      ]
+    };
+
+    const shippingDetails = (shippingModule.getters as any).getShippingMethods(null, null, null, rootGetters);
+
+    expect(shippingDetails).toEqual([{ code: 'example shipping method' }]);
+  });
+
+  it('getDefaultShippingMethod should return default shipping method from rootStore', () => {
+    const rootGetters = {
+      'checkout/getDefaultShippingMethod': { code: 'example shipping method' }
+    };
+
+    const personalDetails = (shippingModule.getters as any).getDefaultShippingMethod(null, null, null, rootGetters);
+
+    expect(personalDetails).toEqual({ code: 'example shipping method' });
+  });
+});


### PR DESCRIPTION
### Related issues
Closes #3460 

### Short description and why it's useful
More than 150 unit tests have been introduced for `Checkout` components (`CartSummary`, `OrderReview`, `Payment`, `PersonalDetails`, `Product`, `Shipping`) and Vuex stores for actions, mutations and getters.

### Which environment this relates to
- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)