### PR TITLE
fix z-index for aside in compare list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Processing order...` modal closing too early - @grimasod (#4021)
 - Keep registered payment methods after `syncTotals`  - @grimasod (#4020)
 - Added status code to the cache content and use it in cache response - @resubaka (#4014)
+- Fixed z-index for aside in compare list - @gibkigonzo (#4037)
 
 ## [1.11.0] - 2019.12.20
 

--- a/src/themes/default/pages/Compare.vue
+++ b/src/themes/default/pages/Compare.vue
@@ -147,7 +147,7 @@ $screen-l: 1170px;
 
   &__features {
     position: absolute;
-    z-index: 1;
+    z-index: 3;
     top: 0;
     left: 0;
     width: $features-column-width-mobile;


### PR DESCRIPTION
### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->
Before:
![Zrzut ekranu z 2020-01-30 13-57-20](https://user-images.githubusercontent.com/42383376/73451725-95f8ed00-4368-11ea-9a51-cfd69ed71095.png)
After:
![Zrzut ekranu z 2020-01-30 13-57-36](https://user-images.githubusercontent.com/42383376/73451739-9b563780-4368-11ea-90c7-b6c71e246260.png)


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

