### PR TITLE
Pass item_id in addition to SKU/details for cart update/delete action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.0-rc1] - UNRELEASED
 
 ### Added
+- Pass the original item_id when updating/deleting a cart entry @carlokok (#4218)
 - Separating endpoints for CSR/SSR - @Fifciu (#2861)
 - Added short hands for version and help flags - @jamesgeorge007 (#3946)
 - Add `or` operator for Elasticsearch filters in `quickSearchByQuery` and use exists if value is `null` - @cewald (#3960)

--- a/core/modules/cart/helpers/createCartItemForUpdate.ts
+++ b/core/modules/cart/helpers/createCartItemForUpdate.ts
@@ -5,6 +5,7 @@ const createCartItemForUpdate = (clientItem: CartItem, serverItem: any, updateId
   const sku = clientItem.parentSku && config.cart.setConfigurableProductOptions ? clientItem.parentSku : clientItem.sku
   const cartItem = {
     sku,
+    item_id: serverItem ? serverItem.item_id : null,
     qty: mergeQty ? (clientItem.qty + serverItem.qty) : clientItem.qty,
     product_option: clientItem.product_option
   } as any as CartItem


### PR DESCRIPTION
### Related Issues

closes #4218

### Short Description and Why It's Useful
Currently vue-storefront passes sku and the configurable/custom options info to the api when updating or deleting an item. For a custom implementation it would be a lot easier if in addition it could pass item_id, so that server implementations know which item it is exactly, without having to do a deep compare.


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

