### PR TITLE
Keep git after yarn install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed sorting on category page and product tile sizing - @andrzejewsky (#3817)
 - Redirect from simple product using url_path - @benjick (#3804)
 - Mount app in 'beforeResolve' if it's not dispatched in 'onReady' - @gibkigonzo (#3669)
-- change translation from jp-JP to ja-JP - @gibkigonzo (#3824)
+- Change translation from jp-JP to ja-JP - @gibkigonzo (#3824)
 
 ### Changed / Improved
 - Changed pre commit hook to use NODE_ENV production to check for debugger statements - @resubaka (#3686)
 - Improve the readability of 'getShippingDetails()' and 'updateDetails()' method of UserShippingDetails component - @adityasharma7 (#3770)
+- Keep git after yarn install in dockerfile - @ddanier (#3826)
 
 ## [1.11.0-rc.2] - 2019.10.31
 

--- a/docker/vue-storefront/Dockerfile
+++ b/docker/vue-storefront/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /var/www
 COPY package.json ./
 COPY yarn.lock ./
 
-RUN apk add --no-cache --virtual .build-deps ca-certificates wget git python make g++ \
+RUN apk add --no-cache --virtual .build-deps ca-certificates wget python make g++ \
+  && apk add --no-cache git \
   && yarn install --no-cache \
   && apk del .build-deps
 


### PR DESCRIPTION
### Related issues
none

### Short description and why it's useful
We need to keep git after the initial install inside the Dockerfile, as there is an additional "yarn install" inside vue-storefront.sh. This would fail without having git around.

### Screenshots of visual changes before/after (if there are any)
none

### Which environment this relates to
no idea what would be fitting here

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

