### PR TITLE
Detecting device type based on UserAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom currency separators and amount of fraction digits - @EndPositive (#3553)
 - Product Page Schema implementation as JSON-LD - @Michal-Dziedzinski (#3704)
 - Add `/cache-version.json` route to get current cache version
+- Built-in module for detecting device type based on UserAgent with SSR support - @Fifciu
 
 ### Fixed
 

--- a/core/app.ts
+++ b/core/app.ts
@@ -50,7 +50,12 @@ const createApp = async (ssrContext, config, storeCode = null): Promise<{app: Vu
   store.state.__DEMO_MODE__ = (config.demomode === true)
   if (ssrContext) {
     // @deprecated - we shouldn't share server context between requests
-    Vue.prototype.$ssrRequestContext = {output: {cacheTags: ssrContext.output.cacheTags}}
+    Vue.prototype.$ssrRequestContext = {
+      output: {
+        cacheTags: ssrContext.output.cacheTags
+      },
+      userAgent: ssrContext.server.request.headers['user-agent']
+    }
 
     Vue.prototype.$cacheTags = ssrContext.output.cacheTags
   }

--- a/src/modules/client.ts
+++ b/src/modules/client.ts
@@ -17,6 +17,7 @@ import { PaymentCashOnDeliveryModule } from './payment-cash-on-delivery'
 import { NewsletterModule } from '@vue-storefront/core/modules/newsletter'
 import { InitialResourcesModule } from '@vue-storefront/core/modules/initial-resources'
 
+// import { DeviceModule } from './device/index';
 import { registerModule } from '@vue-storefront/core/lib/modules'
 
 // TODO:distributed across proper pages BEFORE 1.11
@@ -38,6 +39,7 @@ export function registerClientModules () {
   registerModule(CmsModule)
   registerModule(NewsletterModule)
   registerModule(InitialResourcesModule)
+  // registerModule(DeviceModule)
 }
 
 // Deprecated API, will be removed in 2.0

--- a/src/modules/device/README.md
+++ b/src/modules/device/README.md
@@ -1,0 +1,32 @@
+### Device
+
+Based on: https://github.com/nuxt-community/device-module
+
+It provides as some logic helpers based on UserAgent. List of tests:
+```
+isMobile,
+isMobileOrTablet,
+isTablet,
+isDesktop,
+isDesktopOrTablet,
+isIos,
+isWindows,
+isMacOS
+```
+
+They are accessible by, e.g::
+```
+this.$device.isMobile
+```
+Or in asyncData by (you need to import Vue):
+```
+Vue.prototype.$device.isMobile
+```
+
+We could totally disable this feature by setting `config.device.appendToInstance` to false and the small library will not by imported.
+
+In addition when we are using installer script. I've added multiselect so we could pick which tests we want to have.
+
+I've tested it with `curl -A "some user agent" http://localhost:3000 and it worked.
+
+That's obvious we should use media queries whenever we can. However, sometimes we have more advanced structure and we are ending with hidden useless vue instance.

--- a/src/modules/device/index.ts
+++ b/src/modules/device/index.ts
@@ -1,0 +1,34 @@
+import { isServer } from '@vue-storefront/core/helpers/index';
+import { StorefrontModule } from '@vue-storefront/core/lib/modules';
+import Vue from 'vue'
+
+const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.39 Safari/537.36'
+
+export const DeviceModule: StorefrontModule = async function ({ app, appConfig }) {
+  let headersOrUserAgent
+  if (isServer) {
+    headersOrUserAgent = Vue.prototype.$ssrRequestContext.userAgent || DEFAULT_USER_AGENT
+  } else {
+    headersOrUserAgent = window.navigator.userAgent || DEFAULT_USER_AGENT
+  }
+
+  if (appConfig.device && appConfig.device.appendToInstance && appConfig.device.tests && appConfig.device.tests.length) {
+    const deviceLibrary: any = await import(/* webpackChunkName: "device" */ './logic')
+    let userAgent = typeof headersOrUserAgent === 'string'
+      ? headersOrUserAgent
+      : headersOrUserAgent['user-agent']
+
+    Vue.prototype.$device = deviceLibrary.default(userAgent, appConfig.device.tests)
+    if (userAgent === 'Amazon CloudFront') {
+      if (headersOrUserAgent['cloudfront-is-mobile-viewer'] === 'true') {
+        Vue.prototype.$device.isMobile = true
+        Vue.prototype.$device.isMobileOrTablet = true
+      }
+      if (headersOrUserAgent['cloudfront-is-tablet-viewer'] === 'true') {
+        Vue.prototype.$device.isMobile = false
+        Vue.prototype.$device.isMobileOrTablet = true
+      }
+    }
+    (<any>app).device = Vue.prototype.$device
+  }
+}

--- a/src/modules/device/index.ts
+++ b/src/modules/device/index.ts
@@ -29,6 +29,6 @@ export const DeviceModule: StorefrontModule = async function ({ app, appConfig }
         Vue.prototype.$device.isMobileOrTablet = true
       }
     }
-    (<any>app).device = Vue.prototype.$device
+   (app as any).device  = Vue.prototype.$device
   }
 }

