### PR TITLE
Redirect from simple product using url_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed problem with cutting image height in category page on 1024px+ screen res - @AdKamil (#3781)
 - Fixed null value of search input - @AdKamil (#3778)
 - Fixed product sorting - @AdKamil (#3785)
-- Redirect from simple product using url_path - @benjick
+- Redirect from simple product using url_path - @benjick (#3804)
 
 
 ## [1.11.0-rc.2] - 2019.10.31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed problem with cutting image height in category page on 1024px+ screen res - @AdKamil (#3781)
 - Fixed null value of search input - @AdKamil (#3778)
 - Fixed product sorting - @AdKamil (#3785)
+- Redirect from simple product using url_path - @benjick
 
 
 ## [1.11.0-rc.2] - 2019.10.31

--- a/core/pages/Product.js
+++ b/core/pages/Product.js
@@ -10,6 +10,7 @@ import { ProductOption } from '@vue-storefront/core/modules/catalog/components/P
 import omit from 'lodash-es/omit'
 import Composite from '@vue-storefront/core/mixins/composite'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { formatProductLink } from '@vue-storefront/core/modules/url/helpers'
 
 export default {
   name: 'Product',
@@ -160,7 +161,8 @@ export default {
     onStateCheck () {
       if (this.parentProduct && this.parentProduct.id !== this.product.id) {
         Logger.log('Redirecting to parent, configurable product', this.parentProduct.sku)()
-        this.$router.replace({ name: 'product', params: { parentSku: this.parentProduct.sku, childSku: this.product.sku, slug: this.parentProduct.slug } })
+        const parentUrl = formatProductLink(this.parentProduct, currentStoreView().storeCode)
+        this.$router.replace(parentUrl)
       }
     },
     onAfterPriceUpdate (product) {


### PR DESCRIPTION
### Short description and why it's useful
Before this `localhost/se/simple-product` would redirect to `localhost/p/xxx/yyy/zzz`. This change redirects to `localhost/se/configurable-product`.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

