### PR TITLE
update getCurrentCartHash after add/remove coupon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add missing cache tags for category and product - @gibkigonzo (#4173)
 - add ssrAppId to avoid second meta render on csr - @gibkigonzo (#4203)
 - take control over default broswer behavior and use saved category page size to load prev products - @gibkigonzo (#4201)
+- update getCurrentCartHash after add/remove coupon - @gibkigonzo (#4220)
 
 ## [1.11.2] - 2020.03.10
 

--- a/core/modules/cart/store/actions/couponActions.ts
+++ b/core/modules/cart/store/actions/couponActions.ts
@@ -1,22 +1,31 @@
 import { CartService } from '@vue-storefront/core/data-resolver'
+import * as types from '@vue-storefront/core/modules/cart/store/mutation-types'
 
 const couponActions = {
-  async removeCoupon ({ getters, dispatch }, { sync = true } = {}) {
+  async removeCoupon ({ getters, dispatch, commit }, { sync = true } = {}) {
     if (getters.canSyncTotals) {
       const { result } = await CartService.removeCoupon()
 
       if (result && sync) {
         await dispatch('syncTotals', { forceServerSync: true })
+
+        // 'getCurrentCartHash' has been changed (it's based on cart items data)
+        // so we need to update it in vuex and StorageManager
+        commit(types.CART_SET_ITEMS_HASH, getters.getCurrentCartHash)
         return result
       }
     }
   },
-  async applyCoupon ({ getters, dispatch }, couponCode) {
+  async applyCoupon ({ getters, dispatch, commit }, couponCode) {
     if (couponCode && getters.canSyncTotals) {
       const { result } = await CartService.applyCoupon(couponCode)
 
       if (result) {
         await dispatch('syncTotals', { forceServerSync: true })
+
+        // 'getCurrentCartHash' has been changed (it's based on cart items data)
+        // so we need to update it in vuex and StorageManager
+        commit(types.CART_SET_ITEMS_HASH, getters.getCurrentCartHash)
       }
       return result
     }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #4220

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
After we add/remove coupon we need to update `current-cart-hash` because cart items has been changed (added or removed discount). Then merge actions should handle rest.


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

