### PR TITLE
omit stock when creating cart hash, it is not needed to compare products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update getCurrentCartHash after add/remove coupon - @gibkigonzo (#4220)
 - update replaceNumberToString, so it will change ONLY numbers to string - @gibkigonzo (#4217)
 - allow empty shipping methods in checkout - @gibkigozno (#4192)
+- omit stock when creating cart hash, it is not needed to compare products - @gibkigozno (#4235)
 
 ## [1.11.2] - 2020.03.10
 

--- a/core/helpers/index.ts
+++ b/core/helpers/index.ts
@@ -7,6 +7,7 @@ import { sha3_224 } from 'js-sha3'
 import store from '@vue-storefront/core/store'
 import { adjustMultistoreApiUrl } from '@vue-storefront/core/lib/multistore'
 import { coreHooksExecutors } from '@vue-storefront/core/hooks';
+import omit from 'lodash-es/omit'
 
 export const processURLAddress = (url: string = '') => {
   if (url.startsWith('/')) return `${config.api.url}${url}`
@@ -222,8 +223,11 @@ export const serial = async promises => {
 }
 
 // helper to calculate the hash of the shopping cart
-export const calcItemsHmac = (items, token) => {
-  return sha3_224(JSON.stringify({ items, token: token }))
+export const calcItemsHmac = (items = [], token) => {
+  return sha3_224(JSON.stringify({
+    items: items.map(item => omit(item, ['stock'])),
+    token: token
+  }))
 }
 
 export function extendStore (moduleName: string | string[], module: any) {


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Right now there may be problem with comparing products as when we add product to cart and go to checkout there is added `stock` to product, and this is saved in LS. Now we can commit new hash after that, but I think that we shouldn't check if products have different stock. 



### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

