### PR TITLE
take control over default broswer behavior and use saved category page size to load prev products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes bug that caused addToCart action not to display messages to user - @juho-jaakkola (#4185)
 - add missing cache tags for category and product - @gibkigonzo (#4173)
 - add ssrAppId to avoid second meta render on csr - @gibkigonzo (#4203)
+- take control over default broswer behavior and use saved category page size to load prev products - @gibkigonzo (#4201)
 
 ## [1.11.2] - 2020.03.10
 

--- a/core/helpers/index.ts
+++ b/core/helpers/index.ts
@@ -200,6 +200,9 @@ export const routerHelper = Vue.observable({
 !isServer && window.addEventListener('online', () => { onlineHelper.isOnline = true })
 !isServer && window.addEventListener('offline', () => { onlineHelper.isOnline = false })
 !isServer && window.addEventListener('popstate', () => { routerHelper.popStateDetected = true })
+if (!isServer && 'scrollRestoration' in history) {
+  history.scrollRestoration = 'manual'
+}
 
 /*
   * serial executes Promises sequentially.

--- a/core/helpers/router.ts
+++ b/core/helpers/router.ts
@@ -1,3 +1,4 @@
+import rootStore from '@vue-storefront/core/store';
 import VueRouter, { RouteConfig } from 'vue-router'
 import { RouterManager } from '@vue-storefront/core/lib/router-manager'
 import { ErrorHandler, RawLocation, Route } from 'vue-router/types/router'
@@ -15,14 +16,15 @@ export const createRouter = (): VueRouter => {
   return new VueRouter({
     mode: 'history',
     base: __dirname,
-    scrollBehavior: (to, from, savedPosition) => {
+    scrollBehavior: (to, from) => {
       if (to.hash) {
         return {
           selector: to.hash
         }
       }
-      if (savedPosition) {
-        return savedPosition
+      if (rootStore.getters['url/isBackRoute']) {
+        const { scrollPosition = { x: 0, y: 0 } } = rootStore.getters['url/getCurrentRoute']
+        return scrollPosition
       } else if (to.path !== from.path) { // do not change scroll position when navigating on the same page (ex. change filters)
         return { x: 0, y: 0 }
       }

--- a/core/modules/url/store/getters.ts
+++ b/core/modules/url/store/getters.ts
@@ -1,4 +1,5 @@
 export const getters = {
   getCurrentRoute: (state) => state.currentRoute,
-  isBackRoute: (state) => state.isBackRoute
+  isBackRoute: (state) => state.isBackRoute,
+  getPrevRoute: (state) => state.prevRoute
 }

--- a/core/modules/url/store/mutations.ts
+++ b/core/modules/url/store/mutations.ts
@@ -7,10 +7,10 @@ export const mutations: MutationTree<any> = {
     state.dispatcherMap = Object.assign({}, state.dispatcherMap, { [payload.url]: payload.routeData })
   },
   [types.SET_CURRENT_ROUTE] (state, payload = {}) {
-    state.currentRoute = omit(payload, ['matched'])
+    state.currentRoute = omit({...payload}, ['matched'])
   },
   [types.SET_PREV_ROUTE] (state, payload = {}) {
-    state.prevRoute = omit(payload, ['matched'])
+    state.prevRoute = omit({...payload}, ['matched'])
   },
   [types.IS_BACK_ROUTE] (state, payload) {
     state.isBackRoute = payload

--- a/core/modules/url/test/unit/store/actions.spec.ts
+++ b/core/modules/url/test/unit/store/actions.spec.ts
@@ -8,6 +8,7 @@ const SearchQuery = {
   applyFilter: jest.fn()
 };
 
+jest.mock('@vue-storefront/core/store', () => ({ Module: jest.fn() }))
 jest.mock('@vue-storefront/core/lib/search/searchQuery', () => () =>
   SearchQuery
 );

--- a/core/modules/url/types/UrlState.ts
+++ b/core/modules/url/types/UrlState.ts
@@ -1,11 +1,19 @@
 import { Route } from 'vue-router';
 import { LocalizedRoute } from '@vue-storefront/core/lib/types'
 
+interface UrlModuleRoute extends Partial<Route> {
+  scrollPosition?: {
+    x: number,
+    y: number
+  },
+  categoryPageSize?: number
+}
+
 // This object should represent structure of your modules Vuex state
 // It's a good practice is to name this interface accordingly to the KET (for example mailchimpState)
 export interface UrlState {
   dispatcherMap: { [path: string]: LocalizedRoute},
-  currentRoute: Partial<Route>,
-  prevRoute: Partial<Route>,
+  currentRoute: UrlModuleRoute,
+  prevRoute: UrlModuleRoute,
   isBackRoute: boolean
 }

--- a/src/themes/default/pages/Category.vue
+++ b/src/themes/default/pages/Category.vue
@@ -102,9 +102,8 @@ const composeInitialPageState = async (store, route, forceLoad = false) => {
     const filters = getSearchOptionsFromRouteParams(route.params)
     const cachedCategory = store.getters['category-next/getCategoryFrom'](route.path)
     const currentCategory = cachedCategory && !forceLoad ? cachedCategory : await store.dispatch('category-next/loadCategory', { filters })
-    if (!store.getters['url/isBackRoute']) {
-      await store.dispatch('category-next/loadCategoryProducts', { route, category: currentCategory, pageSize: THEME_PAGE_SIZE })
-    }
+    const pageSize = store.getters['url/isBackRoute'] ? store.getters['url/getCurrentRoute'].categoryPageSize : THEME_PAGE_SIZE
+    await store.dispatch('category-next/loadCategoryProducts', { route, category: currentCategory, pageSize })
     const breadCrumbsLoader = store.dispatch('category-next/loadCategoryBreadcrumbs', { category: currentCategory, currentRouteName: currentCategory.name, omitCurrent: true })
 
     if (isServer) await breadCrumbsLoader


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #4201

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
This change allow to control default browser scroll behavior when user use browser navigation buttons. It's necessary because we need to wait for asyncData in page component and to that moment we can't go to new page because there can be old data and scroll can be in wrong place. Now we save scroll position and use it when page is resolved.


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

