### PR TITLE
OutputCaching: Support for x-vs-store-code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `or` operator for Elasticsearch filters in `quickSearchByQuery` and use exists if value is `null` - @cewald (#3960)
 - Add unified fetch in mappingFallback for all searched entities - @gibkigonzo (#3942)
 - add npm-run-all for parallel build - @gibkigonzo (#3819)
+- Add OutputCaching support for x-vs-store-code - @benjick (#3979)
 
 ### Fixed
 - Fixed Search product fails for category filter when categoryId is string - @adityasharma7 (#3929)

--- a/core/scripts/server.ts
+++ b/core/scripts/server.ts
@@ -170,6 +170,9 @@ app.get('*', (req, res, next) => {
       next()
     }
   }
+  
+  const site = req.headers['x-vs-store-code'] || 'main'
+  const cacheKey = `page:${site}:${req.url}`
 
   const dynamicRequestHandler = renderer => {
     if (!renderer) {
@@ -207,7 +210,7 @@ app.get('*', (req, res, next) => {
       output = ssr.applyAdvancedOutputProcessing(context, output, templatesCache, isProd);
       if (config.server.useOutputCache && cache) {
         cache.set(
-          'page:' + req.url,
+          cacheKey,
           { headers: res.getHeaders(), body: output },
           tagsArray
         ).catch(errorHandler)
@@ -240,7 +243,7 @@ app.get('*', (req, res, next) => {
   const dynamicCacheHandler = () => {
     if (config.server.useOutputCache && cache) {
       cache.get(
-        'page:' + req.url
+        cacheKey
       ).then(output => {
         if (output !== null) {
           if (output.headers) {


### PR DESCRIPTION
### Short Description and Why It's Useful
Currently it's not possible to use the `x-vs-store-code` header and `outputCaching` because the caching only looks at `req.url`. This fixes that.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

