### PR TITLE
Add correct type matching to `getConfigurationMatchLevel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Built-in module for detecting device type based on UserAgent with SSR support - @Fifciu
 - Update to `storefront-query-builder` version `1.0.0` - @cewald (#4234)
 - Move generating files from webpack config to script @gibkigonzo (#4236)
+- Add correct type matching to `getConfigurationMatchLevel` - @cewald (#4241)
 
 ### Fixed
 

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -62,7 +62,7 @@ const getConfigurationMatchLevel = (configuration, variant): number => {
 
       return [].concat(configuration[configProperty])
         .map(f => toString(f.id))
-        .includes(variantPropertyId)
+        .includes(toString(variantPropertyId))
     })
     .filter(Boolean)
     .length


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

There are usecases where the property values are either strings or numbers.
By consolidate the type, using `toString` we can prevent that no configurable items are found because the option property-types doesn't match.

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Can cause missing product options.
### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

