### PR TITLE
Fix resultPorcessor typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `resultPorcessor` typo - @psmyrek
 - Fixed Search product fails for category filter when categoryId is string - @adityasharma7 (#3929)
 - Revert init filters in Vue app - @gibkigonzo (#3929)
 - All categories disappearing if you add the child category name to includeFields - @1070rik (#4015)

--- a/core/lib/search/adapter/api-search-query/searchAdapter.ts
+++ b/core/lib/search/adapter/api-search-query/searchAdapter.ts
@@ -118,15 +118,15 @@ export class SearchAdapter {
       if (resp.error) {
         throw new Error(JSON.stringify(resp.error))
       } else {
-        throw new Error('Unknown error with API catalog result in resultPorcessor for entity type \'' + type + '\'')
+        throw new Error('Unknown error with API catalog result in resultProcessor for entity type \'' + type + '\'')
       }
     }
   }
 
-  public registerEntityType (entityType, { url = '', url_ssr = '', queryProcessor, resultPorcessor }) {
+  public registerEntityType (entityType, { url = '', url_ssr = '', queryProcessor, resultProcessor }) {
     this.entities[entityType] = {
       queryProcessor: queryProcessor,
-      resultPorcessor: resultPorcessor
+      resultProcessor: resultProcessor
     }
     if (url !== '') {
       this.entities[entityType]['url'] = url
@@ -145,7 +145,7 @@ export class SearchAdapter {
           // function that can modify the query each time before it's being executed
           return query
         },
-        resultPorcessor: (resp, start, size) => {
+        resultProcessor: (resp, start, size) => {
           return this.handleResult(resp, type, start, size)
         }
       })

--- a/docs/guide/data/entity-types.md
+++ b/docs/guide/data/entity-types.md
@@ -27,7 +27,7 @@ searchAdapter.registerEntityTypeByQuery('testentity', {
     // function that can modify the query each time before it's being executed
     return query;
   },
-  resultPorcessor: (resp, start, size) => {
+  resultProcessor: (resp, start, size) => {
     if (resp === null) {
       throw new Error('Invalid graphQl result - null not exepcted');
     }
@@ -38,7 +38,7 @@ searchAdapter.registerEntityTypeByQuery('testentity', {
         throw new Error(JSON.stringify(resp.error));
       } else {
         throw new Error(
-          "Unknown error with graphQl result in resultPorcessor for entity type 'category'",
+          "Unknown error with graphQl result in resultProcessor for entity type 'category'",
         );
       }
     }


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

This PR fixes typo `resultPorcessor` in search adapter for `api-search-query`. When `server.api` is configured to `api-search-query` this typo triggers the following error: `TypeError: searchAdapter.entities[Request.type].resultProcessor is not a function` because there is no `resultProcessor` defined.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->
No visual changes.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

