### PR TITLE
findConfigurableChildAsync - return best match for configurable variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix overlapping text in PersonalDetails component - @jakubmakielkowski (#4024)
 - Redirect from checkout to home with a proper store code - @Fifciu
 - Added back error notification when user selects invalid configuration - @1070rik (#4033)
+- findConfigurableChildAsync - return best match for configurable variant - @gibkigonzo (#4042)
 
 ### Changed / Improved
 - Optimized `translation.processor` to process only enabled locale CSV files - @pkarw (#3950)

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -62,7 +62,6 @@ const getConfigurationMatchLevel = (configuration, variant): number => {
 }
 
 export function findConfigurableChildAsync ({ product, configuration = null, selectDefaultChildren = false, availabilityCheck = true }) {
-  const regularProductPrice = product.original_price_incl_tax ? product.original_price_incl_tax : product.price_incl_tax
   const selectedVariant = product.configurable_children.reduce((prevVariant, nextVariant) => {
     if (availabilityCheck) {
       if (nextVariant.stock && !config.products.listOutOfStockProducts) {
@@ -80,20 +79,14 @@ export function findConfigurableChildAsync ({ product, configuration = null, sel
     if (configuration.sku && nextVariant.sku === configuration.sku) { // by sku or first one
       return nextVariant
     } else {
-      if (!configuration || (configuration && Object.keys(configuration).length === 0)) { // no configuration - return the first child cheaper than the original price - if found
-        if (nextVariant.price_incl_tax <= regularProductPrice) {
-          return getVariantWithLowestPrice(prevVariant, nextVariant)
-        }
-      } else {
-        const prevVariantMatch = getConfigurationMatchLevel(configuration, prevVariant)
-        const nextVariantMatch = getConfigurationMatchLevel(configuration, nextVariant)
+      const prevVariantMatch = getConfigurationMatchLevel(configuration, prevVariant)
+      const nextVariantMatch = getConfigurationMatchLevel(configuration, nextVariant)
 
-        if (prevVariantMatch === nextVariantMatch) {
-          return getVariantWithLowestPrice(prevVariant, nextVariant)
-        }
-
-        return nextVariantMatch > prevVariantMatch ? nextVariant : prevVariant
+      if (prevVariantMatch === nextVariantMatch) {
+        return getVariantWithLowestPrice(prevVariant, nextVariant)
       }
+
+      return nextVariantMatch > prevVariantMatch ? nextVariant : prevVariant
     }
   }, undefined)
   return selectedVariant

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -87,10 +87,12 @@ export function findConfigurableChildAsync ({ product, configuration = null, sel
       } else {
         const prevVariantMatch = getConfigurationMatchLevel(configuration, prevVariant)
         const nextVariantMatch = getConfigurationMatchLevel(configuration, nextVariant)
-        // compare variants based on configuration match
-        const bestMatch = nextVariantMatch >= prevVariantMatch ? nextVariant : prevVariant
 
-        return bestMatch
+        if (prevVariantMatch === nextVariantMatch) {
+          return getVariantWithLowestPrice(prevVariant, nextVariant)
+        }
+
+        return nextVariantMatch > prevVariantMatch ? nextVariant : prevVariant
       }
     }
   }, undefined)

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -5,6 +5,7 @@ import omit from 'lodash-es/omit'
 import remove from 'lodash-es/remove'
 import toString from 'lodash-es/toString'
 import union from 'lodash-es/union'
+import isObject from 'lodash-es/union'
 // TODO: Remove this dependency
 import { optionLabel } from './optionLabel'
 import i18n from '@vue-storefront/i18n'
@@ -42,6 +43,24 @@ const getVariantWithLowestPrice = (prevVariant, nextVariant) => (
   nextVariant.price_incl_tax <= prevVariant.price_incl_tax // prev variant price is higher then next
 ) ? nextVariant : prevVariant
 
+/**
+ * Counts how much coniguration match for specific variant
+ */
+const countMatchConfiguration = (configuration, variant): number => {
+  if (!variant || !configuration) return 0
+  const configProperties = Object.keys(omit(configuration, ['price']))
+  return configProperties
+    .map(configProperty => {
+      const filter = configuration[configProperty]
+      const configurationId = filter && isObject(filter) && filter.id
+      const variantPropertyId = variant[configProperty]
+      return (configurationId && variantPropertyId) &&
+        (toString(configurationId) === toString(variantPropertyId))
+    })
+    .filter(Boolean)
+    .length
+}
+
 export function findConfigurableChildAsync ({ product, configuration = null, selectDefaultChildren = false, availabilityCheck = true }) {
   const regularProductPrice = product.original_price_incl_tax ? product.original_price_incl_tax : product.price_incl_tax
   const selectedVariant = product.configurable_children.reduce((prevVariant, nextVariant) => {
@@ -66,17 +85,12 @@ export function findConfigurableChildAsync ({ product, configuration = null, sel
           return getVariantWithLowestPrice(prevVariant, nextVariant)
         }
       } else {
-        const matchConfiguration = Object.keys(omit(configuration, ['price'])).every((configProperty) => {
-          let configurationPropertyFilters = configuration[configProperty] || []
-          if (!Array.isArray(configurationPropertyFilters)) configurationPropertyFilters = [configurationPropertyFilters]
-          const configurationIds = configurationPropertyFilters.map(filter => toString(filter.id)).filter(filterId => !!filterId)
-          if (!configurationIds.length) return true // skip empty
-          return configurationIds.includes(toString(nextVariant[configProperty]))
-        })
+        const prevVariantMatch = countMatchConfiguration(configuration, prevVariant)
+        const nextVariantMatch = countMatchConfiguration(configuration, nextVariant)
+        // compare variants based on configuration match
+        const bestConfigVariant = nextVariantMatch > prevVariantMatch ? nextVariant : prevVariant
 
-        if (matchConfiguration) {
-          return getVariantWithLowestPrice(prevVariant, nextVariant)
-        }
+        return bestConfigVariant
       }
     }
   }, undefined)

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -46,7 +46,7 @@ const getVariantWithLowestPrice = (prevVariant, nextVariant) => (
 /**
  * Counts how much coniguration match for specific variant
  */
-const countMatchConfiguration = (configuration, variant): number => {
+const getConfigurationMatchLevel = (configuration, variant): number => {
   if (!variant || !configuration) return 0
   const configProperties = Object.keys(omit(configuration, ['price']))
   return configProperties
@@ -85,12 +85,12 @@ export function findConfigurableChildAsync ({ product, configuration = null, sel
           return getVariantWithLowestPrice(prevVariant, nextVariant)
         }
       } else {
-        const prevVariantMatch = countMatchConfiguration(configuration, prevVariant)
-        const nextVariantMatch = countMatchConfiguration(configuration, nextVariant)
+        const prevVariantMatch = getConfigurationMatchLevel(configuration, prevVariant)
+        const nextVariantMatch = getConfigurationMatchLevel(configuration, nextVariant)
         // compare variants based on configuration match
-        const bestConfigVariant = nextVariantMatch > prevVariantMatch ? nextVariant : prevVariant
+        const bestMatch = nextVariantMatch >= prevVariantMatch ? nextVariant : prevVariant
 
-        return bestConfigVariant
+        return bestMatch
       }
     }
   }, undefined)


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Fix bug in findConfigurableChildAsync - if there is configuration object but `matchConfiguration` is false then it should return previous variant. And also when there is configuration we shouldn't return variant with lowest price but with best match.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

