### PR TITLE
add helper that removes non default addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - check max quantity in microcart - @gibkigonzo (#3314)
 - Add unit tests for `core/modules/newsletter` - @psmyrek (#3464)
 - Add unit test for `core/modules/wishlist` - @psmyrek (#3471)
+- Add helper that removes non default addresses - @gibkigonzo (#3921)
 
 ### Changed / Improved
 - Use `encodeURIComponent` to encode get parameters in `multimatch.js` - @adityasharma7 (#3736)

--- a/core/modules/user/components/UserAccount.ts
+++ b/core/modules/user/components/UserAccount.ts
@@ -1,4 +1,5 @@
 import toString from 'lodash-es/toString'
+import { removeNonDefaultAddress } from '../helpers'
 const Countries = require('@vue-storefront/core/i18n/resource/countries.json')
 
 export const UserAccount = {
@@ -148,6 +149,7 @@ export const UserAccount = {
           newPassword: this.password
         })
       }
+      removeNonDefaultAddress(updatedProfile)
       this.exitSection(null, updatedProfile)
     },
     exitSection (event, updatedProfile) {

--- a/core/modules/user/components/UserShippingDetails.ts
+++ b/core/modules/user/components/UserShippingDetails.ts
@@ -1,4 +1,5 @@
 import toString from 'lodash-es/toString'
+import { removeNonDefaultAddress } from '../helpers'
 const Countries = require('@vue-storefront/i18n/resource/countries.json')
 
 export const UserShippingDetails = {
@@ -109,6 +110,7 @@ export const UserShippingDetails = {
           })
         }
       }
+      removeNonDefaultAddress(updatedShippingDetails)
       this.exitSection(null, updatedShippingDetails)
     },
     exitSection (event, updatedShippingDetails) {

--- a/core/modules/user/helpers/index.ts
+++ b/core/modules/user/helpers/index.ts
@@ -1,0 +1,5 @@
+import removeNonDefaultAddress from './removeNonDefaultAddress'
+
+export {
+  removeNonDefaultAddress
+}

--- a/core/modules/user/helpers/removeNonDefaultAddress.ts
+++ b/core/modules/user/helpers/removeNonDefaultAddress.ts
@@ -1,0 +1,9 @@
+/**
+ * we can have only two addresses: 'shipping' or 'billing'
+ */
+const removeNonDefaultAddress = (updatedProfile) => {
+  if (!(updatedProfile && updatedProfile.addresses)) return
+  updatedProfile.addresses = updatedProfile.addresses.filter((address) => address.default_shipping || address.default_billing)
+}
+
+export default removeNonDefaultAddress


### PR DESCRIPTION
### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
We can have maximum two addresses. One billing and one shipping. So if someone creates account, add shipping address (`default_shipping`) and tried to edit it before this fix https://github.com/DivanteLtd/vue-storefront/pull/3921 then he can't add company address which is billing address ( `default_billing`). So this change ensure that we don't have any address that is neither billing or shipping address. (which is invalid one, that could be added before PR: 3921).

This is error which we get if there are already two addresses (one shipping and one without any flag).
```
{"code":500,"result":[{"keyword":"maxItems","dataPath":".customer.addresses","schemaPath":"#/properties/customer/properties/addresses/maxItems","params":{"limit":2},"message":"should NOT have more than 2 items"}]}
```

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

