### PR TITLE
Add a cache version endpoint for external caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `saveBandwidthOverCache` parameter for skipping caching for products data - @andrzejewsky (#3706)
 - New zoom effect for product gallery images - @Michal-Dziedzinski (#2755)
 - Product Page Schema implementation as JSON-LD - @Michal-Dziedzinski (#3704)
+- Add `/cache-version.json` route to get current cache version
 
 ### Fixed
 - Fixed Search product fails for category filter when categoryId is string - @adityasharma7 (#3929)

--- a/core/scripts/server.ts
+++ b/core/scripts/server.ts
@@ -2,6 +2,7 @@ import { serverHooksExecutors } from '@vue-storefront/core/server/hooks'
 let config = require('config')
 const path = require('path')
 const glob = require('glob')
+const fs = require('fs')
 const rootPath = require('app-root-path').path
 const resolve = file => path.resolve(rootPath, file)
 const serverExtensions = glob.sync('src/modules/*/server.{ts,js}')
@@ -145,6 +146,12 @@ app.use('/service-worker.js', serve('dist/service-worker.js', false, {
 
 app.post('/invalidate', invalidateCache)
 app.get('/invalidate', invalidateCache)
+
+function cacheVersion (req, res) {
+  res.send(fs.readFileSync(resolve('core/build/cache-version.json')))
+}
+
+app.get('/cache-version.json', cacheVersion)
 
 app.get('*', (req, res, next) => {
   if (NOT_ALLOWED_SSR_EXTENSIONS_REGEX.test(req.url)) {


### PR DESCRIPTION
### Related Issues

https://github.com/ClickAndMortar/docker/issues/5

### Short Description and Why It's Useful

Useful to fetch current cache version, to leverage Redis caching from an external proxy for instance.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)
