### PR TITLE
Breadcrumbs Filter and Component fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add to cart from Wishlist and Product listing for simple products - @Dnd-Dboy, @dz3n (#2637)
 - Add global Category and Breadcrumb filters, defined in local.json - @grimasod (#3691)
 - Add constant which conditions the number of products loading per page - @AdKamil (#3630)
-- Added price filtering key as config - @roywcm 
+- Added price filtering key as config - @roywcm
 
 ### Fixed
 - Always close zoom overlay after changing product - @psmyrek (#3818)
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed adding products search results to category-next product store - @grimasod (#3877)
 - Use `defaultSortBy` for sorting category products by default @haelbichalex (#3873)
 - Fixed some potential mutations of Config object in `catalog` and `catalog-next` - @grimasod (#3843)
+- Fixed Breadcrumb filters - apply to second category fetch  - @grimasod (#3887)
 
 ### Changed / Improved
 - Changed pre commit hook to use NODE_ENV production to check for debugger statements - @resubaka (#3686)

--- a/core/data-resolver/types/DataResolver.d.ts
+++ b/core/data-resolver/types/DataResolver.d.ts
@@ -17,7 +17,8 @@ declare namespace DataResolver {
     start?: number,
     sort?: string,
     includeFields?: string[],
-    excludeFields?: string[]
+    excludeFields?: string[],
+    reloadAll?: boolean
   }
 
   interface Customer {

--- a/core/modules/catalog-next/store/category/actions.ts
+++ b/core/modules/catalog-next/store/category/actions.ts
@@ -130,9 +130,9 @@ const actions: ActionTree<CategoryState, RootState> = {
   },
   async loadCategories ({ commit, getters }, categorySearchOptions: DataResolver.CategorySearchOptions): Promise<Category[]> {
     const searchingByIds = !(!categorySearchOptions || !categorySearchOptions.filters || !categorySearchOptions.filters.id)
-    const searchedIds: string[] = searchingByIds ? (categorySearchOptions.filters.id as string[]) : []
+    const searchedIds: string[] = searchingByIds ? ([...categorySearchOptions.filters.id] as string[]) : []
     const loadedCategories: Category[] = []
-    if (searchingByIds) { // removing from search query already loaded categories, they are added to returned results
+    if (searchingByIds && !categorySearchOptions.reloadAll) { // removing from search query already loaded categories, they are added to returned results
       for (const [categoryId, category] of Object.entries(getters.getCategoriesMap)) {
         if (searchedIds.includes(categoryId)) {
           loadedCategories.push(category as Category)
@@ -198,7 +198,7 @@ const actions: ActionTree<CategoryState, RootState> = {
     if (!category) return
     const categoryHierarchyIds = _prepareCategoryPathIds(category) // getters.getCategoriesHierarchyMap.find(categoryMapping => categoryMapping.includes(category.id))
     const categoryFilters = Object.assign({ 'id': categoryHierarchyIds }, cloneDeep(config.entities.category.breadcrumbFilterFields))
-    const categories = await dispatch('loadCategories', {filters: categoryFilters})
+    const categories = await dispatch('loadCategories', { filters: categoryFilters, reloadAll: Object.keys(config.entities.category.breadcrumbFilterFields).length > 0 })
     const sorted = []
     for (const id of categoryHierarchyIds) {
       const index = categories.findIndex(cat => cat.id.toString() === id)

--- a/core/modules/catalog-next/store/category/actions.ts
+++ b/core/modules/catalog-next/store/category/actions.ts
@@ -197,7 +197,7 @@ const actions: ActionTree<CategoryState, RootState> = {
   async loadCategoryBreadcrumbs ({ dispatch, getters }, { category, currentRouteName, omitCurrent = false }) {
     if (!category) return
     const categoryHierarchyIds = _prepareCategoryPathIds(category) // getters.getCategoriesHierarchyMap.find(categoryMapping => categoryMapping.includes(category.id))
-    const categoryFilters = { 'id': categoryHierarchyIds }
+    const categoryFilters = Object.assign({ 'id': categoryHierarchyIds }, cloneDeep(config.entities.category.breadcrumbFilterFields))
     const categories = await dispatch('loadCategories', {filters: categoryFilters})
     const sorted = []
     for (const id of categoryHierarchyIds) {

--- a/src/themes/default/components/core/blocks/Checkout/ThankYouPage.vue
+++ b/src/themes/default/components/core/blocks/Checkout/ThankYouPage.vue
@@ -4,6 +4,7 @@
       <div class="container">
         <breadcrumbs
           :with-homepage="true"
+          :routes="[]"
           :active-route="this.$t('Order confirmation')"
         />
         <h2 class="category-title">

--- a/src/themes/default/pages/Compare.vue
+++ b/src/themes/default/pages/Compare.vue
@@ -2,7 +2,7 @@
   <div class="compare">
     <div class="bg-cl-secondary py35 pl20">
       <div class="container">
-        <breadcrumbs :with-homepage="true" active-route="Compare" />
+        <breadcrumbs :with-homepage="true" :routes="[]" active-route="Compare" />
         <h2>{{ title }}</h2>
       </div>
     </div>

--- a/src/themes/default/pages/MyAccount.vue
+++ b/src/themes/default/pages/MyAccount.vue
@@ -4,6 +4,7 @@
       <div class="container">
         <breadcrumbs
           :with-homepage="true"
+          :routes="[]"
           active-route="My Account"
         />
         <h1>

--- a/src/themes/default/pages/Static.vue
+++ b/src/themes/default/pages/Static.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="bg-cl-secondary py35 pl20">
       <div class="container">
-        <breadcrumbs :with-homepage="true" :active-route="$props.title" />
+        <breadcrumbs :with-homepage="true" :routes="[]" :active-route="$props.title" />
         <h2 class="fs-big">
           {{ $props.title }}
         </h2>


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Fixes multiple Breadcrumb issues that are new in v1.11

1. Issues with the Breadcrumb Category filters: there are cases when categories have already been loaded and saved to the category map, but do not match with the breadcrumb filters. In these cases we need to run the category search query without using the category map.

A specific example is Magento's "Default Category". Often every product belongs to this category, but it may not be wanted in the breadcrumbs. It can be excluded by turning off "Include in menu" and adding `"breadcrumbFilterFields": { "include_in_menu": true }` to the config. This fix is required for this behavior to work correctly.

2. Breadcrumbs on non-catalog pages: The "routes" prop on the Breadcrumbs component had been removed from pages like Compare and My Account, as they only need the new "with-homepage" prop and the existing "active-route" prop. But without the "routes" prop, the catalog breadcrumbs can appear where they shouldn't, so the "routes" prop needs to be restored.

### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

