### PR TITLE
Add inc/dec steps to product qty on product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom currency separators and amount of fraction digits - @EndPositive (#3553)
 - Product Page Schema implementation as JSON-LD - @Michal-Dziedzinski (#3704)
 - Add `/cache-version.json` route to get current cache version
+- Add inc/dec steps to product qty on product page
 
 ### Fixed
 

--- a/src/themes/default/components/core/ProductQuantity.vue
+++ b/src/themes/default/components/core/ProductQuantity.vue
@@ -3,8 +3,9 @@
     <base-input-number
       :name="name"
       :value="value"
-      :min="1"
+      :min="min"
       :max="max"
+      :step="step"
       :disabled="disabled"
       @input="$emit('input', $event)"
       @blur="$v.$touch()"
@@ -44,9 +45,17 @@ export default {
       type: Boolean,
       default: false
     },
+    minQuantity: {
+      type: Number,
+      default: 1
+    },
     maxQuantity: {
       type: Number,
       default: undefined
+    },
+    stepQuantity: {
+      type: Number,
+      default: 1
     },
     checkMaxQuantity: {
       type: Boolean,
@@ -65,12 +74,18 @@ export default {
     isOnline (value) {
       return onlineHelper.isOnline
     },
+    min () {
+      return this.minQuantity
+    },
     max () {
       if (!this.isOnline || !this.isSimpleOrConfigurable) {
         return null
       }
 
       return this.maxQuantity
+    },
+    step () {
+      return this.stepQuantity
     },
     disabled () {
       if (!this.isOnline) {

--- a/src/themes/default/components/core/blocks/Form/BaseInputNumber.vue
+++ b/src/themes/default/components/core/blocks/Form/BaseInputNumber.vue
@@ -6,6 +6,7 @@
       type="number"
       :min="min"
       :max="max"
+      :step="step"
       :disabled="disabled"
       class="m0 no-outline base-input-number__input brdr-cl-primary bg-cl-transparent h4"
       :focus="autofocus"
@@ -35,11 +36,15 @@ export default {
     },
     min: {
       type: Number,
-      default: 0
+      default: 1
     },
     max: {
       type: Number,
       default: undefined
+    },
+    step: {
+      type: Number,
+      default: 1
     },
     disabled: {
       type: Boolean,

--- a/src/themes/default/pages/Product.vue
+++ b/src/themes/default/pages/Product.vue
@@ -112,6 +112,8 @@
               v-if="getCurrentProduct.type_id !== 'grouped' && getCurrentProduct.type_id !== 'bundle'"
               v-model="getCurrentProduct.qty"
               :max-quantity="maxQuantity"
+              :min-quantity="minQuantity"
+              :step-quantity="stepQuantity"
               :loading="isStockInfoLoading"
               :is-simple-or-configurable="isSimpleOrConfigurable"
               :show-quantity="manageQuantity"
@@ -256,6 +258,8 @@ export default {
     return {
       detailsOpen: false,
       maxQuantity: 0,
+      minQuantity: 1,
+      stepQuantity: 1,
       quantityError: false,
       isStockInfoLoading: false,
       hasAttributesLoaded: false,
@@ -407,6 +411,13 @@ export default {
 
         this.manageQuantity = res.isManageStock
         this.maxQuantity = res.isManageStock ? res.qty : null
+        // use 'product.stock.qty_increments' data been loaded from Elasticsearch for min/step values
+        if(this.getCurrentProduct.stock) {
+          this.stepQuantity = this.getCurrentProduct.stock.qty_increments ?? 1
+          this.minQuantity = this.stepQuantity
+        }
+        // current qty (items to be placed into the cart) should not be less than 'min' value
+        if (this.getCurrentProduct.qty < this.minQuantity) this.getCurrentProduct.qty = parseInt(this.minQuantity)
       } finally {
         this.isStockInfoLoading = false
       }


### PR DESCRIPTION
### Short Description and Why It's Useful
Quantity increments are not used for products now. This PR adds steps to product qty input on product page.



### Screenshots of Visual Changes before/after (if There Are Any)
![image](https://user-images.githubusercontent.com/5052385/76965314-c43c8700-692c-11ea-9673-108d370e3ece.png)


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

