### PR TITLE
hot fix for Cannot assign to read only property 'storeCode' #3748

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - disable product mutation when assigning product variant - @gibkigonzo (#3735)
+- fix issue with Cannot assign to read only property 'storeCode' - @yuriboyko (#3748)
 
 ## [1.10.4] - 18.10.2019
 

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -24,9 +24,13 @@ export async function prepareStoreView (storeCode: string): Promise<StoreView> {
   }
   const storeViewHasChanged = !rootStore.state.storeView || rootStore.state.storeView.storeCode !== storeCode
   if (storeCode) { // current store code
-    if ((storeView = config.storeViews[storeCode])) {
+    const currentStoreView = config.storeViews[storeCode]
+    if (currentStoreView) {
+      storeView = Object.assign({}, currentStoreView);
       storeView.storeCode = storeCode
       rootStore.state.user.current_storecode = storeCode
+    } else {
+      console.warn(`Not found 'storeView' matching the given 'storeCode': ${storeCode}`)
     }
   } else {
     storeView.storeCode = config.defaultStoreCode || ''


### PR DESCRIPTION
### Related issues
#3748

### Short description and why it's useful
Fix issue with error appeared in Production mode if multistore is enabled


### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

