### PR TITLE
When having multiple custom options with overlapping option_type_id v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+- Fixes when having multiple custom options with overlapping option_type_id values, selecting 1 changes the others - @carlokok (#4196)
 - Update eslint and fix code style. - @gibkigonzo (#4179 #4181)
 - add missing cache tags for category and product - @gibkigonzo (#4173)
 

--- a/src/themes/default/components/core/ProductCustomOptions.vue
+++ b/src/themes/default/components/core/ProductCustomOptions.vue
@@ -23,11 +23,11 @@
               type="radio"
               class="m0 no-outline"
               :name="('customOption_' + option.option_id)"
-              :id="('customOption_' + opval.option_type_id)"
+              :id="('customOption_' + option.option_id + '_' + opval.option_type_id)"
               focus
               :value="opval.option_type_id"
               v-model="inputValues[('customOption_' + option.option_id)]"
-            ><label class="pl10 lh20 h4 pointer" :for="('customOption_' + opval.option_type_id)" v-html="opval.title" />
+            ><label class="pl10 lh20 h4 pointer" :for="('customOption_' + option.option_id +'_' + opval.option_type_id)" v-html="opval.title" />
           </div>
         </div>
         <div v-if="option.type === 'checkbox'">


### PR DESCRIPTION
### Short Description and Why It's Useful

Currently, when using custom options, the html ids of the radio buttons overlap if the id of their value (option_type_id) is the same. This patch makes the html ids unique, making the option usable independent. 

### Screenshots of Visual Changes before/after (if There Are Any)
![afbeelding](https://user-images.githubusercontent.com/238568/77413421-9ab5ac80-6dbf-11ea-84ec-b56117c7599c.png)

Before, changing geheugenkaart also changes Behuizing, now they work independent. (Custom options json https://gist.github.com/carlokok/db1b40eeb7bc04683736a0a02d4b6281)

### Which Environment This Relates To

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

