### PR TITLE
keep category products on ssr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Breadcrumb filters - apply to second category fetch  - @grimasod (#3887)
 - Fixed `config.storeViews.commonCache` being ignored - @grimasod (#3895)
 - Fixed static pages, password notification, offline mode #3902 - @andrzejewsky (#3902)
+- Keep category products objects on ssr - @gibkigonzo (#3924)
 
 ### Changed / Improved
 - Changed pre commit hook to use NODE_ENV production to check for debugger statements - @resubaka (#3686)

--- a/core/modules/catalog-next/store/category/getters.ts
+++ b/core/modules/catalog-next/store/category/getters.ts
@@ -16,10 +16,13 @@ import { _prepareCategoryPathIds, getSearchOptionsFromRouteParams } from '../../
 import { removeStoreCodeFromRoute } from '@vue-storefront/core/lib/multistore'
 import cloneDeep from 'lodash-es/cloneDeep'
 
-function mapCategoryProducts (productsSkus, productsData) {
-  return productsSkus.map(prodSku => {
-    const product = productsData.find(prodData => prodData.sku === prodSku)
-    return cloneDeep(product)
+function mapCategoryProducts (productsFromState, productsData) {
+  return productsFromState.map(prodState => {
+    if (typeof prodState === 'string') {
+      const product = productsData.find(prodData => prodData.sku === prodState)
+      return cloneDeep(product)
+    }
+    return prodState
   })
 }
 

--- a/core/modules/catalog-next/store/category/mutations.ts
+++ b/core/modules/catalog-next/store/category/mutations.ts
@@ -1,3 +1,4 @@
+import { isServer } from '@vue-storefront/core/helpers';
 import { nonReactiveState } from './index';
 import Vue from 'vue'
 import { MutationTree } from 'vuex'
@@ -9,11 +10,11 @@ import cloneDeep from 'lodash-es/cloneDeep'
 const mutations: MutationTree<CategoryState> = {
   [types.CATEGORY_SET_PRODUCTS] (state, products = []) {
     nonReactiveState.products = cloneDeep(products)
-    state.products = products.map(prod => prod.sku)
+    state.products = isServer ? products : products.map(prod => prod.sku)
   },
   [types.CATEGORY_ADD_PRODUCTS] (state, products = []) {
     nonReactiveState.products.push(...cloneDeep(products))
-    state.products.push(...products.map(prod => prod.sku))
+    state.products.push(...(isServer ? products : products.map(prod => prod.sku)))
   },
   [types.CATEGORY_ADD_CATEGORY] (state, category: Category) {
     if (category) {


### PR DESCRIPTION
### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
In SSR we need to keep products as objects because state is moved to CSR (not nonReactiveState). Right now it works in 1.11 because we fetch products for cache and there is lazy-hydration, but it can be a bug in future. I add it in 1.10.5 but forgot 1.11.


### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

