### PR TITLE
3957: Fix manage_stock: false in product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed Search product fails for category filter when categoryId is string - @adityasharma7 (#3929)
+- Fixed Manage Stock false prevents adding items to cart - @eerohakio (#3957)
 
 ### Changed / Improved
 - Optimized `translation.processor` to process only enabled locale CSV files - @pkarw (#3950)

--- a/core/modules/catalog/store/stock/actions.ts
+++ b/core/modules/catalog/store/stock/actions.ts
@@ -12,7 +12,7 @@ const actions: ActionTree<StockState, RootState> = {
     const checkStatus = {
       qty: product.stock ? product.stock.qty : 0,
       status: getStatus(product, 'ok'),
-      manage_stock: product.stock ? product.stock.manage_stock: true
+      manageStock: product.stock ? product.stock.manage_stock: true
     }
 
     if (config.stock.synchronize) {
@@ -39,14 +39,14 @@ const actions: ActionTree<StockState, RootState> = {
         qty: result ? result.qty : 0,
         status: getStatus(result, 'ok'),
         onlineCheckTaskId: task_id,
-        manage_stock: result ? result.manage_stock : true,
+        manageStock: result ? result.manage_stock : true,
       }
     }
 
     return {
       qty: product.stock ? product.stock.qty : 0,
       status: getStatus(product, 'volatile'),
-      manage_stock: product.stock ? product.stock.manage_stock : true
+      manageStock: product.stock ? product.stock.manage_stock : true
     }
   },
   async list ({ commit }, { skus }) {

--- a/core/modules/catalog/store/stock/actions.ts
+++ b/core/modules/catalog/store/stock/actions.ts
@@ -11,7 +11,8 @@ const actions: ActionTree<StockState, RootState> = {
   async queueCheck ({ dispatch }, { product }) {
     const checkStatus = {
       qty: product.stock ? product.stock.qty : 0,
-      status: getStatus(product, 'ok')
+      status: getStatus(product, 'ok'),
+      manage_stock: product.stock ? product.stock.manage_stock: true
     }
 
     if (config.stock.synchronize) {
@@ -37,13 +38,15 @@ const actions: ActionTree<StockState, RootState> = {
       return {
         qty: result ? result.qty : 0,
         status: getStatus(result, 'ok'),
-        onlineCheckTaskId: task_id
+        onlineCheckTaskId: task_id,
+        manage_stock: result ? result.manage_stock : true,
       }
     }
 
     return {
       qty: product.stock ? product.stock.qty : 0,
-      status: getStatus(product, 'volatile')
+      status: getStatus(product, 'volatile'),
+      manage_stock: product.stock ? product.stock.manage_stock : true
     }
   },
   async list ({ commit }, { skus }) {

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -423,7 +423,7 @@ export default {
           qty: this.getCurrentProduct.qty
         })
         this.maxQuantity = res.qty
-        this.manageStock = res.manage_stock
+        this.manageStock = res.manageStock
       } finally {
         this.isStockInfoLoading = false
       }

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -130,7 +130,7 @@
               class="row m0 mb35"
               v-if="getCurrentProduct.type_id !== 'grouped' && getCurrentProduct.type_id !== 'bundle'"
               v-model="getCurrentProduct.qty"
-              :max-quantity="maxQuantity"
+              :max-quantity="availableQuantity"
               :loading="isStockInfoLoading"
               :is-simple-or-configurable="isSimpleOrConfigurable"
               :show-quantity="showProductQuantity"
@@ -335,13 +335,19 @@ export default {
         this.isStockInfoLoading ||
         (
           this.isOnline &&
-          (!this.maxQuantity && this.manageStock ) &&
+          !this.hasAvailableQuantity &&
           this.isSimpleOrConfigurable
         )
     },
+    availableQuantity () {
+      return this.manageStock ? this.maxQuantity : 999;
+    },
+    hasAvailableQuantity () {
+      return this.availableQuantity > 0
+    },
     showProductQuantity () {
       return this.manageStock
-    }
+    },
   },
   async mounted () {
     await this.$store.dispatch('recently-viewed/addItem', this.getCurrentProduct)

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -133,7 +133,7 @@
               :max-quantity="maxQuantity"
               :loading="isStockInfoLoading"
               :is-simple-or-configurable="isSimpleOrConfigurable"
-              show-quantity
+              :show-quantity="showProductQuantity"
               @error="handleQuantityError"
             />
             <div class="row m0">
@@ -272,7 +272,8 @@ export default {
       maxQuantity: 0,
       quantityError: false,
       isStockInfoLoading: false,
-      hasAttributesLoaded: false
+      hasAttributesLoaded: false,
+      manageStock: true
     }
   },
   computed: {
@@ -332,7 +333,14 @@ export default {
     isAddToCartDisabled () {
       return this.quantityError ||
         this.isStockInfoLoading ||
-        (this.isOnline && !this.maxQuantity && this.isSimpleOrConfigurable)
+        (
+          this.isOnline &&
+          (!this.maxQuantity && this.manageStock ) &&
+          this.isSimpleOrConfigurable
+        )
+    },
+    showProductQuantity () {
+      return this.manageStock
     }
   },
   async mounted () {
@@ -409,6 +417,7 @@ export default {
           qty: this.getCurrentProduct.qty
         })
         this.maxQuantity = res.qty
+        this.manageStock = res.manage_stock
       } finally {
         this.isStockInfoLoading = false
       }


### PR DESCRIPTION
* Add extra check to validate manage_stock value from product
* Add computed property for show-quantity to reflect manage stock value
* Set manage stock default as true(this is 99% of the cases)
* Set product-quantity input max value to 999 if manage_stock is set to false
* Modify store actions to have manage_stock attribute

### Related Issues
https://github.com/DivanteLtd/vue-storefront/issues/3957

### Short Description and Why It's Useful
Fixes issue when manage_stock is set to false and product cannot be added to cart due addToCart button is disabled, also changes visibility of availability data in product page not to show quantity amount for items that doesn't have stock managed

### Which Environment This Relates To
- [X] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)