### PR TITLE
Add `vsf-capybara` support as a dependency and extend CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.0-rc1] - UNRELEASED
 
 ### Added
+- Add `vsf-capybara` support as a dependency and extend CLI to support customization - @psmyrek (#4209)
 - Separating endpoints for CSR/SSR - @Fifciu (#2861)
 - Added short hands for version and help flags - @jamesgeorge007 (#3946)
 - Add `or` operator for Elasticsearch filters in `quickSearchByQuery` and use exists if value is `null` - @cewald (#3960)

--- a/core/scripts/installer.js
+++ b/core/scripts/installer.js
@@ -513,7 +513,7 @@ class Storefront extends Abstract {
           backend_dir: this.answers.backend_dir || false
         }
 
-        jsonFile.writeFileSync(TARGET_FRONTEND_CONFIG_FILE, config, {spaces: 2})
+        jsonFile.writeFileSync(TARGET_FRONTEND_CONFIG_FILE, config, {spaces: 2, flag: 'a'})
       } catch (e) {
         reject(new Error('Can\'t create storefront config.'))
       }

--- a/core/scripts/installer.js
+++ b/core/scripts/installer.js
@@ -513,7 +513,7 @@ class Storefront extends Abstract {
           backend_dir: this.answers.backend_dir || false
         }
 
-        jsonFile.writeFileSync(TARGET_FRONTEND_CONFIG_FILE, config, {spaces: 2, flag: 'a'})
+        jsonFile.writeFileSync(TARGET_FRONTEND_CONFIG_FILE, config, {spaces: 2})
       } catch (e) {
         reject(new Error('Can\'t create storefront config.'))
       }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,6 @@
     "inquirer": "^6.3.1",
     "listr": "^0.14.3",
     "replace-in-file": "^4.1.1",
-    "semver-sort": "^0.0.4"
+    "semver": "^7.1.3"
   }
 }

--- a/packages/cli/scripts/install.js
+++ b/packages/cli/scripts/install.js
@@ -178,11 +178,13 @@ module.exports = function (installationDir) {
           taskQueue.push(tasks.cloneVersion)
           if (answers.themeName !== 'classic') {
             taskQueue.push(tasks.cloneTheme)
-            taskQueue.push(tasks.configureTheme)
           }
           if (answers.installation === options.installation.installer) {
             taskQueue.push(tasks.installDeps)
             taskQueue.push(tasks.runInstaller)
+          }
+          if (answers.themeName !== 'classic') {
+            taskQueue.push(tasks.configureTheme)
           }
           new Listr(taskQueue).run(answers)
         })

--- a/packages/cli/scripts/install.js
+++ b/packages/cli/scripts/install.js
@@ -5,7 +5,9 @@ const Listr = require('listr')
 const execa = require('execa')
 const spawn = require('child_process')
 const fs = require('fs')