--- a/src/modules/device/logic/index.ts
+++ b/src/modules/device/logic/index.ts
@@ -1,0 +1,69 @@
+// these regular expressions are borrowed from below page.
+// https://stackoverflow.com/questions/11381673/detecting-a-mobile-browser
+
+// eslint-disable-next-line
+const REGEX_MOBILE1 = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i
+
+// eslint-disable-next-line
+const REGEX_MOBILE2 = /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i
+
+// eslint-disable-next-line
+const REGEX_MOBILE_OR_TABLET1 = /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i
+// eslint-disable-next-line
+const REGEX_MOBILE_OR_TABLET2 = /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i
+
+const testers = {
+  isMobile (a) {
+    return REGEX_MOBILE1.test(a) || REGEX_MOBILE2.test(a.substr(0, 4))
+  },
+  
+  isMobileOrTablet (a) {
+    return REGEX_MOBILE_OR_TABLET1.test(a) || REGEX_MOBILE_OR_TABLET2.test(a.substr(0, 4))
+  },
+  
+  isIos (a) {
+    return /iPad|iPhone|iPod/.test(a)
+  },
+  
+  isWindows (a) {
+    return /Windows/.test(a)
+  },
+  
+  isMacOS (a) {
+    return /Mac OS X/.test(a)
+  }
+}
+
+interface DeviceTests {
+  isMobile?: Boolean,
+  isMobileOrTablet?: Boolean,
+  isTablet?: Boolean,
+  isDesktop?: Boolean,
+  isDesktopOrTablet?: Boolean,
+  isIos?: Boolean,
+  isWindows?: Boolean,
+  isMacOS?: Boolean,
+}
+
+export default (userAgent: string, tests: Array<string>): DeviceTests => {
+
+  const deviceTests: DeviceTests = {}
+
+  for (let test of tests) {
+    if (testers[test]) {
+      deviceTests[test] = testers[test](userAgent)
+    } else {
+      switch (test) {
+        case 'isTablet':
+          deviceTests[test] = !testers['isMobile'](userAgent) && !testers['isMobileOrTablet'](userAgent)
+        case 'isDesktop':
+          deviceTests[test] = !testers['isMobileOrTablet'](userAgent)
+        case 'isDesktopOrTablet':
+          deviceTests[test] = !testers['isMobile'](userAgent)
+      }
+    }
+  }
+
+  return deviceTests
+
+}

--- a/src/modules/device/logic/index.ts
+++ b/src/modules/device/logic/index.ts
@@ -55,11 +55,14 @@ export default (userAgent: string, tests: Array<string>): DeviceTests => {
     } else {
       switch (test) {
         case 'isTablet':
-          deviceTests[test] = !testers['isMobile'](userAgent) && !testers['isMobileOrTablet'](userAgent)
+          deviceTests[test] = !testers['isMobile'](userAgent) && !testers['isMobileOrTablet'](userAgent);
+          break;
         case 'isDesktop':
           deviceTests[test] = !testers['isMobileOrTablet'](userAgent)
+          break;
         case 'isDesktopOrTablet':
           deviceTests[test] = !testers['isMobile'](userAgent)
+          break;
       }
     }
   }


### PR DESCRIPTION
### Related issues
<!--  Put related issue number which this PR is closing. For example #123 -->

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

I've just rewritten this: https://github.com/DivanteLtd/vue-storefront/pull/3835
As VSF Module. I set is as built-in and disabled by default.

Based on: https://github.com/nuxt-community/device-module

It provides as some logic helpers based on UserAgent. List of tests:
```
isMobile,
isMobileOrTablet,
isTablet,
isDesktop,
isDesktopOrTablet,
isIos,
isWindows,
isMacOS
```

They are accessible by, e.g::
```
this.$device.isMobile
```
Or in asyncData by (you need to import Vue):
```
Vue.prototype.$device.isMobile
```

We could totally disable this feature by setting `config.device.appendToInstance` to false and the small library will not by imported.

In addition when we are using installer script. I've added multiselect so we could pick which tests we want to have.

I've tested it with `curl -A "some user agent" http://localhost:3000 and it worked.

Some time ago, I've tried to do that only in the template's code. However, with that I had hydration errors because Client was rendering Mobile version and server Desktop version. This PR should solve that Problem and allow us to render components based on Device.

That's obvious we should use media queries whenever we can. However, sometimes we have more advanced structure and we are ending with hidden useless vue instance.

To enable it we have to add in the config:
```
"device": {
    "appendToInstance": true,
    "tests": [
      "isMobile",
      "isDesktop"
    ]
  }
```

As tests we have to provide array of test that we want to make.

### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->
![image](https://user-images.githubusercontent.com/30155292/69376605-d96d1600-0caa-11ea-844a-29041cd183b3.png)
![image](https://user-images.githubusercontent.com/30155292/69376779-3668cc00-0cab-11ea-96bd-706bbc123f02.png)
![image](https://user-images.githubusercontent.com/30155292/69376822-50a2aa00-0cab-11ea-8c09-3b8650bf9df6.png)
![image](https://user-images.githubusercontent.com/30155292/69376881-6fa13c00-0cab-11ea-80ea-de4f8b16bf23.png)


### Which environment this relates to
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog

- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing VS sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

