### PR TITLE
allow empty shipping methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add missing cache tags for category and product - @gibkigonzo (#4173)
 - add ssrAppId to avoid second meta render on csr - @gibkigonzo (#4203)
 - take control over default broswer behavior and use saved category page size to load prev products - @gibkigonzo (#4201)
+- allow empty shipping methods in checkout - @gibkigozno (#4192)
 
 ## [1.11.2] - 2020.03.10
 

--- a/core/modules/cart/store/actions/methodsActions.ts
+++ b/core/modules/cart/store/actions/methodsActions.ts
@@ -60,10 +60,10 @@ const methodsActions = {
     }
   },
   async updateShippingMethods ({ dispatch }, { shippingMethods }) {
-    if (shippingMethods.length > 0) {
-      const newShippingMethods = shippingMethods.map(method => ({ ...method, is_server_method: true }))
-      await dispatch('checkout/replaceShippingMethods', newShippingMethods, { root: true })
-    }
+    const newShippingMethods = shippingMethods
+      .map(method => ({ ...method, is_server_method: true }))
+      .filter(method => !method.hasOwnProperty('available') || method.available)
+    await dispatch('checkout/replaceShippingMethods', newShippingMethods, { root: true })
   },
   async syncShippingMethods ({ getters, rootGetters, dispatch }, { forceServerSync = false }) {
     if (getters.canUpdateMethods && (getters.isTotalsSyncRequired || forceServerSync)) {

--- a/core/modules/cart/test/unit/store/methodsActions.spec.ts
+++ b/core/modules/cart/test/unit/store/methodsActions.spec.ts
@@ -159,4 +159,10 @@ describe('Cart methodsActions', () => {
     await (cartActions as any).updateShippingMethods(contextMock, { shippingMethods: [{ method: 1 }] });
     expect(contextMock.dispatch).toBeCalledWith('checkout/replaceShippingMethods', [{ is_server_method: true, method: 1 }], { root: true })
   })
+
+  it('doesn\'t add not available method', async () => {
+    const contextMock = createContextMock()
+    await (cartActions as any).updateShippingMethods(contextMock, { shippingMethods: [{ method: 1, available: false }] });
+    expect(contextMock.dispatch).toBeCalledWith('checkout/replaceShippingMethods', [], { root: true })
+  })
 });


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #4192

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
This change allows to have empty shipping methods array, also I've added checking if method is available. 


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

