### PR TITLE
Keep registered payment methods after totals sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed No image thumbnails leaded on 404 page - @andrzejewsky (#3955)
 - Fixed Stock logic not working with manage_stock set to false - @andrzejewsky - (#3957)
 - Support old price format in `ProductPrice` - @gibkigonzo (#3978)
-- Fixed product bundle comparison condition - @gk-daniel (#4004) 
+- Fixed product bundle comparison condition - @gk-daniel (#4004)
+- Keep registered payment methods after `syncTotals`  - @grimasod (#4020)
 
 ## [1.11.0] - 2019.12.20
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

This fixes a problem where all registered payment methods are replaced with only the server payment methods after `syncTotals`. It now uses the same code as `syncPaymentMethods` to merge previously registered methods with those returned by the servr

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

