### PR TITLE
Add type check to `getConfigurationMatchLevel` to prevent type exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix overlapping text in PersonalDetails component - @jakubmakielkowski (#4024)
 - Redirect from checkout to home with a proper store code - @Fifciu
 - Added back error notification when user selects invalid configuration - @1070rik (#4033)
-- findConfigurableChildAsync - return best match for configurable variant - @gibkigonzo (#4042)
+- findConfigurableChildAsync - return best match for configurable variant - @gibkigonzo, @cewald (#4042, #4216)
 - use storeCode for mappingFallback url - @gibkigonzo (#4050)
 - `getVariantWithLowestPrice` uses inexistent `final_price` property - @cewald (#4091)
 - Fixed `NOT_ALLOWED_SSR_EXTENSIONS_REGEX` to only match with file extensions having a dot - @haelbichalex (#4100)

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -56,8 +56,12 @@ const getConfigurationMatchLevel = (configuration, variant): number => {
   return configProperties
     .map(configProperty => {
       const variantPropertyId = variant[configProperty]
+      if (configuration[configProperty] === null) {
+        return false
+      }
+
       return [].concat(configuration[configProperty])
-        .map((f) => toString(f.id))
+        .map(f => toString(f.id))
         .includes(variantPropertyId)
     })
     .filter(Boolean)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

This related to the changes of #4042 & #3939.

There are use-cases where the variant properties are null. E.g. if you load a configurable product using the `product/loadProduct` action without specifying a specific variant. The current, new `getConfigurationMatchLevel` method will drop an `TypeError: Cannot read property 'id' of null` exception.

I extended the method to support this behavior.

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Just in-case, prevent this error.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

