### PR TITLE
#2637 Add to cart from wishlist and add to cart from product listing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add unit test for `core/modules/checkout` - @psmyrek (#3460)
 - Add unit tests for `core/modules/order` - @dz3n (#3466)
 - Add unit tests for `core/modules/user` - @dz3n (#3470)
+- Add to cart from Wishlist and Product listing for simple products - @AdKamil (#2637)
 
 ### Fixed
 - Fixed problem with cutting image height in category page on 1024px+ screen res - @AdKamil (#3781)

--- a/src/themes/default/components/core/blocks/Wishlist/Product.vue
+++ b/src/themes/default/components/core/blocks/Wishlist/Product.vue
@@ -13,6 +13,19 @@
         <div class="h6 cl-bg-tertiary pt5 sku">
           {{ product.sku }}
         </div>
+        <div v-if="canAddToCart">
+          <add-to-cart
+            v-if="product.product_option || product.type_id === 'simple'"
+            :product="product"
+          />
+          <router-link
+            v-else
+            :to="productLink"
+            class="my15 no-outline button-full block brdr-none w-100 px10 py20 bg-cl-mine-shaft :bg-cl-th-secondary ripple weight-400 h4 cl-white sans-serif fs-medium no-underline pointer align-center border-box"
+          >
+            {{ $t('Configure') }}
+          </router-link>
+        </div>
       </div>
     </div>
     <div class="col-xs flex py15 align-right">
@@ -41,11 +54,15 @@ import ProductImage from 'theme/components/core/ProductImage'
 import RemoveButton from './RemoveButton'
 import i18n from '@vue-storefront/i18n'
 import { htmlDecode } from '@vue-storefront/core/lib/store/filters'
+import AddToCart from 'theme/components/core/AddToCart'
+
+const THEME_ADD_TO_CART_FROM_WISHLIST = true
 
 export default {
   components: {
     RemoveButton,
-    ProductImage
+    ProductImage,
+    AddToCart
   },
   mixins: [Product],
   computed: {
@@ -57,6 +74,9 @@ export default {
         loading: this.thumbnail,
         src: this.thumbnail
       }
+    },
+    canAddToCart () {
+      return THEME_ADD_TO_CART_FROM_WISHLIST
     }
   },
   methods: {


### PR DESCRIPTION
### Related issues
#2637

closes #3645 

### Short description and why it's useful
This feature was previously created by @Dnd-Dboy [link](https://github.com/DivanteLtd/vue-storefront/pull/3645).

This feature adds posibillity to add product to cart from wishlist. If product is simple then `add to cart` button appears, if not then button `configure` appears. This button redirects to product page.

I decided to not include this feature on category page, because i think it needs to be consulted with UX designer.


### Screenshots of visual changes before/after (if there are any)
[link](https://gyazo.com/a68b08082927a40e6f6bb41178aa988b)

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature


- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

