### PR TITLE
Add `or` operator for Elasticsearch filters and use exists if value is `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Separating endpoints for CSR/SSR - @Fifciu (#2861)
 - Added short hands for version and help flags - @jamesgeorge007 (#3946)
-- Add `or` operator for Elasticsearch filters in `quickSearchByQuery` and use exists if value is `null` - @cewald #3834
+- Add `or` operator for Elasticsearch filters in `quickSearchByQuery` and use exists if value is `null` - @cewald (#3960)
 
 ### Fixed
 - Fixed Search product fails for category filter when categoryId is string - @adityasharma7 (#3929)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Separating endpoints for CSR/SSR - @Fifciu (#2861)
 - Added short hands for version and help flags - @jamesgeorge007 (#3946)
+- Add `or` operator for Elasticsearch filters in `quickSearchByQuery` and use exists if value is `null` - @cewald #3834
 
 ### Fixed
 - Fixed Search product fails for category filter when categoryId is string - @adityasharma7 (#3929)

--- a/core/lib/search/adapter/api/elasticsearchQuery.js
+++ b/core/lib/search/adapter/api/elasticsearchQuery.js
@@ -25,11 +25,26 @@ export async function prepareElasticsearchQueryBody (searchQuery) {
           query = query.filter('range', filter.attribute, filter.value)
         } else {
           // process terms filters
+          const operator = Object.keys(filter.value)[0]
           filter.value = filter.value[Object.keys(filter.value)[0]]
-          if (!Array.isArray(filter.value)) {
+          if (!Array.isArray(filter.value) && filter.value !== null) {
             filter.value = [filter.value]
           }
-          query = query.filter('terms', getMapping(filter.attribute), filter.value)
+          if (operator === 'or') {
+            if (filter.value === null) {
+              query = query.orFilter('bool', (b) => {
+                return b.notFilter('exists', getMapping(filter.attribute))
+              })
+            } else {
+              query = query.orFilter('terms', getMapping(filter.attribute), filter.value)
+            }
+          } else {
+            if (filter.value === null) {
+              query = query.filter('exists', getMapping(filter.attribute))
+            } else {
+              query = query.filter('terms', getMapping(filter.attribute), filter.value)
+            }
+          }
         }
       } else if (filter.scope === 'catalog') {
         hasCatalogFilters = true
@@ -46,7 +61,7 @@ export async function prepareElasticsearchQueryBody (searchQuery) {
             let rangeAttribute = catalogfilter.attribute
             // filter by product fiunal price
             if (rangeAttribute === 'price') {
-              rangeAttribute = config.products.priceFilterKey
+              rangeAttribute = 'final_price'
             }
             // process range filters
             filterQr = filterQr.andFilter('range', rangeAttribute, catalogfilter.value)


### PR DESCRIPTION
# Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

I needed a possibility to simply add an `or`/`should` filter to the `quickSearchByQuery` method.
This wasn't possible yet, so I extended the `prepareElasticsearchQueryBody` method of the ElasticSearch search-adapter to accept an `or` operator in the value property.
I also added an ES `exists` filter if the value is `null` if you just wan't the field to be `null`.

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

I had to make a product query where I wanted a collection of products with a specific value or an empty one. This wasn't possible yet because all filters are chained as 'AND' filters.

Now you can make query like this (`or` in the last two lines) to show all products with `custom_attribute` is `2` or `3` or `custom_attribute` is just empty (`null`):
```js
let query = new SearchQuery()
query
  .applyFilter({ key: 'visibility', value: { in: [2, 3, 4] } })
  .applyFilter({ key: 'status', value: { in: [0, 1] } })
  .applyFilter({ key: 'category_ids', value: { in: [categoryId] } })
  .applyFilter({ key: 'custom_attribute', value: { or: null } })
  .applyFilter({ key: 'custom_attribute', value: { or: [2, 3] } })
```

In our use-case the products have clusters, so I wan't to show products to the customer which have his current cluster OR if there are not enough of them just regular products without a cluster.

With this changes I can make queries like this to the ES while I still can use all the advantages of `quickSearchByQuery`:
```
{
  "filter": {
    "bool": {
      "should": [
        {
          "terms": {
            "custom_attribute": [2, 3]
          }
        },
        {
          "bool": {
            "must_not": [
              {
                "exists": {
                  "field": "custom_attribute"
                }
              }
            ]
          }
        }
      ]
    }
  }
}
```

If you think it isn't an essential functionallity, just ignore and close this PR.
But I thought this might come in handy.

### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

