### PR TITLE
omit totals for product comparision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update replaceNumberToString, so it will change ONLY numbers to string - @gibkigonzo (#4217)
 - allow empty shipping methods in checkout - @gibkigozno (#4192)
 - configure products before price update - this is needed to have variant sku as product sku - @gibkigonzo (#4053)
-- omit stock when creating cart hash, it is not needed to compare products - @gibkigozno (#4235)
+- omit stock and totals when creating cart hash, it is not needed to compare products - @gibkigozno (#4235, #4273)
 
 ## [1.11.2] - 2020.03.10
 

--- a/core/helpers/index.ts
+++ b/core/helpers/index.ts
@@ -225,7 +225,9 @@ export const serial = async promises => {
 // helper to calculate the hash of the shopping cart
 export const calcItemsHmac = (items = [], token) => {
   return sha3_224(JSON.stringify({
-    items: items.map(item => omit(item, ['stock'])),
+    // we need to omit those properties because they are loaded async and added to product data
+    // and they are not needed to compare products
+    items: items.map(item => omit(item, ['stock', 'totals'])),
     token: token
   }))
 }


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
After adding coupon we get different data in `totals`, which results in different current-cart-hash in merge actions. We can skip it when comparing products.

Reproduction:
- login
- add product to cart
- add coupon
- go back to homepage
- refresh page


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

