### PR TITLE
Set `null` as default value for custom option in product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change translation from jp-JP to ja-JP - @gibkigonzo (#3824)
 - Fixed ecosystem config for pm2 - @andrzejewsky (#3842)
 - Fixed `mappingFallback` for extending modules -  @andrzejewsky (#3822)
+- Set `null` as default value for custom option in product page -  @gibkigonzo (#3885)
 
 ### Changed / Improved
 - Changed pre commit hook to use NODE_ENV production to check for debugger statements - @resubaka (#3686)

--- a/core/modules/catalog/helpers/customOption.ts
+++ b/core/modules/catalog/helpers/customOption.ts
@@ -27,18 +27,19 @@ export const selectedCustomOptionValue = (optionType: string, optionValues: Opti
     case 'select':
     case 'drop_down': {
       const selectedValue = optionValues.find((value) => value.option_type_id === inputValue as number)
+      const optionTypeId = selectedValue && selectedValue.option_type_id
 
-      return String(selectedValue && selectedValue.option_type_id) || ''
+      return optionTypeId ? String(optionTypeId) : null
     }
     case 'checkbox': {
       const checkboxOptionValues = inputValue as number[] || []
 
       return optionValues.filter((value) => checkboxOptionValues.includes(value.option_type_id))
         .map((value) => value.option_type_id)
-        .join(',')
+        .join(',') || null
     }
     default: {
-      return ''
+      return null
     }
   }
 }


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #3885

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
If custom option is not required then we should send `null` instead of empty string to pass magento validation.

QA: I've added non-required custom option to `Wayfarer Messenger Bag - custom options` in vsf demo magento


### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

