### PR TITLE
Proposing two fixes for i18n issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CookieNotification CSR&SSR mismatch fixed - @Fifciu (#3922)
 - The attribute filter in `attribute/list` was not filtering the already loaded attributes properly - @pkarw (#3964)
 - Update `hasProductErrors` in Product component and support additional sku in custom options - @gibkigonzo (#3976)
+- Fixed logic for generating ${lang}.json files in multi-store setup - @jpkempf
+- Fixed logic for collecting valid locales in single-store, multi-lang setup - @jpkempf
 
 ## [1.11.0] - 2019.12.20
 

--- a/core/i18n/helpers.ts
+++ b/core/i18n/helpers.ts
@@ -6,7 +6,7 @@ export const currentBuildLocales = (): string[] => {
     ? Object.values(config.storeViews)
       .map((store: any) => store && typeof store === 'object' && store.i18n && store.i18n.defaultLocale)
       .filter(Boolean)
-    : []
+    : config.i18n.availableLocale
   const locales = multistoreLocales.includes(defaultLocale)
     ? multistoreLocales
     : [defaultLocale, ...multistoreLocales]

--- a/core/i18n/scripts/translation.preprocessor.js
+++ b/core/i18n/scripts/translation.preprocessor.js
@@ -55,7 +55,7 @@ module.exports = function (csvDirectories, config = null) {
     fs.writeFileSync(path.join(__dirname, '../resource/i18n', `multistoreLanguages.json`), JSON.stringify(bundledLanguages))
   } else {
     currentLocales.forEach((language) => {
-      if (language !== fallbackLocale) return // it's already loaded
+      if (language === fallbackLocale) return // it's already loaded
       const filePath = path.join(__dirname, '../resource/i18n', `${language}.json`)
       console.debug(`Writing JSON file: ${language}.json`)
       fs.writeFileSync(filePath, JSON.stringify(messages[language]))


### PR DESCRIPTION
### Short Description and Why It's Useful

This PR proposes to adjust some behaviour around locales and localisation files that was originally introduced in #3728:

- `092493e` fixes a problem where the only working locale in a single-store, multi-language scenario was the default locale.
- `60c1206` fixes a problem where, if `bundleAllStoreviewLanguages` is set to `false`, a `${lang}.json` file would only be generated for the fallback locale.

I work on a team that has built a custom b2b application on top of VSF and without `092493e`, our language switching mechanism would be completely broken. The changes from `60c1206` are not actually relevant to us, but we came across this in our investigation and from what I can tell that line in it's current form does not make any sense, so we're proposing a fix for that as well here.

Perhaps @gibkigonzo can weigh in on whether or not the proposed changes in this PR represent an improvement.

I'm happy to adjust any mistakes I might have made in the steps I took to create this PR, and please feel free to also refer to @gopkumargopi for questions. Thank you in advance for your time!

### Which Environment This Relates To

- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

