### PR TITLE
make config as readonly

### DIFF
--- a/core/build/config.js
+++ b/core/build/config.js
@@ -1,0 +1,49 @@
+import config from './config.json'
+import { deepFreeze } from '@vue-storefront/core/helpers/deepFreeze'
+
+const freezedConfig = deepFreeze(config)
+
+export const {
+  server,
+  staticPages,
+  seo,
+  console,
+  redis,
+  graphql,
+  api,
+  elasticsearch,
+  ssr,
+  queues,
+  defaultStoreCode,
+  storeViews,
+  entities,
+  cart,
+  attributes,
+  products,
+  orders,
+  localForage,
+  reviews,
+  users,
+  stock,
+  images,
+  install,
+  demomode,
+  tax,
+  shipping,
+  syncTasks,
+  i18n,
+  expireHeaders,
+  newsletter,
+  mailer,
+  theme,
+  analytics,
+  googleTagManager,
+  hotjar,
+  cms,
+  cms_block,
+  cms_page,
+  usePriceTiers,
+  useZeroPriceProduct,
+  query
+} = freezedConfig
+export default freezedConfig

--- a/core/build/webpack.base.config.ts
+++ b/core/build/webpack.base.config.ts
@@ -121,7 +121,7 @@ export default {
     extensions: ['.js', '.vue', '.gql', '.graphqls', '.ts'],
     alias: {
       // Main aliases
-      'config': path.resolve(__dirname, './config.json'),
+      'config': path.resolve(__dirname, './config.js'),
       'src': path.resolve(__dirname, '../../src'),
 
       // Theme aliases

--- a/core/helpers/deepFreeze.ts
+++ b/core/helpers/deepFreeze.ts
@@ -1,0 +1,17 @@
+export const deepFreeze = (obj) => {
+  // Retrieve the property names defined on obj
+  const propNames = Object.getOwnPropertyNames(obj);
+
+  // Freeze properties before freezing self
+  propNames.forEach((name) => {
+    const prop = obj[name]
+
+    // Freeze prop if it is an object
+    if (typeof prop === 'object' && prop !== null) {
+      deepFreeze(prop)
+    }
+  })
+
+  // Freeze self (no-op if already frozen)
+  return Object.freeze(obj)
+}

--- a/core/modules/catalog-next/store/category/actions.ts
+++ b/core/modules/catalog-next/store/category/actions.ts
@@ -140,7 +140,7 @@ const actions: ActionTree<CategoryState, RootState> = {
       categorySearchOptions.filters.id = searchedIds.filter(categoryId => !getters.getCategoriesMap[categoryId] && !getters.getNotFoundCategoryIds.includes(categoryId))
     }
     if (!searchingByIds || categorySearchOptions.filters.id.length) {
-      categorySearchOptions.filters = Object.assign(config.entities.category.filterFields, categorySearchOptions.filters)
+      categorySearchOptions.filters = Object.assign({}, config.entities.category.filterFields, categorySearchOptions.filters)
       const categories = await CategoryService.getCategories(categorySearchOptions)
       const notFoundCategories = searchedIds.filter(categoryId => !categories.some(cat => cat.id === parseInt(categoryId)))
 


### PR DESCRIPTION
### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
This pr will make config as readonly. With freeze it will not be reactive (it is now) and could not be changed. It showed me config mutation on the category page
 `core/modules/catalog-next/store/category/actions.ts` so it could help to avoid those issues. wdyt?


### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

