### PR TITLE
Accepting both values for new and sale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed problem with cutting image height in category page on 1024px+ screen res - @AdKamil (#3781)
 - Fixed null value of search input - @AdKamil (#3778)
 - Fixed product sorting - @AdKamil (#3785)
-
+- Fixed displaying `sale` and `new` mark - @andrzejewsky (#3800)
 
 ## [1.11.0-rc.2] - 2019.10.31
 

--- a/core/modules/catalog/components/ProductTile.ts
+++ b/core/modules/catalog/components/ProductTile.ts
@@ -34,10 +34,10 @@ export const ProductTile = {
       }
     },
     isOnSale () {
-      return this.product.sale === '1' ? 'sale' : ''
+      return [true, '1'].includes(this.product.sale) ? 'sale' : ''
     },
     isNew () {
-      return this.product.new === '1' ? 'new' : ''
+      return [true, '1'].includes(this.product.new) ? 'new' : ''
     }
   }
 }


### PR DESCRIPTION
### Related issues
closes #3800

### Short description and why it's useful
Sometimes our API returns boolean values, which effects on displaying items on the front-end. This PR is a quickfix that accepts both formats. In the future would be nice to fix that in the API directly.


### Which environment this relates to
- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

### Contribution and currently important rules acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

