### PR TITLE
fixes #3870 'static/ in .gitignore release/1.11'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ core/resource/i18n/ru-RU.json
 
 #unit testing
 /test/unit/coverage
-static/
+/static


### PR DESCRIPTION
### Related issues
#3870 

### Short description and why it's useful
Changed `static/` to `/static` in /.gitignore so to limit the scope to the '/static' root folder that is created upon running 'generate' package.json task.
Previously `static/` matched any folder in the worktree named `static` 

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

