### PR TITLE
chore: use canary version of core packages

### DIFF
--- a/packages/about-you/composables/package.json
+++ b/packages/about-you/composables/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@vue-storefront/about-you-api": "^0.0.1",
     "@vue/composition-api": "^0.3.4",
-    "@vue-storefront/core": "^2.0.0",
+    "@vue-storefront/core": "2.0.1-prealpha.300",
     "vue": "^2.6.x"
   },
   "devDependencies": {

--- a/packages/boilerplate/api-client/package.json
+++ b/packages/boilerplate/api-client/package.json
@@ -12,7 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@vue-storefront/core": "^2.0.0"
+    "@vue-storefront/core": "2.0.1-prealpha.300"
   },
   "files": [
     "lib/**/*"

--- a/packages/boilerplate/composables/package.json
+++ b/packages/boilerplate/composables/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@vue-storefront/boilerplate-api": "^0.0.1",
-    "@vue-storefront/core": "^2.0.0",
+    "@vue-storefront/core": "2.0.1-prealpha.300",
     "@vue/composition-api": "^0.3.4"
   },
   "files": [

--- a/packages/commercetools/composables/package.json
+++ b/packages/commercetools/composables/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@vue-storefront/commercetools-api": "^0.0.3",
-    "@vue-storefront/core": "^2.0.0",
+    "@vue-storefront/core": "2.0.1-prealpha.300",
     "@vue/composition-api": "^0.3.4",
     "js-cookie": "^2.2.1",
     "vue": "^2.6.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2634,6 +2634,14 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
+"@vue-storefront/core@2.0.1-prealpha.300":
+  version "2.0.1-prealpha.300"
+  resolved "https://registry.yarnpkg.com/@vue-storefront/core/-/core-2.0.1-prealpha.300.tgz#29ef1afa90dd1efb92ecc155b0e77f0899ec411a"
+  integrity sha512-kXvPfJGEnak2FuO7LYbYYyxvVDWmKQl6lGxnxvQu8Dm8Kme+pPQ2zHtLeMQYVKAE1fmPoiq/gYPjFl3GMaTejg==
+  dependencies:
+    "@vue/composition-api" "^0.4.0"
+    vue "^2.6.11"
+
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.0.0.tgz#048fe579958da408fb7a8b2a3ec050b50a661040"


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

use core packages from canary release
