### PR TITLE
Fixes bug that caused addToCart action not to display messages to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Update eslint and fix code style. - @gibkigonzo (#4179 #4181)
+- Fixes bug that caused addToCart action not to display messages to user - @juho-jaakkola (#4185)
 - add missing cache tags for category and product - @gibkigonzo (#4173)
 
 ## [1.11.2] - 2020.03.10

--- a/core/modules/cart/store/actions/connectActions.ts
+++ b/core/modules/cart/store/actions/connectActions.ts
@@ -69,7 +69,7 @@ const connectActions = {
     const cartToken = getters['getCartToken']
     if (storedItems.length && !cartToken) {
       Logger.info('Creating server cart token', 'cart')()
-      await dispatch('connect', { guestCart: false })
+      return dispatch('connect', { guestCart: false })
     }
   }
 }

--- a/core/modules/cart/store/actions/itemActions.ts
+++ b/core/modules/cart/store/actions/itemActions.ts
@@ -80,9 +80,18 @@ const itemActions = {
         productIndex++
       }
     }
-    await dispatch('create')
+
+    let newDiffLog = await dispatch('create')
+    if (newDiffLog !== undefined) {
+      diffLog.merge(newDiffLog)
+    }
+
     if (getters.isCartSyncEnabled && getters.isCartConnected && !forceServerSilence) {
-      return dispatch('sync', { forceClientState: true })
+      const syncDiffLog = await dispatch('sync', { forceClientState: true })
+
+      if (!syncDiffLog.isEmpty()) {
+        diffLog.merge(syncDiffLog)
+      }
     }
 
     return diffLog

--- a/core/modules/cart/test/unit/store/itemActions.spec.ts
+++ b/core/modules/cart/test/unit/store/itemActions.spec.ts
@@ -46,7 +46,8 @@ jest.mock('@vue-storefront/core/modules/cart/helpers', () => ({
     createNotifications: jest.fn()
   },
   createDiffLog: () => ({
-    pushNotifications: jest.fn()
+    pushNotifications: jest.fn(),
+    merge: jest.fn()
   })
 }));
 jest.mock('@vue-storefront/core/helpers', () => ({
@@ -140,7 +141,12 @@ describe('Cart itemActions', () => {
       }
     })
 
-    contextMock.dispatch.mockImplementationOnce(() => Promise.resolve({ status: 'ok', onlineCheckTaskId: 1 }))
+    // The third 'dispatch' call gets an instance of DiffLog class, which has the isEmpty() method.
+    // The return value of the second 'dispatch' call is not used at all, so it can be left empty.
+    contextMock.dispatch
+      .mockImplementationOnce(() => Promise.resolve({ status: 'ok', onlineCheckTaskId: 1 }))
+      .mockImplementationOnce(() => Promise.resolve({}))
+      .mockImplementationOnce(() => Promise.resolve({ isEmpty: () => { return true } }))
 
     await (cartActions as any).addItems(contextMock, { productsToAdd: [product] })
     expect(contextMock.commit).toBeCalledWith(types.CART_ADD_ITEM, { product: { ...product, onlineStockCheckid: 1 } })


### PR DESCRIPTION
### Related Issues

closes #4185 

### Short Description and Why It's Useful

The very first time something was added to the cart, the user did not see any messages
("Added to cart", "n items need to be backordered", etc). These were displayed only
on the following times. This commit fixes it so that the messages are displayed also
on the very first action call.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

