### PR TITLE
Save shipping to cache storage when property updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add to cart from Wishlist and Product listing for simple products - @Dnd-Dboy, @dz3n (#2637)
 - Add global Category and Breadcrumb filters, defined in local.json - @grimasod (#3691)
 - Add constant which conditions the number of products loading per page - @AdKamil (#3630)
-- Added price filtering key as config - @roywcm 
+- Added price filtering key as config - @roywcm
 
 ### Fixed
 - Always close zoom overlay after changing product - @psmyrek (#3818)
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed pre commit hook to use NODE_ENV production to check for debugger statements - @resubaka (#3686)
 - Improve the readability of 'getShippingDetails()' and 'updateDetails()' method of UserShippingDetails component - @adityasharma7 (#3770)
 - Keep git after yarn install in dockerfile - @ddanier (#3826)
+- Update the Storage Manager shipping details cache immediately when then Vuex checkout store is updated - @grimasod (#3894)
 
 ## [1.11.0-rc.2] - 2019.10.31
 

--- a/core/modules/checkout/index.ts
+++ b/core/modules/checkout/index.ts
@@ -24,7 +24,7 @@ export const CheckoutModule: StorefrontModule = function ({store}) {
     }
 
     if (
-      type.endsWith(types.CHECKOUT_SAVE_SHIPPING_DETAILS)
+      type.endsWith(types.CHECKOUT_SAVE_SHIPPING_DETAILS) || type.endsWith(types.CHECKOUT_UPDATE_PROP_VALUE)
     ) {
       StorageManager.get('checkout').setItem('shipping-details', state.checkout.shippingDetails).catch((reason) => {
         console.error(reason) // it doesn't work on SSR


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

The Storage Manager needs to subscribe to the `CHECKOUT_UPDATE_PROP_VALUE` mutation as well as the `CHECKOUT_SAVE_SHIPPING_DETAILS` mutation.

Currently, shipping details can become out of synch between the Vuex Checkout store and the Storage Manager cache. When a user completes the Personal Details section and when they select the shipping country, those items are saved to the Vuex store. But those updates are only saved to the cache when the Shipping section is completed.

This PR update the Storage Manager shipping cache when Vuex store is updated. 

### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

