### PR TITLE
Next: Format subtotal, shipping and totals on OrderReview page

### DIFF
--- a/packages/core/theme-module/theme/pages/Checkout/OrderReview.vue
+++ b/packages/core/theme-module/theme/pages/Checkout/OrderReview.vue
@@ -117,19 +117,19 @@
         <div class="summary__total">
           <SfProperty
             name="Subtotal"
-            :value="totals.subtotal"
+            :value="cartGetters.getFormattedPrice(totals.subtotal)"
             class="sf-property--full-width property"
           />
           <SfProperty
             name="Shipping"
-            :value="checkoutGetters.getShippingMethodPrice(chosenShippingMethod)"
+            :value="cartGetters.getFormattedPrice(checkoutGetters.getShippingMethodPrice(chosenShippingMethod))"
             class="sf-property--full-width property"
           />
         </div>
         <SfDivider />
         <SfProperty
           name="Total price"
-          :value="totals.total"
+          :value="cartGetters.getFormattedPrice(totals.total)"
           class="sf-property--full-width sf-property--large summary__property-total"
         />
         <SfCheckbox v-model="terms" name="terms" class="summary__terms">


### PR DESCRIPTION
### Short Description and Why It's Useful

Small omision in the default template for OrderReview (order details): subtotal, shipping and total didn't use price formatting.

### Screenshots of Visual Changes before/after (if There Are Any)
Before:
![afbeelding](https://user-images.githubusercontent.com/238568/80944699-73082a00-8dea-11ea-9688-ad31753242a8.png)


After:
![afbeelding](https://user-images.githubusercontent.com/238568/80944630-4eac4d80-8dea-11ea-835b-5f4214d56de5.png)


### Which Environment This Relates To

- [x] Next 

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

