### PR TITLE
Unification of webpack config in theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed / Improved
 - Set cache tag when loading a category - @haelbichalex (#3940)
+- In development build `webpack.config.js` in theme folder is now called without the `default` key
 
 ### Fixed
 - Added Finnish translations - @mattiteraslahti and @alphpkeemik

--- a/core/build/dev-server.js
+++ b/core/build/dev-server.js
@@ -2,14 +2,14 @@ const path = require('path')
 const webpack = require('webpack')
 const MFS = require('memory-fs')
 
-let baseClientConfig = require('./webpack.client.config')
-let baseServerConfig = require('./webpack.server.config')
+let baseClientConfig = require('./webpack.client.config').default
+let baseServerConfig = require('./webpack.server.config').default
 
 const themeRoot = require('./theme-path')
 const extendedConfig = require(path.join(themeRoot, '/webpack.config.js'))
 
-let clientConfig = extendedConfig(baseClientConfig, { isClient: true, isDev: true }).default;
-let serverConfig = extendedConfig(baseServerConfig, { isClient: false, isDev: true }).default;
+let clientConfig = extendedConfig(baseClientConfig, { isClient: true, isDev: true })
+let serverConfig = extendedConfig(baseServerConfig, { isClient: false, isDev: true })
 
 module.exports = function setupDevServer (app, cb) {
   let bundle


### PR DESCRIPTION
### Short Description and Why It's Useful
Currently `src/themes/<theme name>/webpack.config.js` receives webpack config, but it depends on type of build: for development build this config is wrapped inside `default` key, but for production build this `default` key is not present. It is not a problem for default theme, where nothing happens in `src/themes/default/webpack.config.js`, but it is actually a problem for example in `vsf-capybara` theme, where some adjustments have been introduced in `src/themes/capybara/webpack.config.js`.

It would be much simpler and cleaner to always provide webpack config in the same way, regardless of build type.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

