### PR TITLE
add typing for asyncData so it does not throw an typescript error in …

### DIFF
--- a/core/scripts/utils/ssr-renderer.ts
+++ b/core/scripts/utils/ssr-renderer.ts
@@ -1,3 +1,4 @@
+import { Context } from './types';
 const fs = require('fs')
 const path = require('path')
 const compile = require('lodash.template')
@@ -9,7 +10,7 @@ const get = require('lodash/get')
 const config = require('config')
 const minify = require('html-minifier').minify
 
-function createRenderer (bundle, clientManifest, template) {
+function createRenderer (bundle, clientManifest, template?) {
   let shouldPreload = () => {}
   let shouldPrefetch = () => {}
   try {
@@ -104,7 +105,7 @@ function initTemplatesCache (config, compileOptions) {
   return templatesCache
 }
 
-function initSSRRequestContext (app, req, res, config) {
+function initSSRRequestContext (app, req, res, config): Context {
   return {
     url: decodeURI(req.url),
     output: {
@@ -134,11 +135,11 @@ function clearContext (context) {
   delete context['meta']
 }
 
-module.exports = {
+export {
   createRenderer,
   initTemplatesCache,
   initSSRRequestContext,
   applyAdvancedOutputProcessing,
-  compileTemplate: compile,
+  compile as compileTemplate,
   clearContext
 }

--- a/core/scripts/utils/types/index.ts
+++ b/core/scripts/utils/types/index.ts
@@ -1,0 +1,23 @@
+import { Express } from 'express'
+
+export interface Context {
+  url: string,
+  output: {
+    prepend: (context: any) => string,
+    append: (context: any) => string,
+    filter: <T>(output: T, context: any) => T,
+    appendHead: (context: any) => string,
+    template: string,
+    cacheTags: Set<any>
+  },
+  server: {
+    app: Express,
+    response: Express.Response,
+    request: Express.Request
+  },
+  meta: any|null,
+  vs: {
+    config: Record<any, any>,
+    storeCode: string
+  }
+}

--- a/core/types/asyncData.d.ts
+++ b/core/types/asyncData.d.ts
@@ -1,0 +1,15 @@
+import Vue from 'vue';
+import { Route } from 'vue-router';
+import { Context } from '@vue-storefront/core/scripts/utils/types'
+
+interface AsyncDataParameter {
+  store: any,
+  route: Route,
+  context?: Context
+}
+
+declare module 'vue/types/options' {
+  interface ComponentOptions<V extends Vue> {
+    asyncData?: ({ store, route, context }: AsyncDataParameter) => Promise<any>
+  }
+}


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Currently when you try to use typescript in components and use asyncData it throws an error as asyncData does not exist in a component. With this typescript knows about that function.  


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

