### PR TITLE
Fix: slugify sub-category names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed Search product fails for category filter when categoryId is string - @adityasharma7 (#3929)
 - Revert init filters in Vue app - @gibkigonzo (#3929)
+- All categories disappearing if you add the child category name to includeFields - @1070rik (#4015)
 
 ### Changed / Improved
 - Optimized `translation.processor` to process only enabled locale CSV files - @pkarw (#3950)

--- a/core/modules/catalog/helpers/slugifyCategories.ts
+++ b/core/modules/catalog/helpers/slugifyCategories.ts
@@ -20,11 +20,13 @@ const createSlug = (category: ChildrenData): string => {
 
 const slugifyCategories = (category: Category | ChildrenData): Category | ChildrenData => {
   if (category.children_data) {
-    for (let subcat of category.children_data) {
-      if (subcat.name) {
-        return slugifyCategories({ ...subcat, slug: createSlug(subcat) } as any as ChildrenData)
+    category.children_data.forEach((subCat: ChildrenData): void => {
+      if (subCat.name) {
+        subCat.slug = createSlug(subCat)
       }
-    }
+
+      slugifyCategories(subCat)
+    })
   }
 
   return category


### PR DESCRIPTION
### Short Description and Why It's Useful
The old function wouldn't show any categories at all if you added the "*.name" field in the includedFields array in your config. The way it works now is also easier to read.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

