### PR TITLE
Use config setting for common cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `defaultSortBy` for sorting category products by default @haelbichalex (#3873)
 - Fixed some potential mutations of Config object in `catalog` and `catalog-next` - @grimasod (#3843)
 - Set `null` as default value for custom option in product page -  @gibkigonzo (#3885)
+- Fixed `config.storeViews.commonCache` being ignored - @grimasod (#3895)
 
 ### Changed / Improved
 - Changed pre commit hook to use NODE_ENV production to check for debugger statements - @resubaka (#3686)

--- a/core/lib/storage-manager.ts
+++ b/core/lib/storage-manager.ts
@@ -27,7 +27,7 @@ const StorageManager = {
    * @param isLocalized if set to `false` data will be shared between storeViews (default `true`)
    * @param storageQuota max size of storage, 0 if unlimited (default `0`)
    */
-  init: function (collectionName: string, isLocalized = true, storageQuota = 0) {
+  init: function (collectionName: string, isLocalized = !config.storeViews.commonCache, storageQuota = 0) {
     this.storageMap[collectionName] = _prepareCacheStorage(collectionName, isLocalized, storageQuota)
     return this.storageMap[collectionName]
   },


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

The setting `config.storeViews.commonCache` was being ignored, because the `StorageManager.init` function had a default value set to true on the `isLocalized` parameter. This makes it impossible to have a shared cache (without overriding every core module)

This PR changes the default value of the `isLocalized` parameter to the config setting 

### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

