### PR TITLE
use same data format in getConfigurationMatchLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Invoking afterCacheInvalidated server hook in a proper moment - @Fifciu (#4176)
 - Fixed `cart/isVirtualCart` to return `false` when cart is empty - @haelbichalex(#4182)
 - Use `setProductGallery` in `product/setCurrent` to use logic of the action - @cewald (#4153)
+- Use same data format in getConfigurationMatchLevel - @gibkigonzo (#4208)
 
 ### Changed / Improved
 

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -55,11 +55,10 @@ const getConfigurationMatchLevel = (configuration, variant): number => {
   const configProperties = Object.keys(omit(configuration, ['price']))
   return configProperties
     .map(configProperty => {
-      const filter = configuration[configProperty]
-      const configurationId = filter && isObject(filter) && filter.id
       const variantPropertyId = variant[configProperty]
-      return (configurationId && variantPropertyId) &&
-        (toString(configurationId) === toString(variantPropertyId))
+      return [].concat(configuration[configProperty])
+        .map((f) => toString(f.id))
+        .includes(variantPropertyId)
     })
     .filter(Boolean)
     .length


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Filters can be array or object, depends on selected single option or multiple option. So this merge type  into array in getConfigurationMatchLevel.



### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

