### PR TITLE
chore: fix build command for Windows environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "jest": "^24.9.0",
     "lerna": "^3.15.0",
     "lint-staged": "^10.0.7",
+    "rimraf": "^3.0.2",
     "rollup": "^1.25.2",
     "rollup-plugin-terser": "^5.1.2",
     "rollup-plugin-typescript2": "^0.24.3",

--- a/packages/commercetools/api-client/package.json
+++ b/packages/commercetools/api-client/package.json
@@ -7,7 +7,7 @@
   "module": "lib/index.es.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "rm -rf lib && rollup -c",
+    "build": "rimraf lib && rollup -c",
     "dev": "rollup -c -w",
     "test": "cross-env APP_ENV=test jest --rootDir ."
   },

--- a/packages/commercetools/composables/package.json
+++ b/packages/commercetools/composables/package.json
@@ -7,7 +7,7 @@
   "module": "lib/index.es.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "rollup -c",
+    "build": "rimraf lib && rollup -c",
     "dev": "rollup -c -w",
     "test": "jest"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12480,6 +12480,13 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
This allows to build CT packages on Windows without enforcing to use git bash or WSL while still deleting stale `lib` directory contents.