### PR TITLE
Fix incorrect root categories when extending includeFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Group 'productChecksum' and 'productsEquals' logic for all supported products types. Remove 'checksum' when editing product.
 Remove and add coupon when user login Remove 'NA' as default company. Show qty in microcart for all types of product.
 Remove preload font - it gives good performance, but vue-meta refresh page, because there is script onload. - @gibkigonzo (pr#4128)
+- Fix incorrect root categories when extending includeFields - @Michal-Dziedzinski (#4090)
 
 ## [1.11.1] - 2020.02.05
 

--- a/core/modules/catalog/helpers/slugifyCategories.ts
+++ b/core/modules/catalog/helpers/slugifyCategories.ts
@@ -3,30 +3,21 @@ import { slugify } from '@vue-storefront/core/helpers'
 import { Category, ChildrenData } from '@vue-storefront/core/modules/catalog-next/types/Category'
 
 const createSlug = (category: ChildrenData): string => {
-  if (category.slug) {
-    return category.slug
-  }
-
   if (category.url_key && config.products.useMagentoUrlKeys) {
     return category.url_key
   }
 
-  if (category.name) {
-    return `${slugify(category.name)}-${category.id}`
-  }
-
-  return ''
+  return `${slugify(category.name)}-${category.id}`
 }
 
 const slugifyCategories = (category: Category | ChildrenData): Category | ChildrenData => {
   if (category.children_data) {
     for (let subcat of category.children_data) {
-      if (subcat.name) {
-        return slugifyCategories({ ...subcat, slug: createSlug(subcat) } as any as ChildrenData)
+      if (subcat.name && !subcat.slug) {
+        slugifyCategories({...subcat, slug: createSlug(subcat)} as any as ChildrenData)
       }
     }
   }
-
   return category
 }
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #4090 

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Fix incorrect root categories when extending includeFields

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

