### PR TITLE
Fix overlapping text in PersonalDetails in Checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed Search product fails for category filter when categoryId is string - @adityasharma7 (#3929)
 - Revert init filters in Vue app - @gibkigonzo (#3929)
+- Fix overlapping text in PersonalDetails component - @jakubmakielkowski (#4024)
 
 ### Changed / Improved
 - Optimized `translation.processor` to process only enabled locale CSV files - @pkarw (#3950)

--- a/src/themes/default/components/core/blocks/Checkout/PersonalDetails.vue
+++ b/src/themes/default/components/core/blocks/Checkout/PersonalDetails.vue
@@ -159,7 +159,7 @@
       <div class="hidden-xs col-sm-2 col-md-1" />
       <div class="col-xs-11 col-sm-9 col-md-10">
         <div class="row my30">
-          <div class="col-xs-12 col-md-7 px20 button-container">
+          <div class="col-xs-12 col-xl-7 px20 button-container">
             <button-full
               data-testid="personalDetailsSubmit"
               @click.native="sendDataToCheckout"
@@ -169,7 +169,7 @@
             </button-full>
           </div>
           <div
-            class="col-xs-12 col-md-5 center-xs end-md"
+            class="col-xs-12 col-xl-5 center-xs end-xl"
             v-if="!currentUser"
           >
             <p class="h4 cl-accent">


### PR DESCRIPTION
### Related Issues
Closes #4024 

### Screenshots of Visual Changes before/after (if There Are Any)
Text does not overlap
![image](https://user-images.githubusercontent.com/36307776/73121545-7c782f80-3f7b-11ea-8feb-1d233bc46054.png)

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [X] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

