### PR TITLE
sku attribute is missing on compare page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Processing order...` modal closing too early - @grimasod (#4021)
 - Keep registered payment methods after `syncTotals`  - @grimasod (#4020)
 - Added status code to the cache content and use it in cache response - @resubaka (#4014)
+- Fixed sku attribute is missing on compare page - @gibkigonzo (#4036)
 
 ## [1.11.0] - 2019.12.20
 

--- a/core/modules/catalog/helpers/filterAttributes.ts
+++ b/core/modules/catalog/helpers/filterAttributes.ts
@@ -14,9 +14,6 @@ export default function filterAttributes ({
   codesList: any
 }) {
   return filterValues.filter(fv => {
-    if (config.entities.product.standardSystemFields.indexOf(fv) >= 0) {
-      return false
-    }
     if (fv.indexOf('.') >= 0) {
       return false
     }


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
In compare list there is missing 'sku' property. Thats because now `filterAttributes` returns array and reassign `filterValues` in `attribute/list`. So I removed if statement with `config.entities.product.standardSystemFields`


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

