### PR TITLE
Bugfix/attribute filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CookieNotification CSR&SSR mismatch fixed - @Fifciu (#3922)
 - The attribute filter in `attribute/list` was not filtering the already loaded attributes properly - @pkarw (#3964)
 
-## [1.11.0] - 20.12.2019
+## [1.11.0] - 2019.12.20
 
 ### Added
 - Add unit tests for `core/modules/url` - @dz3n (#3469)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - CookieNotification CSR&SSR mismatch fixed - @Fifciu (#3922)
+- The attribute filter in `attribute/list` was not filtering the already loaded attributes properly - @pkarw (#3964)
 
-
-## [1.11.0] - 2019.12.20
+## [1.11.0] - 20.12.2019
 
 ### Added
 - Add unit tests for `core/modules/url` - @dz3n (#3469)

--- a/core/modules/catalog/helpers/filterAttributes.ts
+++ b/core/modules/catalog/helpers/filterAttributes.ts
@@ -1,6 +1,6 @@
 import config from 'config'
 
-const areAttributesAlreadyLoaded = ({
+export default function filterAttributes ({
   filterValues,
   filterField,
   blacklist,
@@ -12,27 +12,22 @@ const areAttributesAlreadyLoaded = ({
   blacklist: string[],
   idsList: any,
   codesList: any
-}): boolean => {
+}) {
   return filterValues.filter(fv => {
     if (config.entities.product.standardSystemFields.indexOf(fv) >= 0) {
       return false
     }
-
     if (fv.indexOf('.') >= 0) {
       return false
     }
-
     if (blacklist !== null && blacklist.includes(fv)) {
       return false
     }
-
     if (filterField === 'attribute_id') {
       return (typeof idsList[fv] === 'undefined' || idsList[fv] === null)
     }
     if (filterField === 'attribute_code') {
       return (typeof codesList[fv] === 'undefined' || codesList[fv] === null)
     }
-  }).length === 0
+  })
 }
-
-export default areAttributesAlreadyLoaded

--- a/core/modules/catalog/store/attribute/actions.ts
+++ b/core/modules/catalog/store/attribute/actions.ts
@@ -8,9 +8,9 @@ import config from 'config'
 import { Logger } from '@vue-storefront/core/lib/logger'
 import { entityKeyName } from '@vue-storefront/core/lib/store/entities'
 import { prefetchCachedAttributes } from '../../helpers/prefetchCachedAttributes'
-import areAttributesAlreadyLoaded from './../../helpers/areAttributesAlreadyLoaded'
 import createAttributesListQuery from './../../helpers/createAttributesListQuery'
 import reduceAttributesLists from './../../helpers/reduceAttributesLists'
+import filterAttributes from '../../helpers/filterAttributes'
 
 const actions: ActionTree<AttributeState, RootState> = {
   async updateAttributes ({ commit, getters }, { attributes }) {
@@ -63,7 +63,8 @@ const actions: ActionTree<AttributeState, RootState> = {
 
     await dispatch('loadCachedAttributes', { filterField, filterValues })
 
-    if (areAttributesAlreadyLoaded({ filterValues, filterField, blacklist, idsList, codesList })) {
+    filterValues = filterAttributes({ filterValues, filterField, blacklist, idsList, codesList })
+    if (filterValues.length === 0) {
       Logger.info('Skipping attribute load - attributes already loaded', 'attr', { orgFilterValues, filterField })()
       return { items: Object.values(codesList) }
     }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

After the refactoring - the attributes filter wasn't filtering the attributes properly: which resulted in the additional network call each time the product query was about to execute.

Actually - it was rather querying ElasticSearch for the nonfiltered attributes like `configurable_children.price`. The filter is removing the multipart attributes (that never existed in elastic search). 

So maybe it's not generating the additional network call but in the end, it's querying Elastic for the attributes that should be switched off (the next time they're not used for a query as they're added to the blacklist I guess)

 
