### PR TITLE
Delay closing modal after order submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed No image thumbnails leaded on 404 page - @andrzejewsky (#3955)
 - Fixed Stock logic not working with manage_stock set to false - @andrzejewsky - (#3957)
 - Support old price format in `ProductPrice` - @gibkigonzo (#3978)
-- Fixed product bundle comparison condition - @gk-daniel (#4004) 
+- Fixed product bundle comparison condition - @gk-daniel (#4004)
+- Fixed `Processing order...` modal closing too early - @grimasod (#4021)
 
 ## [1.11.0] - 2019.12.20
 

--- a/core/modules/order/store/actions.ts
+++ b/core/modules/order/store/actions.ts
@@ -53,7 +53,6 @@ const actions: ActionTree<OrderState, RootState> = {
   async processOrder ({ commit, dispatch }, { newOrder, currentOrderHash }) {
     const order = { ...newOrder, transmited: true }
     const task = await OrderService.placeOrder(order)
-    EventBus.$emit('notification-progress-stop')
 
     if (task.resultCode === 200) {
       dispatch('enqueueOrder', { newOrder: order })
@@ -61,7 +60,7 @@ const actions: ActionTree<OrderState, RootState> = {
       commit(types.ORDER_LAST_ORDER_WITH_CONFIRMATION, { order, confirmation: task.result })
       orderHooksExecutors.afterPlaceOrder({ order, task })
       EventBus.$emit('order-after-placed', { order, confirmation: task.result })
-
+      EventBus.$emit('notification-progress-stop')
       return task
     }
 
@@ -71,10 +70,10 @@ const actions: ActionTree<OrderState, RootState> = {
       Logger.error('Internal validation error; Order entity is not compliant with the schema: ' + JSON.stringify(task.result), 'orders')()
       dispatch('notification/spawnNotification', notifications.internalValidationError(), { root: true })
       dispatch('enqueueOrder', { newOrder: order })
-
+      EventBus.$emit('notification-progress-stop')
       return task
     }
-
+    EventBus.$emit('notification-progress-stop')
     throw new Error('Unhandled place order request error')
   },
   handlePlacingOrderFailed ({ commit, dispatch }, { newOrder, currentOrderHash }) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

This fixes an issue where the `Processing order...`modal was closed too soon, before all processing has completed and before the order confirmation is displayed. This was very noticeable on a slow connection and could cause confusion for users. Now it closes after all processing is complete.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