-const semverSort = require('semver-sort')
+const semverSortDesc = require('semver/functions/rsort')
+const semverSatisfies = require('semver/functions/satisfies')
+const semverCoerce = require('semver/functions/coerce')
 
 module.exports = function (installationDir) {
   installationDir = installationDir || 'vue-storefront'
@@ -17,13 +19,31 @@ module.exports = function (installationDir) {
 
   const options = {
     version: {
-      stable: 'Stable versions (recommended for production)',
-      rc: 'Release Candidates',
-      nightly: 'In development branches (could be unstable!)'
+      stable: 'Stable version (recommended for production)',
+      rc: 'Release Candidate',
+      nightly: 'In development branch (could be unstable!)'
     },
     installation: {
       installer: 'Installer (MacOS/Linux only)',
       manual: 'Manual installation'
+    }
+  }
+
+  const themes = {
+    capybara: {
+      label: 'Capybara - based on Storefront UI',
+      branches: {
+        master: options.version.stable,
+        develop: options.version.nightly
+      },
+      minVsfVersion: '^1.11.0'
+    },
+    classic: {
+      label: 'Classic',
+      branches: {
+        master: options.version.stable
+      },
+      minVsfVersion: '*'
     }
   }
 
@@ -38,23 +58,54 @@ module.exports = function (installationDir) {
         return execa.shell(`git clone --quiet --single-branch --branch ${answers.specificVersion} https://github.com/DivanteLtd/vue-storefront.git ${installationDir} && cd ${installationDir}/core/scripts && git remote rm origin`)
       }
     },
+    cloneTheme: {
+      title: 'Copying Vue Storefront theme',
+      task: answers => execa.shell([
+        `git clone --quiet --single-branch --branch ${answers.themeBranch} https://github.com/DivanteLtd/vsf-${answers.themeName}.git ${installationDir}/src/themes/${answers.themeName}`,
+        `cd ${installationDir}/src/themes/${answers.themeName}`,
+        `git remote rm origin`
+      ].join(' && '))
+    },
+    configureTheme: {
+      title: 'Configuring Vue Storefront theme',
+      task: answers => {
+        const vsfLocalJsonPath = `${installationDir}/config/local.json`
+        const themeLocalJsonPath = `${installationDir}/src/themes/${answers.themeName}/local.json`
+
+        if (fs.existsSync(themeLocalJsonPath)) {
+          try {
+            const vsfLocalJson = fs.existsSync(vsfLocalJsonPath) ? JSON.parse(fs.readFileSync(vsfLocalJsonPath)) : {}
+            const themeLocalJson = JSON.parse(fs.readFileSync(themeLocalJsonPath))
+
+            fs.writeFileSync(vsfLocalJsonPath, JSON.stringify(Object.assign(vsfLocalJson, themeLocalJson), null, 2))
+          } catch (e) {
+            console.error('Problem with parsing or merging local.json configurations', e)
+          }
+        }
+      },
+      skip: answers => {
+        if (!fs.existsSync(`${installationDir}/src/themes/${answers.themeName}/local.json`)) {
+          return 'Missing local.json in theme'
+        }
+      }
+    },
     runInstaller: {
       title: 'Running installer',
-      task: () => spawn.execFileSync('yarn', ['installer'], {stdio: 'inherit', cwd: installationDir})
+      task: () => spawn.execFileSync('yarn', ['installer'], { stdio: 'inherit', cwd: installationDir })
     },
     getStorefrontVersions: {
-      title: 'Check avalilable versions',
+      title: 'Check available versions',
       task: () => execa.stdout('git', ['ls-remote', '--tags', 'https://github.com/DivanteLtd/vue-storefront.git']).then(result => {
-          allTags = result.match(/refs\/tags\/v1.([0-9.]+)(-rc.[0-9])?/gm).map(tag => tag.replace('refs/tags/', ''))
-          allTags = semverSort.desc(allTags)
-          execa.stdout('git', ['ls-remote', '--heads', 'https://github.com/DivanteLtd/vue-storefront.git']).then(branches => {
-            let rcBranches = branches.match(/refs\/heads\/release\/v1.([0-9.]+)/gm).map(tag => tag.replace('refs/heads/', ''))
-            availableBranches = [...rcBranches, ...availableBranches]
-          })
+        allTags = result.match(/refs\/tags\/v1.([0-9.]+)(-rc.[0-9])?/gm).map(tag => tag.replace('refs/tags/', ''))
+        allTags = semverSortDesc(allTags)
+        execa.stdout('git', ['ls-remote', '--heads', 'https://github.com/DivanteLtd/vue-storefront.git']).then(branches => {
+          let rcBranches = branches.match(/refs\/heads\/release\/v1.([0-9.x]+)/gm).map(tag => tag.replace('refs/heads/', ''))
+          availableBranches = [...rcBranches, ...availableBranches]
+        })
       }).catch(e => {
         console.error('Problem with checking versions', e)
       })
-    },
+    }
   }
 
   if (fs.existsSync(installationDir)) {
@@ -81,9 +132,36 @@ module.exports = function (installationDir) {
             message: 'Select specific version',
             choices: function (answers) {
               if (answers.version === options.version.stable) return allTags.filter(tag => !tag.includes('rc')).slice(0, 10)
-              if (answers.version === options.version.rc) return allTags.filter(tag => tag.includes('rc')).slice(0,5)
+              if (answers.version === options.version.rc) return allTags.filter(tag => tag.includes('rc')).slice(0, 5)
               return availableBranches
             }
+          },
+          {
+            type: 'list',
+            name: 'themeName',
+            message: 'Select theme for Vue Storefront',
+            choices: answers => {
+              const isVsfVersionAsBranch = ['master', 'develop'].includes(answers.specificVersion)
+              const selectedVsfVersion = semverCoerce(answers.specificVersion)
+
+              return Object.entries(themes)
+                .filter(([, themeConfig]) => isVsfVersionAsBranch || semverSatisfies(selectedVsfVersion, themeConfig.minVsfVersion, { includePrerelease: true }))
+                .map(([themeName, themeConfig]) => ({
+                  name: themeConfig.label,
+                  value: themeName
+                }))
+            }
+          },
+          {
+            type: 'list',
+            name: 'themeBranch',
+            message: 'Select theme version',
+            choices: answers => Object.entries(themes[answers.themeName].branches)
+              .map(([branchName, branchLabel]) => ({
+                name: branchLabel,
+                value: branchName
+              })),
+            when: answers => answers.themeName !== 'classic'
           },
           {
             type: 'list',
@@ -98,6 +176,10 @@ module.exports = function (installationDir) {
         .then(answers => {
           const taskQueue = []
           taskQueue.push(tasks.cloneVersion)
+          if (answers.themeName !== 'classic') {
+            taskQueue.push(tasks.cloneTheme)
+            taskQueue.push(tasks.configureTheme)
+          }
           if (answers.installation === options.installation.installer) {
             taskQueue.push(tasks.installDeps)
             taskQueue.push(tasks.runInstaller)


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #4209 

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
This PR adds `vsf-capybara` theme as a selectable dependency for `vue-storefront` installation using CLI. CLI makes sure that `vsf-capybara` will be installed only with supported `vue-storefront` version - `^1.11.0`.

Changes in CLI are ready for moving old default theme to separate repository - `vsf-classic` - in task https://github.com/DivanteLtd/vue-storefront/issues/4211. The only changes needed in CLI after `vsf-classic` repository will be created are removing 3 conditions `answers.themeName !== 'classic'`, which currently prevents CLI from attempting to download default a.k.a. `vsf-classic` theme from GitHub, which does not exist yet.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->
#### Installing `vue-storefront` with `vsf-capybara` theme ####
![cli-capybara](https://user-images.githubusercontent.com/56868128/78550205-f2aed300-7803-11ea-979f-ede616ed9c39.gif)


#### Installing `vue-storefront` with old default a.k.a. `vsf-classic` theme ####
For this scenario default theme is not downloaded from GitHub yet, because currently `vue-storefront` has this theme built-in in path `src/themes/default` and `vsf-classic` repository is not created yet. CLI supports this scenario:

![cli-classic](https://user-images.githubusercontent.com/56868128/78550190-ef1b4c00-7803-11ea-9872-c3d1e59006f9.gif)


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

