### PR TITLE
[Docs] - added http protocol before "localhost" for ES and orders

### DIFF
--- a/docs/guide/installation/windows.md
+++ b/docs/guide/installation/windows.md
@@ -83,12 +83,12 @@ yarn install
 export default {
   elasticsearch: {
     httpAuth: '',
-    host: 'localhost:8080/api/catalog',
+    host: 'http://localhost:8080/api/catalog',
     index: 'vue_storefront_catalog',
   },
   // we have vue-storefront-api (https://github.com/DivanteLtd/vue-storefront-api) endpoints below:
   orders: {
-    endpoint: 'localhost:8080/api/order/create',
+    endpoint: 'http://localhost:8080/api/order/create',
   },
   images: {
     baseUrl: 'https://demo.vuestorefront.io/img/',


### PR DESCRIPTION
### Short Description and Why It's Useful

Setting up vue storefront locally with the use of docker after setting up the local.json configuration an error occurs " Can not connect the vue-storefront-api / ElasticSearch instance! Error: FetchError in request to ES: Error: only http(s) protocols are supported". The issue gets resolved when adding Http protocol before "localhost:8080/api/catalog" and "localhost:8080/api/order/create". Windows.md updated for future set ups.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

