### PR TITLE
disable mapFallback url by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimized attributes loading - @andrzejewsky (#3948)
 - Improve typescript support for test utils - @resubaka (#4067)
 - Removed `product/loadConfigurableAttributes` calls - @andrzejewsky, @gibkigonzo (#3336)
+- Disable `mapFallback` url by default - @gibkigonzo(#4092)
 
 ## [1.11.1] - 2020.02.05
 

--- a/config/default.json
+++ b/config/default.json
@@ -563,6 +563,7 @@
     }
   },
   "urlModule": {
+    "enableMapFallbackUrl": false,
     "endpoint": "/api/url",
     "map_endpoint": "/api/url/map"
   }

--- a/core/modules/url/store/actions.ts
+++ b/core/modules/url/store/actions.ts
@@ -60,7 +60,8 @@ export const actions: ActionTree<UrlState, any> = {
         if (routeData !== null) {
           return resolve(parametrizeRouteData(routeData, query, storeCodeInPath))
         } else {
-          dispatch('mapFallbackUrl', { url, params: parsedQuery }).then(mappedFallback => {
+          const mappingActionName = config.urlModule.enableMapFallbackUrl ? 'mapFallbackUrl' : 'mappingFallback'
+          dispatch(mappingActionName, { url, params: parsedQuery }).then(mappedFallback => {
             const routeData = getFallbackRouteData({ mappedFallback, url })
             dispatch('registerMapping', { url, routeData }) // register mapping for further usage
             resolve(parametrizeRouteData(routeData, query, storeCodeInPath))
@@ -75,7 +76,10 @@ export const actions: ActionTree<UrlState, any> = {
    * This method could be overriden in custom module to provide custom URL mapping logic
    */
   async mappingFallback ({ dispatch }, { url, params }: { url: string, params: any}) {
-    console.warn('Deprecated action mappingFallback - use mapFallbackUrl instead')
+    console.warn(`
+      Deprecated action mappingFallback - use mapFallbackUrl instead.
+      You can enable mapFallbackUrl by changing 'config.urlModule.enableMapFallbackUrl' to true
+    `)
     const { storeCode, appendStoreCode } = currentStoreView()
     const productQuery = new SearchQuery()
     url = (removeStoreCodeFromRoute(url.startsWith('/') ? url.slice(1) : url) as string)
@@ -152,6 +156,9 @@ export const actions: ActionTree<UrlState, any> = {
           })
         }
       )
+      if (!response.ok) {
+        return null
+      }
       response = await response.json()
       return response
     } catch (err) {


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
I think it's better to disable mapFallback by default in 1.12 and enable it by default in 1.13. This require update api to 1.12 so we shouldn't enforce dev to do that. Same approach as is with `api` and `api-search-query`


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

