### PR TITLE
`getVariantWithLowestPrice` uses inexistent `final_price` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added back error notification when user selects invalid configuration - @1070rik (#4033)
 - findConfigurableChildAsync - return best match for configurable variant - @gibkigonzo (#4042)
 - use storeCode for mappingFallback url - @gibkigonzo (#4050)
+- `getVariantWithLowestPrice` uses inexistent `final_price` property - @cewald (#4091)
 
 ### Changed / Improved
 - Optimized `translation.processor` to process only enabled locale CSV files - @pkarw (#3950)

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -37,11 +37,15 @@ export const hasImage = (product) => product && product.image && product.image !
  */
 export const childHasImage = (children = []) => children.some(hasImage)
 
-const getVariantWithLowestPrice = (prevVariant, nextVariant) => (
-  !prevVariant || // if this is first variant
-  !prevVariant.final_price || // prev variant doesn't have final_price
-  nextVariant.price_incl_tax <= prevVariant.price_incl_tax // prev variant price is higher then next
-) ? nextVariant : prevVariant
+const getVariantWithLowestPrice = (prevVariant, nextVariant) => {
+  if (!prevVariant || !prevVariant.original_price_incl_tax) {
+    return nextVariant
+  }
+
+  const prevPrice = prevVariant.price_incl_tax || prevVariant.original_price_incl_tax
+  const nextPrice = nextVariant.price_incl_tax || nextVariant.original_price_incl_tax
+  return nextPrice < prevPrice ? nextVariant : prevVariant
+}
 
 /**
  * Counts how much coniguration match for specific variant


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

With the recent changes (ab03f2d1138fad9c92a0e2166df732c763bdc0a1), there was a `getVariantWithLowestPrice()` added to `core/modules/catalog/helpers/index.ts`.

My question is: why there is the `final_price` property used? I can't find a place where this property is set for child products and therefore this method always returns the last configurable child product.

I have updated this method to use the correct props based on the used fields in `findConfigurableChildAsync`.

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

In my case, always the last configurable product is selected because of this missing property. It should select the lowest one.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

