### PR TITLE
Next: Support Windows paths in addition to unix paths for vsf theme module.

### DIFF
--- a/packages/core/theme-module/index.js
+++ b/packages/core/theme-module/index.js
@@ -22,12 +22,12 @@ module.exports = async function DefaultThemeModule(moduleOptions) {
   const themeComponentsDir = path.join(this.options.rootDir, 'pages');
   const themePagesDir = path.join(this.options.rootDir, 'components');
   const themeHelpersDir = path.join(this.options.rootDir, 'helpers');
-  const themeFiles = getAllFilesFromDir(baseThemeDir).filter(file => !file.includes('/static/'));
+  const themeFiles = getAllFilesFromDir(baseThemeDir).filter(file => !file.includes(path.sep + 'static' + path.sep));
 
   const compileAgnosticTemplate = (filePath) => {
     return compileTemplate(
       path.join(__dirname, filePath),
-      this.options.buildDir.split('.nuxt').pop() + '.theme/' + filePath.split('theme/').pop(),
+      this.options.buildDir.split('.nuxt').pop() + '.theme' + path.sep + filePath.split('theme' + path.sep).pop(),
       {
         apiClient: moduleOptions.apiClient,
         helpers: moduleOptions.helpers,

--- a/packages/core/theme-module/scripts/copyThemeFiles.js
+++ b/packages/core/theme-module/scripts/copyThemeFiles.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const getAllFilesFromDir = require('./getAllFilesFromDir.js');
 const ensureDirectoryExists = require('./ensureDirectoryExists');
 
@@ -9,8 +10,8 @@ async function copyFile(fileDir, outDir) {
   return fs.writeFileSync(outDir, data);
 }
 
-function copyThemeFile(path) {
-  return copyFile(path, path.replace('/theme/', '/theme/.theme/'));
+function copyThemeFile(themePath) {
+  return copyFile(themePath, themePath.replace(path.sep + 'theme' + path.sep, path.sep +'theme' + path.sep + '.theme' + path.sep));
 }
 
 function copyThemeFiles(filesDir) {

--- a/packages/core/theme-module/scripts/getAllFilesFromDir.js
+++ b/packages/core/theme-module/scripts/getAllFilesFromDir.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
-
-const parentDirectory = __dirname.replace(/(\/\w*)$/g, '');
+const path = require('path');
+const parentDirectory = path.resolve(__dirname, '..');
 
 /**
  *
@@ -11,10 +11,10 @@ const parentDirectory = __dirname.replace(/(\/\w*)$/g, '');
 const getAllFilesFromDir = (dirPath, arrayOfFiles = []) => {
   const files = fs.readdirSync(dirPath);
   files.forEach((file) => {
-    if (fs.statSync(dirPath + '/' + file).isDirectory()) {
-      arrayOfFiles = getAllFilesFromDir(dirPath + '/' + file, arrayOfFiles);
+    if (fs.statSync(dirPath + path.sep + file).isDirectory()) {
+      arrayOfFiles = getAllFilesFromDir(dirPath + path.sep + file, arrayOfFiles);
     } else {
-      arrayOfFiles.push((dirPath + '/' + file).split(parentDirectory + '/').pop());
+      arrayOfFiles.push((dirPath + path.sep + file).split(parentDirectory + path.sep).pop());
     }
   });
 


### PR DESCRIPTION
### Short Description and Why It's Useful

Current VSF-Next has some unix specific path logic. This fixes that and makes it work on Windows.


### Which Environment This Relates To

- [x] Next 

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)

Note: there's no changelog in Next yet. But this fixes Windows support.

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

