### PR TITLE
Improve typescript support for test utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove commit register mapping - @gibkigonzo (#3875)
 - Improved method `findConfigurableChildAsync` - find variant with lowest price - @gibkigonzo (#3939)
 - Removed `product/loadConfigurableAttributes` calls - @andrzejewsky (#3336)
+- Improve typescript support for test utils - @resubaka (#4067)
 
 ## [1.11.1] - 2020.02.05
 

--- a/test/unit/utils/index.ts
+++ b/test/unit/utils/index.ts
@@ -1,11 +1,12 @@
 import Vuex from 'vuex'
-import {shallowMount, createLocalVue} from '@vue/test-utils'
+import { shallowMount, createLocalVue, Wrapper, ThisTypedShallowMountOptions } from '@vue/test-utils';
+import Vue, { ComponentOptions } from 'vue';
 
-export const mountMixin = (
-  component: object,
-  mountOptions: object = {},
-  template: string = '<div />'
-) => {
+export const mountMixin = <V extends Vue>(
+  component: ComponentOptions<V>,
+  mountOptions: ThisTypedShallowMountOptions<V> = {},
+  template = '<div />'
+): Wrapper<V> => {
   const localVue = createLocalVue();
 
   localVue.use(Vuex);
@@ -19,12 +20,12 @@ export const mountMixin = (
   })
 };
 
-export const mountMixinWithStore = (
-  component: object,
+export const mountMixinWithStore = <V extends Vue>(
+  component: ComponentOptions<V>,
   storeOptions: object = {},
-  mountOptions: object = {},
-  template: string = '<div />'
-) => {
+  mountOptions: ThisTypedShallowMountOptions<V> = {},
+  template = '<div />'
+): Wrapper<V> => {
   const localVue = createLocalVue();
 
   localVue.use(Vuex);


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Improved the utils with better typescript support so you don't need to use an any cast. 


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

