### PR TITLE
make initial custom options reactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CookieNotification CSR&SSR mismatch fixed - @Fifciu (#3922)
 - The attribute filter in `attribute/list` was not filtering the already loaded attributes properly - @pkarw (#3964)
 - Update `hasProductErrors` in Product component and support additional sku in custom options - @gibkigonzo (#3976)
+- Make initial custom option value reactive - @gibkigonzo
 
 ## [1.11.0] - 2019.12.20
 

--- a/core/modules/catalog/components/ProductCustomOptions.ts
+++ b/core/modules/catalog/components/ProductCustomOptions.ts
@@ -54,9 +54,9 @@ export const ProductCustomOptions = {
     setupInputFields () {
       for (const customOption of this.product.custom_options) {
         const fieldName = customOptionFieldName(customOption)
-        this['inputValues'][fieldName] = defaultCustomOptionValue(customOption)
+        this.$set(this.inputValues, fieldName, defaultCustomOptionValue(customOption))
         if (customOption.is_require) { // validation rules are very basic
-          this.validation.rules[fieldName] = 'required' // TODO: add custom validators for the custom options
+          this.$set(this.validation.rules, fieldName, 'required') // TODO: add custom validators for the custom options
         }
         this.optionChanged(customOption)
       }


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
`inputValues` may not be reactive because adding dynamic props require using $set



### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

