### PR TITLE
Bugfix/wrong attribute error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All categories disappearing if you add the child category name to includeFields - @1070rik (#4015)
 - Fix overlapping text in PersonalDetails component - @jakubmakielkowski (#4024)
 - Redirect from checkout to home with a proper store code - @Fifciu
+- Added back error notification when user selects invalid configuration - @1070rik (#4033)
 
 ### Changed / Improved
 - Optimized `translation.processor` to process only enabled locale CSV files - @pkarw (#3950)

--- a/core/modules/catalog/events.ts
+++ b/core/modules/catalog/events.ts
@@ -2,6 +2,7 @@ import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 import { PRODUCT_SET_CURRENT_CONFIGURATION, PRODUCT_SET_CURRENT } from './store/product/mutation-types'
 import omit from 'lodash-es/omit'
 import config from 'config'
+import i18n from '@vue-storefront/core/i18n';
 
 // Listeners moved from Product.js
 
@@ -46,6 +47,14 @@ export const filterChangedProduct = async (filterOption, store, router) => {
         }
       ), { root: true })
     }
+
+    store.dispatch('notification/spawnNotification', {
+      type: 'warning',
+      message: i18n.t(
+        'No such configuration for the product. Please do choose another combination of attributes.'
+      ),
+      action1: {label: i18n.t('OK')}
+    })
   }
 }
 


### PR DESCRIPTION
### Related Issues

### Short Description and Why It's Useful
When upgrading from v1.10 to v1.11 we're told to remove the Product.js mixin because the functionality from this file is moved to the events.ts file. However, Product.js used to notify the user if they selected an invalid product configuration and this wasn't copied to the event.ts file. I don't know if this wasn't copied on purpose or if it was just forgotten but I think it's way better to still notify a user if a configuration is not possible.

### Screenshots of Visual Changes before/after (if There Are Any)

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

