### PR TITLE
User accounts now get created to the correct website in multistore setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Product page breadcrumbs problem when products are in multiple categories in different branches of the category tree - @grimasod (#3691)
 - Change translation from jp-JP to ja-JP - @gibkigonzo (#3824)
 - Fix ecosystem config for pm2 - @andrzejewsky (#3842)
+- User accounts now get created to the correct website if Magento has more than one - @juho-jaakkola (#3848)
 
 ### Changed / Improved
 - Changed pre commit hook to use NODE_ENV production to check for debugger statements - @resubaka (#3686)

--- a/config/default.json
+++ b/config/default.json
@@ -116,6 +116,7 @@
     "de": {
       "storeCode": "de",
       "storeId": 3,
+      "websiteId": 1,
       "name": "German Store",
       "url": "/de",
       "appendStoreCode": true,
@@ -147,6 +148,7 @@
       "extend": "de",
       "storeCode": "it",
       "storeId": 4,
+      "websiteId": 1,
       "name": "Italian Store",
       "url": "/it",
       "appendStoreCode": true,

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -42,11 +42,13 @@ export async function prepareStoreView (storeCode: string): Promise<StoreView> {
     elasticsearch: Object.assign({}, config.elasticsearch),
     storeCode: null,
     storeId: config.defaultStoreCode && config.defaultStoreCode !== '' ? config.storeViews[config.defaultStoreCode].storeId : 1,
+    websiteId: 1,
     seo: Object.assign({}, config.seo)
   }
 
   if (config.storeViews.multistore === true) {
     storeView.storeCode = storeCode || config.defaultStoreCode || ''
+    storeView.websiteId = config.storeViews[storeView.storeCode].websiteId || 1
   } else {
     storeView.storeCode = storeCode || ''
   }

--- a/core/lib/types.ts
+++ b/core/lib/types.ts
@@ -12,6 +12,7 @@ export interface StoreView {
   extend?: string,
   disabled?: boolean,
   storeId: any,
+  websiteId: any,
   name?: string,
   url?: string,
   appendStoreCode?: boolean,

--- a/core/modules/user/store/actions.ts
+++ b/core/modules/user/store/actions.ts
@@ -11,6 +11,7 @@ import { UserService } from '@vue-storefront/core/data-resolver'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import { userHooksExecutors, userHooks } from '../hooks'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 const actions: ActionTree<UserState, RootState> = {
   async startSession ({ commit, dispatch, getters }) {
@@ -67,9 +68,13 @@ const actions: ActionTree<UserState, RootState> = {
     return resp
   },
   /**
-   * Login user and return user profile and current token
+   * Create a new user and return user profile and current token
    */
   async register (context, { password, ...customer }) {
+    // This is required in multistore setup to create the user
+    // account into the correct store.
+    customer.website_id = currentStoreView().websiteId;
+
     return UserService.register(customer, password)
   },
 

--- a/docs/guide/upgrade-notes/README.md
+++ b/docs/guide/upgrade-notes/README.md
@@ -82,6 +82,7 @@ If by some reasons you wan't to have the `localStorage` back on for `Products by
 - The getters `cmsBlocks`, `cmsBlockIdentifier`, `cmsBlockId` are deprecated. Please use `getCmsBlocks`, `getCmsBlockIdentifier`, `getCmsBlockId` instead.
 - Translations for "Order #", "Price ", "Select size ", "You are logged in as" and "items" changed, they now include a placeholder for the value. Please refer to [this commit](https://github.com/DivanteLtd/vue-storefront/pull/3550/commits/366d31bf28a1e27a7f14b222369cba8fe0a6d3e0) in order to adjust them, otherwise they might get lost.
 - `i18n.currencySignPlacement` config value is replaced by `i18n.priceFormat` so price format becomes more flexible
+- `storeViews.<storeCode>.websiteId` was added so that VSF will work correctly with Magento setups that have more than one website
 - Theme initialization needs to be modified in customized themes
   - Delete the line `RouterManager.addRoutes(routes, router, true)`. This is now handled in `setupMultistoreRoutes`, including the default store.
   - Optionally give theme routes priority, to ensure they override module routes if there are any conflicts. For example `setupMultistoreRoutes(config, router, routes, 10)`.


### PR DESCRIPTION
### Related issues

closes #3848

### Short description and why it's useful

New user accounts were not being created into the correct store within a multistore setup, because the `website_id` was missing from the API call causing all accounts to be created to the default store.

Now the `website_id` is explicitly set in the API call.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

