### PR TITLE
trigger app.$mount in beforeResolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disable product mutation when assigning product variant - @gibkigonzo (#3735)
 - Fixed null value of search input - @AdKamil (#3778)
 - Sorting fixed on category page - @AdKamil (#3785)
+- Mount app in 'beforeResolve' if it's not dispatched in 'onReady' - @gibkigonzo (#3669)
 
 ## [1.10.4] - 18.10.2019
 

--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -64,6 +64,10 @@ const invokeClientEntry = async () => {
   }
   router.onReady(async () => {
     router.beforeResolve((to, from, next) => {
+      // Mounting app
+      if (!(app as any)._isMounted) {
+        app.$mount('#app')
+      }
       if (!from.name) return next() // do not resolve asyncData on server render - already been done
       if (Vue.prototype.$ssrRequestContext) Vue.prototype.$ssrRequestContext.output.cacheTags = new Set<string>()
       const matched = router.getMatchedComponents(to)
@@ -99,14 +103,6 @@ const invokeClientEntry = async () => {
         }
       }))
     })
-    // Mounting app
-    if (!RouterManager.isRouteDispatched()) {
-      RouterManager.addDispatchCallback(() => {
-        app.$mount('#app')
-      })
-    } else {
-      app.$mount('#app')
-    }
   })
   registerSyncTaskProcessor()
   window.addEventListener('online', () => { onNetworkStatusChange(store) })

--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -63,12 +63,22 @@ const invokeClientEntry = async () => {
     })
   }
   router.onReady(async () => {
+    // check if app can be mounted
+    const canBeMounted = () => RouterManager.isRouteDispatched() && // route is dispatched
+      !(router as any).history.pending && // there is no pending in router history
+      !(app as any)._isMounted // it's not mounted before
+
+    if (canBeMounted()) {
+      app.$mount('#app')
+    }
     router.beforeResolve((to, from, next) => {
-      // Mounting app
-      if (!(app as any)._isMounted) {
-        app.$mount('#app')
+      if (!from.name) {
+        next()
+        if (canBeMounted()) {
+          app.$mount('#app')
+        }
+        return // do not resolve asyncData on server render - already been done
       }
-      if (!from.name) return next() // do not resolve asyncData on server render - already been done
       if (Vue.prototype.$ssrRequestContext) Vue.prototype.$ssrRequestContext.output.cacheTags = new Set<string>()
       const matched = router.getMatchedComponents(to)
       if (to) { // this is from url
@@ -103,11 +113,6 @@ const invokeClientEntry = async () => {
         }
       }))
     })
-    // if route is dispatched and there is no pending in router history
-    // if there is stil pending then 'beforeResolve' will handle app mount, otherwise 'beforeResolve' will not trigger
-    if (RouterManager.isRouteDispatched() && !(router as any).history.pending) {
-      app.$mount('#app')
-    }
   })
   registerSyncTaskProcessor()
   window.addEventListener('online', () => { onNetworkStatusChange(store) })

--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -103,6 +103,10 @@ const invokeClientEntry = async () => {
         }
       }))
     })
+    // route is already resolved so 'beforeResolve' will not be triggered
+    if (RouterManager.isRouteDispatched()) {
+      app.$mount('#app')
+    }
   })
   registerSyncTaskProcessor()
   window.addEventListener('online', () => { onNetworkStatusChange(store) })

--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -103,8 +103,9 @@ const invokeClientEntry = async () => {
         }
       }))
     })
-    // route is already resolved so 'beforeResolve' will not be triggered
-    if (RouterManager.isRouteDispatched()) {
+    // if route is dispatched and there is no pending in router history
+    // if there is stil pending then 'beforeResolve' will handle app mount, otherwise 'beforeResolve' will not trigger
+    if (RouterManager.isRouteDispatched() && !(router as any).history.pending) {
       app.$mount('#app')
     }
   })

--- a/core/lib/search/adapter/api/searchAdapter.ts
+++ b/core/lib/search/adapter/api/searchAdapter.ts
@@ -80,10 +80,10 @@ export class SearchAdapter {
       },
       body: config.elasticsearch.queryMethod === 'POST' ? JSON.stringify(ElasticsearchQueryBody) : null
     })
-    .then(resp => { return resp.json() })
-    .catch(error => {
-      throw new Error('FetchError in request to ES: ' + error.toString())
-    })
+      .then(resp => { return resp.json() })
+      .catch(error => {
+        throw new Error('FetchError in request to ES: ' + error.toString())
+      })
   }
 
   public handleResult (resp, type, start = 0, size = 50): SearchResponse {


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3669

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Problem occur because we mount app before async route component is resolved. So we can use `beforeResolve`. As described in vue-router docs it's triggered ["**after all in-component guards and async route components are resolved**"](https://router.vuejs.org/guide/advanced/navigation-guards.html#global-resolve-guards). We only need to check if app is already loaded.


### QA
1. Change in `src/themes/default/router/index.js`
```
const Home = () => import(/* webpackChunkName: "vsf-home" */ 'theme/pages/Home.vue')
```
to
```
const Home = () => new Promise((resolve) => {
  setTimeout(async () => {
    resolve(import(/* webpackChunkName: "vsf-home" */ 'theme/pages/Home.vue'))
  }, 5000)
})
```
This will simulate very long lazy loading.
2. check homepage in dev and prod mode => it should crash in prod and there should be mismatch in dev mode

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

