### PR TITLE
fix applying 'is_user_defined' and 'is_visible' in createAttributesListQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.2] - UNRELEASED
+
+### Fixed
+- add '1' as searched value for 'is_user_defined' and 'is_visible' (createAttributesListQuery) - @gibkigonzo (#4075)
+
 ## [1.11.1] - 2020.02.05
 
 ### Added

--- a/core/modules/catalog/helpers/createAttributesListQuery.ts
+++ b/core/modules/catalog/helpers/createAttributesListQuery.ts
@@ -17,10 +17,10 @@ const createAttributesListQuery = ({
     searchQuery = searchQuery.applyFilter({key: filterField, value: {'in': filterValues}})
   }
   if (onlyDefinedByUser) {
-    searchQuery = searchQuery.applyFilter({key: 'is_user_defined', value: {'in': [true]}})
+    searchQuery = searchQuery.applyFilter({key: 'is_user_defined', value: {'in': [true, '1']}})
   }
   if (onlyVisible) {
-    searchQuery = searchQuery.applyFilter({key: 'is_visible', value: {'in': [true]}})
+    searchQuery = searchQuery.applyFilter({key: 'is_visible', value: {'in': [true, '1']}})
   }
 
   return searchQuery


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Right now when we make search for attributes we build invalid query (`createAttributesListQuery`). `'is_user_defined'` and `'is_visible'` can also have `'1'` as value, not only `true`.


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

