### PR TITLE
Support `useSpecificImagePaths` with `useExactUrlsNoProxy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to `storefront-query-builder` version `1.0.0` - @cewald (#4234)
 - Move generating files from webpack config to script @gibkigonzo (#4236)
 - Add correct type matching to `getConfigurationMatchLevel` - @cewald (#4241)
+- Support `useSpecificImagePaths` with `useExactUrlsNoProxy` - @cewald (#4243)
 
 ### Fixed
 

--- a/core/helpers/index.ts
+++ b/core/helpers/index.ts
@@ -47,14 +47,14 @@ export function slugify (text) {
  * @returns {string}
  */
 export function getThumbnailPath (relativeUrl: string, width: number = 0, height: number = 0, pathType: string = 'product'): string {
-  if (config.images.useExactUrlsNoProxy) {
-    return coreHooksExecutors.afterProductThumbnailPathGenerate({ path: relativeUrl, sizeX: width, sizeY: height }).path // this is exact url mode
-  } else {
-    if (config.images.useSpecificImagePaths) {
-      const path = config.images.paths[pathType] !== undefined ? config.images.paths[pathType] : ''
-      relativeUrl = path + relativeUrl
-    }
+  if (config.images.useSpecificImagePaths) {
+    const path = config.images.paths[pathType] !== undefined ? config.images.paths[pathType] : ''
+    relativeUrl = path + relativeUrl
+  }
 
+  if (config.images.useExactUrlsNoProxy) {
+    return coreHooksExecutors.afterProductThumbnailPathGenerate({ path: relativeUrl, sizeX: width, sizeY: height, pathType }).path // this is exact url mode
+  } else {
     let resultUrl
     if (relativeUrl && (relativeUrl.indexOf('://') > 0 || relativeUrl.indexOf('?') > 0 || relativeUrl.indexOf('&') > 0)) relativeUrl = encodeURIComponent(relativeUrl)
     // proxyUrl is not a url base path but contains {{url}} parameters and so on to use the relativeUrl as a template value and then do the image proxy opertions
@@ -69,7 +69,7 @@ export function getThumbnailPath (relativeUrl: string, width: number = 0, height
     }
     const path = relativeUrl && relativeUrl.indexOf('no_selection') < 0 ? resultUrl : config.images.productPlaceholder || ''
 
-    return coreHooksExecutors.afterProductThumbnailPathGenerate({ path, sizeX: width, sizeY: height }).path
+    return coreHooksExecutors.afterProductThumbnailPathGenerate({ path, sizeX: width, sizeY: height, pathType }).path
   }
 }
 

--- a/core/hooks.ts
+++ b/core/hooks.ts
@@ -23,7 +23,7 @@ const {
 const {
   hook: afterProductThumbnailPathGeneratedHook,
   executor: afterProductThumbnailPathGeneratedExecutor
-} = createMutatorHook<{ path: string, sizeX: number, sizeY: number }, { path: string }>()
+} = createMutatorHook<{ path: string, pathType: string, sizeX: number, sizeY: number }, { path: string }>()
 
 /** Only for internal usage in core */
 const coreHooksExecutors = {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Support `useSpecificImagePaths` with `useExactUrlsNoProxy` and add `pathType` to `afterProductThumbnailPathGenerate` hook. You can't combine those two options yet.

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

E.g. I wan't to include a image CDN which should use only relative URL's but should have specific image paths based on type.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

