### PR TITLE
bugfix - revert init filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed Search product fails for category filter when categoryId is string - @adityasharma7 (#3929)
+- Revert init filters in Vue app - @gibkigonzo (#3929)
 
 ### Changed / Improved
 - Optimized `translation.processor` to process only enabled locale CSV files - @pkarw (#3950)

--- a/core/app.ts
+++ b/core/app.ts
@@ -71,10 +71,10 @@ const createApp = async (ssrContext, config, storeCode = null): Promise<{app: Vu
     Object.keys(coreMixins).forEach(key => {
       Vue.mixin(coreMixins[key])
     })
+  })
 
-    Object.keys(coreFilters).forEach(key => {
-      Vue.filter(key, coreFilters[key])
-    })
+  Object.keys(coreFilters).forEach(key => {
+    Vue.filter(key, coreFilters[key])
   })
 
   // @todo remove this part when we'll get rid of global multistore mixin

--- a/core/app.ts
+++ b/core/app.ts
@@ -71,21 +71,11 @@ const createApp = async (ssrContext, config, storeCode = null): Promise<{app: Vu
     Object.keys(coreMixins).forEach(key => {
       Vue.mixin(coreMixins[key])
     })
-  })
 
-  Object.keys(coreFilters).forEach(key => {
-    Vue.filter(key, coreFilters[key])
-  })
-
-  // @todo remove this part when we'll get rid of global multistore mixin
-  if (isServer) {
-    Object.defineProperty(ssrContext, 'helpers', {
-      value: {
-        currentStoreView
-      },
-      writable: true
+    Object.keys(coreFilters).forEach(key => {
+      Vue.filter(key, coreFilters[key])
     })
-  }
+  })
 
   let vueOptions = {
     router: routerProxy,

--- a/core/filters/date.js
+++ b/core/filters/date.js
@@ -12,9 +12,10 @@ once('__VUE_EXTEND_DAYJS_LOCALIZED_FORMAT__', () => {
  * @param {String} date
  * @param {String} format
  */
-export function date (date, format) {
-  const displayFormat = format || currentStoreView().i18n.dateFormat
-  let storeLocale = currentStoreView().i18n.defaultLocale.toLocaleLowerCase()
+export function date (date, format, storeView) {
+  const _storeView = storeView || currentStoreView()
+  const displayFormat = format || _storeView.i18n.dateFormat
+  let storeLocale = _storeView.i18n.defaultLocale.toLocaleLowerCase()
   const separatorIndex = storeLocale.indexOf('-')
   const languageCode = (separatorIndex > -1) ? storeLocale.substr(0, separatorIndex) : storeLocale
 

--- a/core/filters/price.js
+++ b/core/filters/price.js
@@ -13,15 +13,15 @@ const applyCurrencySign = (formattedPrice, { currencySign, priceFormat }) => {
  * Converts number to price string
  * @param {Number} value
  */
-export function price (value) {
+export function price (value, storeView) {
   if (isNaN(value)) {
     return value;
   }
-  const storeView = currentStoreView();
-  if (!storeView.i18n) {
+  const _storeView = storeView || currentStoreView();
+  if (!_storeView.i18n) {
     return value;
   }
-  const { defaultLocale, currencySign, priceFormat } = storeView.i18n
+  const { defaultLocale, currencySign, priceFormat } = _storeView.i18n
 
   const formattedValue = formatValue(value, defaultLocale);
   const valueWithSign = applyCurrencySign(formattedValue, { currencySign, priceFormat })

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -11,6 +11,9 @@ import { coreHooksExecutors } from '@vue-storefront/core/hooks'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import { LocalizedRoute, StoreView } from './types'
 import storeCodeFromRoute from './storeCodeFromRoute'
+import cloneDeep from 'lodash-es/cloneDeep'
+import get from 'lodash-es/get'
+import { isServer } from '@vue-storefront/core/helpers'
 
 function getExtendedStoreviewConfig (storeView: StoreView): StoreView {
   if (storeView.extend) {
@@ -30,21 +33,28 @@ function getExtendedStoreviewConfig (storeView: StoreView): StoreView {
   return storeView
 }
 
+/**
+ * Returns base storeView object that can be created without storeCode
+ */
+function buildBaseStoreView (): StoreView {
+  return cloneDeep({
+    tax: config.tax,
+    i18n: config.i18n,
+    elasticsearch: config.elasticsearch,
+    storeCode: null,
+    storeId: config.defaultStoreCode && config.defaultStoreCode !== '' ? config.storeViews[config.defaultStoreCode].storeId : 1,
+    seo: config.seo
+  })
+}
+
 export function currentStoreView (): StoreView {
-  // TODO: Change to getter all along our code
-  return rootStore.state.storeView
+  const serverStoreView = get(global, 'process.storeView', undefined)
+  const clientStoreView = get(rootStore, 'state.storeView', undefined)
+  return (isServer ? serverStoreView : clientStoreView) || buildBaseStoreView()
 }
 
 export async function prepareStoreView (storeCode: string): Promise<StoreView> {
-  let storeView: StoreView = { // current, default store
-    tax: Object.assign({}, config.tax),
-    i18n: Object.assign({}, config.i18n),
-    elasticsearch: Object.assign({}, config.elasticsearch),
-    storeCode: null,
-    storeId: config.defaultStoreCode && config.defaultStoreCode !== '' ? config.storeViews[config.defaultStoreCode].storeId : 1,
-    seo: Object.assign({}, config.seo)
-  }
-
+  let storeView: StoreView = buildBaseStoreView() // current, default store
   if (config.storeViews.multistore === true) {
     storeView.storeCode = storeCode || config.defaultStoreCode || ''
   } else {
@@ -61,12 +71,18 @@ export async function prepareStoreView (storeCode: string): Promise<StoreView> {
   if (storeViewHasChanged) {
     storeView = coreHooksExecutors.beforeStoreViewChanged(storeView)
     rootStore.state.storeView = storeView
+
+    if (global && isServer) {
+      (global.process as any).storeView = storeView
+    }
+
     await loadLanguageAsync(storeView.i18n.defaultLocale)
   }
   if (storeViewHasChanged || StorageManager.currentStoreCode !== storeCode) {
     initializeSyncTaskStorage()
     StorageManager.currentStoreCode = storeView.storeCode
   }
+
   coreHooksExecutors.afterStoreViewChanged(storeView)
 
   return storeView

--- a/core/mixins/multistore.js
+++ b/core/mixins/multistore.js
@@ -10,13 +10,7 @@ export const multistore = {
      * @param {Int} height
      */
     localizedRoute (routeObj) {
-      let storeView
-
-      if (isServer) {
-        storeView = this.$ssrContext.helpers.currentStoreView()
-      } else {
-        storeView = currentStoreView()
-      }
+      const storeView = currentStoreView()
 
       return localizedRouteHelper(routeObj, storeView.storeCode)
     },
@@ -27,13 +21,7 @@ export const multistore = {
      * @param {Int} height
      */
     localizedDispatcherRoute (routeObj) {
-      let storeView
-
-      if (isServer) {
-        storeView = this.$ssrContext.helpers.currentStoreView()
-      } else {
-        storeView = currentStoreView()
-      }
+      const storeView = currentStoreView()
 
       return localizedDispatcherRouteHelper(routeObj, storeView.storeCode)
     }

--- a/src/themes/default-amp/components/core/ProductTile.vue
+++ b/src/themes/default-amp/components/core/ProductTile.vue
@@ -28,21 +28,21 @@
         class="price-original mr5 lh30 cl-secondary"
         v-if="product.special_price && parseFloat(product.original_price_incl_tax) > 0 && !onlyImage"
       >
-        {{ product.original_price_incl_tax | price }}
+        {{ product.original_price_incl_tax | price(storeView) }}
       </span>
 
       <span
         class="price-special lh30 cl-accent weight-700"
         v-if="product.special_price && parseFloat(product.special_price) > 0 && !onlyImage"
       >
-        {{ product.price_incl_tax | price }}
+        {{ product.price_incl_tax | price(storeView) }}
       </span>
 
       <span
         class="lh30 cl-secondary"
         v-if="!product.special_price && parseFloat(product.price_incl_tax) > 0 && !onlyImage"
       >
-        {{ product.price_incl_tax | price }}
+        {{ product.price_incl_tax | price(storeView) }}
       </span>
     </router-link>
   </div>
@@ -52,6 +52,7 @@
 import rootStore from '@vue-storefront/core/store'
 import { ProductTile } from '@vue-storefront/core/modules/catalog/components/ProductTile.ts'
 import config from 'config'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 export default {
   mixins: [ProductTile],
@@ -63,6 +64,11 @@ export default {
     onlyImage: {
       type: Boolean,
       default: false
+    }
+  },
+  computed: {
+    storeView () {
+      return currentStoreView()
     }
   },
   methods: {

--- a/src/themes/default-amp/pages/Product.vue
+++ b/src/themes/default-amp/pages/Product.vue
@@ -44,17 +44,17 @@
                   v-if="product.special_price && product.price_incl_tax && product.original_price_incl_tax"
                 >
                   <span class="h2 cl-mine-shaft weight-700">
-                    {{ product.price_incl_tax * product.qty | price }}
+                    {{ product.price_incl_tax * product.qty | price(storeView) }}
                   </span>&nbsp;
                   <span class="price-original h3">
-                    {{ product.original_price_incl_tax * product.qty | price }}
+                    {{ product.original_price_incl_tax * product.qty | price(storeView) }}
                   </span>
                 </div>
                 <div
                   class="h2 cl-mine-shaft weight-700"
                   v-if="!product.special_price && product.price_incl_tax"
                 >
-                  {{ product.price_incl_tax * product.qty | price }}
+                  {{ product.price_incl_tax * product.qty | price(storeView) }}
                 </div>
               </div>
               <div
@@ -158,6 +158,9 @@ export default {
       product: 'product/getCurrentProduct',
       gallery: 'product/getProductGallery'
     }),
+    storeView () {
+      return currentStoreView()
+    },
     priceCurrency: () => currentStoreView().i18n.currencyCode
   },
   directives: { focusClean },

--- a/src/themes/default/components/core/ProductLinks.vue
+++ b/src/themes/default/components/core/ProductLinks.vue
@@ -8,11 +8,11 @@
           </p>
           <div class="col-xs-4 cl-bg-tertiary">
             <div v-if="productLink.product.special_price && productLink.product.price_incl_tax && productLink.product.original_price_incl_tax">
-              <span class="price-special">{{ productLink.product.price_incl_tax | price }}</span>&nbsp;
-              <span class="price-original">{{ productLink.product.original_price_incl_tax | price }}</span>
+              <span class="price-special">{{ productLink.product.price_incl_tax | price(storeView) }}</span>&nbsp;
+              <span class="price-original">{{ productLink.product.original_price_incl_tax | price(storeView) }}</span>
             </div>
             <div v-if="!productLink.product.special_price && productLink.product.price_incl_tax">
-              {{ productLink.product.price_incl_tax | price }}
+              {{ productLink.product.price_incl_tax | price(storeView) }}
             </div>
           </div>
         </div>
@@ -35,11 +35,17 @@
 </template>
 
 <script>
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 export default {
   props: {
     products: {
       type: Array,
       required: true
+    }
+  },
+  computed: {
+    storeView () {
+      return currentStoreView()
     }
   }
 }

--- a/src/themes/default/components/core/ProductTile.vue
+++ b/src/themes/default/components/core/ProductTile.vue
@@ -45,17 +45,17 @@
       <span
         class="price-original mr5 lh30 cl-secondary"
         v-if="product.special_price && parseFloat(product.original_price_incl_tax) > 0 && !onlyImage"
-      >{{ product.original_price_incl_tax | price }}</span>
+      >{{ product.original_price_incl_tax | price(storeView) }}</span>
 
       <span
         class="price-special lh30 cl-accent weight-700"
         v-if="product.special_price && parseFloat(product.special_price) > 0 && !onlyImage"
-      >{{ product.price_incl_tax | price }}</span>
+      >{{ product.price_incl_tax | price(storeView) }}</span>
 
       <span
         class="lh30 cl-secondary"
         v-if="!product.special_price && parseFloat(product.price_incl_tax) > 0 && !onlyImage"
-      >{{ product.price_incl_tax | price }}</span>
+      >{{ product.price_incl_tax | price(storeView) }}</span>
     </router-link>
   </div>
 </template>
@@ -69,6 +69,7 @@ import AddToWishlist from 'theme/components/core/blocks/Wishlist/AddToWishlist'
 import AddToCompare from 'theme/components/core/blocks/Compare/AddToCompare'
 import { IsOnWishlist } from '@vue-storefront/core/modules/wishlist/components/IsOnWishlist'
 import { IsOnCompare } from '@vue-storefront/core/modules/compare/components/IsOnCompare'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 export default {
   mixins: [ProductTile, IsOnWishlist, IsOnCompare],
@@ -96,6 +97,9 @@ export default {
     },
     favoriteIcon () {
       return this.isOnWishlist ? 'favorite' : 'favorite_border'
+    },
+    storeView () {
+      return currentStoreView()
     }
   },
   methods: {

--- a/src/themes/default/components/core/blocks/Checkout/CartSummary.vue
+++ b/src/themes/default/components/core/blocks/Checkout/CartSummary.vue
@@ -11,7 +11,7 @@
             {{ segment.title }}
           </div>
           <div v-if="segment.value != null" class="col-xs align-right cl-accent h4">
-            {{ segment.value | price }}
+            {{ segment.value | price(storeView) }}
           </div>
         </div>
 
@@ -20,7 +20,7 @@
             {{ segment.title }}
           </div>
           <div class="col-xs align-right">
-            {{ segment.value | price }}
+            {{ segment.value | price(storeView) }}
           </div>
         </div>
       </div>
@@ -54,10 +54,16 @@
 <script>
 import { CartSummary } from '@vue-storefront/core/modules/checkout/components/CartSummary'
 import Product from './Product'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 export default {
   components: {
     Product
+  },
+  computed: {
+    storeView () {
+      return currentStoreView()
+    }
   },
   mixins: [CartSummary]
 }

--- a/src/themes/default/components/core/blocks/Checkout/OrderConfirmation.vue
+++ b/src/themes/default/components/core/blocks/Checkout/OrderConfirmation.vue
@@ -34,13 +34,13 @@
                 </span>
               </td>
               <td class="fs-medium lh25" :data-th="$t('Price')">
-                {{ product.price_incl_tax | price }}
+                {{ product.price_incl_tax | price(storeView) }}
               </td>
               <td class="fs-medium lh25 align-right" :data-th="$t('Qty')">
                 {{ product.qty }}
               </td>
               <td class="fs-medium lh25" :data-th="$t('Subtotal')">
-                {{ product.price_incl_tax * product.qty | price }}
+                {{ product.price_incl_tax * product.qty | price(storeView) }}
               </td>
             </tr>
           </tbody>
@@ -65,6 +65,7 @@ import { ConfirmOrders } from '@vue-storefront/core/modules/offline-order/compon
 import { CancelOrders } from '@vue-storefront/core/modules/offline-order/components/CancelOrders'
 import Modal from 'theme/components/core/Modal'
 import ButtonFull from 'theme/components/theme/ButtonFull.vue'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 export default {
   props: {
@@ -78,6 +79,11 @@ export default {
     this.$nextTick(() => {
       this.$bus.$emit('modal-show', 'modal-order-confirmation')
     })
+  },
+  computed: {
+    storeView () {
+      return currentStoreView()
+    }
   },
   methods: {
     confirmOrders () {

--- a/src/themes/default/components/core/blocks/Checkout/Product.vue
+++ b/src/themes/default/components/core/blocks/Checkout/Product.vue
@@ -42,14 +42,14 @@
         </div>
         <div class="col-xs-12 col-md-3 serif">
           <div v-if="isOnline && product.totals">
-            <span class="h4 cl-error" v-if="product.totals.discount_amount">{{ product.totals.row_total - product.totals.discount_amount + product.totals.tax_amount | price }} </span>
-            <span class="price-original h5" v-if="product.totals.discount_amount">{{ product.totals.row_total_incl_tax | price }}</span>
-            <span v-if="!product.totals.discount_amount" class="h4">{{ product.totals.row_total_incl_tax | price }}</span>
+            <span class="h4 cl-error" v-if="product.totals.discount_amount">{{ product.totals.row_total - product.totals.discount_amount + product.totals.tax_amount | price(storeView) }} </span>
+            <span class="price-original h5" v-if="product.totals.discount_amount">{{ product.totals.row_total_incl_tax | price(storeView) }}</span>
+            <span v-if="!product.totals.discount_amount" class="h4">{{ product.totals.row_total_incl_tax | price(storeView) }}</span>
           </div>
           <div v-else>
-            <span class="h4 cl-error" v-if="product.special_price">{{ product.price_incl_tax * product.qty | price }} </span>
-            <span class="price-original h5" v-if="product.special_price">{{ product.original_price_incl_tax * product.qty | price }}</span>
-            <span v-if="!product.special_price" class="h4">{{ product.price_incl_tax * product.qty | price }}</span>
+            <span class="h4 cl-error" v-if="product.special_price">{{ product.price_incl_tax * product.qty | price(storeView) }} </span>
+            <span class="price-original h5" v-if="product.special_price">{{ product.original_price_incl_tax * product.qty | price(storeView) }}</span>
+            <span v-if="!product.special_price" class="h4">{{ product.price_incl_tax * product.qty | price(storeView) }}</span>
           </div>
         </div>
       </div>
@@ -61,9 +61,13 @@
 import { Product } from '@vue-storefront/core/modules/checkout/components/Product'
 import { onlineHelper } from '@vue-storefront/core/helpers'
 import ProductImage from 'theme/components/core/ProductImage'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 export default {
   computed: {
+    storeView () {
+      return currentStoreView()
+    },
     isOnline () {
       return onlineHelper.isOnline
     },

--- a/src/themes/default/components/core/blocks/Checkout/Shipping.vue
+++ b/src/themes/default/components/core/blocks/Checkout/Shipping.vue
@@ -113,14 +113,14 @@
             @blur="$v.shipping.city.$touch()"
             autocomplete="address-level2"
             :validations="[
-            {
-              condition: $v.shipping.city.$error && !$v.shipping.city.required,
-              text: $t('Field is required')
-            },
-            {
-              condition: $v.shipping.city.$error && $v.shipping.city.required,
-              text: $t('Please provide valid city name')
-            }
+              {
+                condition: $v.shipping.city.$error && !$v.shipping.city.required,
+                text: $t('Field is required')
+              },
+              {
+                condition: $v.shipping.city.$error && $v.shipping.city.required,
+                text: $t('Please provide valid city name')
+              }
             ]"
           />
 
@@ -184,7 +184,7 @@
             {{ $t('Shipping method') }}
           </h4>
           <div v-for="(method, index) in shippingMethods" :key="index" class="col-md-6">
-            <label class="radioStyled"> {{ method.method_title }} | {{ method.amount | price }}
+            <label class="radioStyled"> {{ method.method_title }} | {{ method.amount | price(storeView) }}
               <input
                 type="radio"
                 :value="method.method_code"
@@ -245,7 +245,7 @@
               </h4>
             </div>
             <div class="col-md-6 mb15">
-              <label class="radioStyled"> {{ getShippingMethod().method_title }} | {{ getShippingMethod().amount | price }}
+              <label class="radioStyled"> {{ getShippingMethod().method_title }} | {{ getShippingMethod().amount | price(storeView) }}
                 <input type="radio" value="" checked disabled name="chosen-shipping-method">
                 <span class="checkmark" />
               </label>
@@ -261,6 +261,7 @@
 import { required, minLength } from 'vuelidate/lib/validators'
 import { unicodeAlpha, unicodeAlphaNum } from '@vue-storefront/core/helpers/validators'
 import { Shipping } from '@vue-storefront/core/modules/checkout/components/Shipping'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 import BaseCheckbox from 'theme/components/core/blocks/Form/BaseCheckbox'
 import BaseInput from 'theme/components/core/blocks/Form/BaseInput'
@@ -285,6 +286,9 @@ export default {
           label: item.name
         }
       })
+    },
+    storeView () {
+      return currentStoreView()
     }
   },
   validations: {

--- a/src/themes/default/components/core/blocks/Microcart/Microcart.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Microcart.vue
@@ -65,7 +65,7 @@
           </button>
         </div>
         <div v-if="segment.value != null" class="col-xs align-right">
-          {{ segment.value | price }}
+          {{ segment.value | price(storeView) }}
         </div>
       </div>
       <div class="row py20">
@@ -94,7 +94,7 @@
           {{ segment.title }}
         </div>
         <div class="col-xs align-right h2 total-price-value">
-          {{ segment.value | price }}
+          {{ segment.value | price(storeView) }}
         </div>
       </div>
     </div>
@@ -127,6 +127,7 @@
 import { mapGetters, mapActions } from 'vuex'
 import i18n from '@vue-storefront/i18n'
 import { isModuleRegistered } from '@vue-storefront/core/lib/modules'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 import VueOfflineMixin from 'vue-offline/mixin'
 import onEscapePress from '@vue-storefront/core/mixins/onEscapePress'
@@ -184,7 +185,10 @@ export default {
       appliedCoupon: 'cart/getCoupon',
       totals: 'cart/getTotals',
       isOpen: 'cart/getIsMicroCartOpen'
-    })
+    }),
+    storeView () {
+      return currentStoreView()
+    }
   },
   methods: {
     ...mapActions({

--- a/src/themes/default/components/core/blocks/Microcart/Product.vue
+++ b/src/themes/default/components/core/blocks/Microcart/Product.vue
@@ -63,29 +63,29 @@
         <div class="flex mr10 align-right start-xs between-sm prices">
           <div class="prices" v-if="!displayItemDiscounts || !isOnline">
             <span class="h4 serif cl-error price-special" v-if="product.special_price">
-              {{ product.price_incl_tax * product.qty | price }}
+              {{ product.price_incl_tax * product.qty | price(storeView) }}
             </span>
             <span class="h6 serif price-original" v-if="product.special_price">
-              {{ product.original_price_incl_tax * product.qty | price }}
+              {{ product.original_price_incl_tax * product.qty | price(storeView) }}
             </span>
             <span class="h4 serif price-regular" v-else data-testid="productPrice">
-              {{ (product.original_price_incl_tax ? product.original_price_incl_tax : product.price_incl_tax) * product.qty | price }}
+              {{ (product.original_price_incl_tax ? product.original_price_incl_tax : product.price_incl_tax) * product.qty | price(storeView) }}
             </span>
           </div>
           <div class="prices" v-else-if="isOnline && product.totals">
             <span class="h4 serif cl-error price-special" v-if="product.totals.discount_amount">
-              {{ product.totals.row_total - product.totals.discount_amount + product.totals.tax_amount | price }}
+              {{ product.totals.row_total - product.totals.discount_amount + product.totals.tax_amount | price(storeView) }}
             </span>
             <span class="h6 serif price-original" v-if="product.totals.discount_amount">
-              {{ product.totals.row_total_incl_tax | price }}
+              {{ product.totals.row_total_incl_tax | price(storeView) }}
             </span>
             <span class="h4 serif price-regular" v-if="!product.totals.discount_amount">
-              {{ product.totals.row_total_incl_tax | price }}
+              {{ product.totals.row_total_incl_tax | price(storeView) }}
             </span>
           </div>
           <div class="prices" v-else>
             <span class="h4 serif price-regular">
-              {{ (product.regular_price || product.price_incl_tax) * product.qty | price }}
+              {{ (product.regular_price || product.price_incl_tax) * product.qty | price(storeView) }}
             </span>
           </div>
         </div>
@@ -225,6 +225,9 @@ export default {
       return this.quantityError ||
         this.isStockInfoLoading ||
         (this.isOnline && !this.maxQuantity && this.isSimpleOrConfigurable)
+    },
+    storeView () {
+      return currentStoreView()
     }
   },
   methods: {

--- a/src/themes/default/components/core/blocks/MyAccount/MyOrder.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyOrder.vue
@@ -17,7 +17,7 @@
     <!-- My order body -->
     <div class="row fs16 mb20">
       <div class="col-xs-12 h4">
-        <p>{{ order.created_at | date('LLL') }}</p>
+        <p>{{ order.created_at | date('LLL', storeView) }}</p>
         <p class="mt35">
           <a href="#" class="underline" @click.prevent="remakeOrder(singleOrderItems)">{{ $t('Remake order') }}</a>
         </p>
@@ -58,13 +58,13 @@
                 {{ item.sku }}
               </td>
               <td class="fs-medium lh25" :data-th="$t('Price')">
-                {{ item.price_incl_tax | price }}
+                {{ item.price_incl_tax | price(storeView) }}
               </td>
               <td class="fs-medium lh25 align-right" :data-th="$t('Qty')">
                 {{ item.qty_ordered }}
               </td>
               <td class="fs-medium lh25" :data-th="$t('Subtotal')">
-                {{ item.row_total_incl_tax | price }}
+                {{ item.row_total_incl_tax | price(storeView) }}
               </td>
               <td class="fs-medium lh25">
                 <product-image :image="{src: itemThumbnail[item.sku]}" />
@@ -76,31 +76,31 @@
               <td colspan="5" class="align-right">
                 {{ $t('Subtotal') }}
               </td>
-              <td>{{ order.subtotal | price }}</td>
+              <td>{{ order.subtotal | price(storeView) }}</td>
             </tr>
             <tr>
               <td colspan="5" class="align-right">
                 {{ $t('Shipping') }}
               </td>
-              <td>{{ order.shipping_amount | price }}</td>
+              <td>{{ order.shipping_amount | price(storeView) }}</td>
             </tr>
             <tr>
               <td colspan="5" class="align-right">
                 {{ $t('Tax') }}
               </td>
-              <td>{{ order.tax_amount + order.discount_tax_compensation_amount | price }}</td>
+              <td>{{ order.tax_amount + order.discount_tax_compensation_amount | price(storeView) }}</td>
             </tr>
             <tr v-if="order.discount_amount">
               <td colspan="5" class="align-right">
                 {{ $t('Discount') }}
               </td>
-              <td>{{ order.discount_amount | price }}</td>
+              <td>{{ order.discount_amount | price(storeView) }}</td>
             </tr>
             <tr>
               <td colspan="5" class="align-right">
                 {{ $t('Grand total') }}
               </td>
-              <td>{{ order.grand_total | price }}</td>
+              <td>{{ order.grand_total | price(storeView) }}</td>
             </tr>
           </tfoot>
         </table>
@@ -148,6 +148,7 @@ import MyOrder from '@vue-storefront/core/compatibility/components/blocks/MyAcco
 import ReturnIcon from 'theme/components/core/blocks/Header/ReturnIcon'
 import ProductImage from 'theme/components/core/ProductImage'
 import { getThumbnailPath, productThumbnailPath } from '@vue-storefront/core/helpers'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { mapActions } from 'vuex'
 
 export default {
@@ -159,6 +160,11 @@ export default {
   data () {
     return {
       itemThumbnail: []
+    }
+  },
+  computed: {
+    storeView () {
+      return currentStoreView()
     }
   },
   methods: {

--- a/src/themes/default/components/core/blocks/MyAccount/MyOrders.vue
+++ b/src/themes/default/components/core/blocks/MyAccount/MyOrders.vue
@@ -43,13 +43,13 @@
                 #{{ order.increment_id }}
               </td>
               <td class="fs-medium lh25 hide-on-xs">
-                {{ order.created_at | date }}
+                {{ order.created_at | date(null, storeView) }}
               </td>
               <td class="fs-medium lh25 hide-on-xs">
                 {{ order.customer_firstname }} {{ order.customer_lastname }}
               </td>
               <td class="fs-medium lh25 hide-on-xs">
-                {{ order.grand_total | price }}
+                {{ order.grand_total | price(storeView) }}
               </td>
               <td class="fs-medium lh25 hide-on-xs">
                 {{ $t('Purchase') }}
@@ -81,9 +81,15 @@
 
 <script>
 import UserOrder from '@vue-storefront/core/modules/order/components/UserOrdersHistory'
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
 export default {
-  mixins: [UserOrder]
+  mixins: [UserOrder],
+  computed: {
+    storeView () {
+      return currentStoreView()
+    }
+  }
 }
 </script>
 

--- a/src/themes/default/components/core/blocks/Wishlist/Product.vue
+++ b/src/themes/default/components/core/blocks/Wishlist/Product.vue
@@ -31,11 +31,11 @@
     </div>
     <div class="col-xs flex py15 align-right">
       <div>
-        <span class="price-special" v-if="product.special_price">{{ product.price_incl_tax | price }}</span>&nbsp;
-        <span class="price-original" v-if="product.special_price">{{ product.original_price_incl_tax | price }}</span>
+        <span class="price-special" v-if="product.special_price">{{ product.price_incl_tax | price(storeView) }}</span>&nbsp;
+        <span class="price-original" v-if="product.special_price">{{ product.original_price_incl_tax | price(storeView) }}</span>
 
         <span v-if="!product.special_price">
-          {{ product.price_incl_tax | price }}
+          {{ product.price_incl_tax | price(storeView) }}
         </span>
       </div>
       <div>
@@ -80,6 +80,9 @@ export default {
         loading: this.thumbnail,
         src: this.thumbnail
       }
+    },
+    storeView () {
+      return currentStoreView()
     }
   },
   methods: {

--- a/src/themes/default/components/theme/blocks/Reviews/ReviewsList.vue
+++ b/src/themes/default/components/theme/blocks/Reviews/ReviewsList.vue
@@ -9,7 +9,7 @@
         {{ item.title }}
       </h4>
       <p class="cl-tertiary mt10 mb20 fs-medium-small">
-        {{ item.nickname }}, {{ item.created_at | date }}
+        {{ item.nickname }}, {{ item.created_at | date(null, storeView) }}
       </p>
       <p class="cl-gray lh25" itemprop="reviewBody" :content="item.detail">
         {{ item.detail }}
@@ -36,6 +36,7 @@
 
 <script>
 
+import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 export default {
   props: {
     perPage: {
@@ -82,6 +83,9 @@ export default {
       } else {
         return [this.currentPage - 2, this.currentPage - 1, this.currentPage, this.currentPage + 1, this.currentPage + 2]
       }
+    },
+    storeView () {
+      return currentStoreView()
     }
   },
   methods: {

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -46,16 +46,16 @@
                 >
                   <span
                     class="h2 cl-mine-shaft weight-700"
-                  >{{ getCurrentProduct.price_incl_tax * getCurrentProduct.qty | price }}</span>&nbsp;
+                  >{{ getCurrentProduct.price_incl_tax * getCurrentProduct.qty | price(storeView) }}</span>&nbsp;
                   <span
                     class="price-original h3"
-                  >{{ getCurrentProduct.original_price_incl_tax * getCurrentProduct.qty | price }}</span>
+                  >{{ getCurrentProduct.original_price_incl_tax * getCurrentProduct.qty | price(storeView) }}</span>
                 </div>
                 <div
                   class="h2 cl-mine-shaft weight-700"
                   v-if="!getCurrentProduct.special_price && getCurrentProduct.price_incl_tax"
                 >
-                  {{ getCurrentProduct.qty > 0 ? getCurrentProduct.price_incl_tax * getCurrentProduct.qty : getCurrentProduct.price_incl_tax | price }}
+                  {{ getCurrentProduct.qty > 0 ? getCurrentProduct.price_incl_tax * getCurrentProduct.qty : getCurrentProduct.price_incl_tax | price(storeView) }}
                 </div>
               </div>
               <div class="cl-primary variants" v-if="getCurrentProduct.type_id =='configurable'">
@@ -333,6 +333,9 @@ export default {
       return this.quantityError ||
         this.isStockInfoLoading ||
         (this.isOnline && !this.maxQuantity && this.isSimpleOrConfigurable)
+    },
+    storeView () {
+      return currentStoreView()
     }
   },
   async mounted () {


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
On init load https://test.storefrontcloud.io/women/women-20 filters are missing on SSR so we get price without format.



### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

