### PR TITLE
feat: publish canary versions

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,0 +1,25 @@
+name: Publish canary
+on:
+  push:
+    branches:
+      - next
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+          registry-url: https://registry.npmjs.org/
+      - name: Build packages
+        run: |
+          yarn
+          yarn build:core
+      - name: Publish canary version
+        run: |
+          yarn lerna publish --canary --force-publish --yes --preid prealpha --dist-tag canary
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 lerna-debug.log
 .idea
 .vscode
+.npmrc

--- a/packages/about-you/api-client/package.json
+++ b/packages/about-you/api-client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vue-storefront/about-you-api",
   "version": "0.0.1",
+  "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -16,8 +17,5 @@
   },
   "files": [
     "lib/**/*"
-  ],
-  "publishConfig": {
-    "access": "public"
-  }
+  ]
 }

--- a/packages/about-you/composables/package.json
+++ b/packages/about-you/composables/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vue-storefront/about-you",
   "version": "0.0.3",
+  "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -25,9 +26,5 @@
   },
   "files": [
     "lib/**/*"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "gitHead": "8d866340da30761f4f72a6d1b60f78f9665c6738"
+  ]
 }

--- a/packages/boilerplate/api-client/package.json
+++ b/packages/boilerplate/api-client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vue-storefront/boilerplate-api",
   "version": "0.0.1",
+  "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",

--- a/packages/boilerplate/composables/package.json
+++ b/packages/boilerplate/composables/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vue-storefront/boilerplate-composables",
   "version": "0.0.1",
+  "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",

--- a/packages/commercetools/api-client/package.json
+++ b/packages/commercetools/api-client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vue-storefront/commercetools-api",
   "version": "0.0.3",
+  "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -32,6 +33,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "8d866340da30761f4f72a6d1b60f78f9665c6738"
+  }
 }

--- a/packages/commercetools/composables/package.json
+++ b/packages/commercetools/composables/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vue-storefront/commercetools",
   "version": "0.0.3",
+  "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -26,6 +27,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "8d866340da30761f4f72a6d1b60f78f9665c6738"
+  }
 }

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -23,6 +23,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "8d866340da30761f4f72a6d1b60f78f9665c6738"
+  }
 }

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "@vue/composition-api": "^0.4.0",
-    "vue": "^2.6.11",
-    "yarn": "^1.22.0"
+    "vue": "^2.6.11"
   },
   "devDependencies": {
     "@vue/test-utils": "^1.0.0-beta.30",

--- a/packages/core/nuxt-module/package.json
+++ b/packages/core/nuxt-module/package.json
@@ -18,6 +18,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "8d866340da30761f4f72a6d1b60f78f9665c6738"
+  }
 }

--- a/packages/core/theme-module/package.json
+++ b/packages/core/theme-module/package.json
@@ -18,6 +18,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "8d866340da30761f4f72a6d1b60f78f9665c6738"
+  }
 }

--- a/packages/prismic/package.json
+++ b/packages/prismic/package.json
@@ -24,6 +24,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "8d866340da30761f4f72a6d1b60f78f9665c6738"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15271,11 +15271,6 @@ yargs@^7.0.0:
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
 
-yarn@^1.22.0:
-  version "1.22.4"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.4.tgz#01c1197ca5b27f21edc8bc472cd4c8ce0e5a470e"
-  integrity sha512-oYM7hi/lIWm9bCoDMEWgffW8aiNZXCWeZ1/tGy0DWrN6vmzjCXIKu2Y21o8DYVBUtiktwKcNoxyGl/2iKLUNGA==
-
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"


### PR DESCRIPTION
Publishing packages as canary versions.
Every time something is pushed to `next` branch, then changed packages are publishing `canary` release.

Every commit will create a new package with dust-tag `canary`
Example adding package: `yarn add @vue-storefront/core@canary`

If a package should be published then in package.json remove `private: true` attribute and make sure it contains:
```
"publishConfig": {
  "access": "public"
}
```