### PR TITLE
Fixed products sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed instant checkout functionality - @andrzejewsky (#3765)
 - Fixed links to the promoted banners - @andrzejewsky (#3753)
 - Fixed missing parameter in the compare list - @andrzejewsky (#3757)
+- Fixed product sorting - @AdKamil (#3785)
 
 ### Added
 - Added support for ES7 - @andrzejewsky (#3690)

--- a/config/default.json
+++ b/config/default.json
@@ -325,7 +325,7 @@
       "order": "desc"
     },
     "sortByAttributes": {
-      "Latest": "updated_at",
+      "Latest": "updated_at:desc",
       "Price: Low to high":"final_price",
       "Price: High to low":"final_price:desc"
     },


### PR DESCRIPTION
### Related issues
#3785

### Short description and why it's useful
Fixed product sorting. If user came to category page first time, product were sorted by `latest:desc`. When he wanted to change filter for e.g `price:desc` and then come back to previous filter it was only `latest`. 
I've unified that to `latest:desc`

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

