### PR TITLE
product breadcrumbs - check if current category is not highest one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed error page display with enabled multistore - @gibkigonzo (#3890)
 - Fixed edit shipping address in my account - @gibkigonzo (#3921)
 - Fetch cms_block content in serverPrefetch method - @gibkigonzo (#3910)
+- product breadcrumbs - check if current category is not highest one - @gibkigonzo (#3933)
 
 ### Changed / Improved
 - Changed pre commit hook to use NODE_ENV production to check for debugger statements - @resubaka (#3686)

--- a/core/modules/catalog-next/store/category/actions.ts
+++ b/core/modules/catalog-next/store/category/actions.ts
@@ -130,7 +130,7 @@ const actions: ActionTree<CategoryState, RootState> = {
   },
   async loadCategories ({ commit, getters }, categorySearchOptions: DataResolver.CategorySearchOptions): Promise<Category[]> {
     const searchingByIds = !(!categorySearchOptions || !categorySearchOptions.filters || !categorySearchOptions.filters.id)
-    const searchedIds: string[] = searchingByIds ? ([...categorySearchOptions.filters.id] as string[]) : []
+    const searchedIds: string[] = searchingByIds ? [...categorySearchOptions.filters.id].map(String) : []
     const loadedCategories: Category[] = []
     if (searchingByIds && !categorySearchOptions.reloadAll) { // removing from search query already loaded categories, they are added to returned results
       for (const [categoryId, category] of Object.entries(getters.getCategoriesMap)) {

--- a/core/modules/catalog/store/product/actions.ts
+++ b/core/modules/catalog/store/product/actions.ts
@@ -687,7 +687,11 @@ const actions: ActionTree<ProductState, RootState> = {
       let breadcrumbCategory
       const categoryFilters = Object.assign({ 'id': [...product.category_ids] }, cloneDeep(config.entities.category.breadcrumbFilterFields))
       const categories = await dispatch('category-next/loadCategories', { filters: categoryFilters, reloadAll: Object.keys(config.entities.category.breadcrumbFilterFields).length > 0 }, { root: true })
-      if (currentCategory && currentCategory.id && (categories.findIndex(category => category.id === currentCategory.id) >= 0)) {
+      if (
+        (currentCategory && currentCategory.id) && // current category exist
+        (config.entities.category.categoriesRootCategorylId !== currentCategory.id) && // is not highest category (All) - if we open product from different page then category page
+        (categories.findIndex(category => category.id === currentCategory.id) >= 0) // can be found in fetched categories
+      ) {
         breadcrumbCategory = currentCategory // use current category if set and included in the filtered list
       } else {
         breadcrumbCategory = categories.sort((a, b) => (a.level > b.level) ? -1 : 1)[0] // sort starting by deepest level


### PR DESCRIPTION
### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Fixes error with breadrucmbs when opens product from compare page.

QA:
- add something to the compare from the homepage (from women category)
- go to mens / jackets cat.
- open compare and click the product you added
- again go to mens / jackets cat.
- open compare and click the product you added
- check the breadcrumbs - it's wrong


### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

