### PR TITLE
upadate cart hash after sync with backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Use LRU as object contructor based on newest changes in module - @gibkigonzo (#4242)
+- upadate cart hash after sync with backend - @gibkigonzo (#4387)
 
 
 ## [1.11.3] - 2020.04.27

--- a/core/modules/cart/store/actions/synchronizeActions.ts
+++ b/core/modules/cart/store/actions/synchronizeActions.ts
@@ -75,9 +75,10 @@ const synchronizeActions = {
 
     Logger.error(result, 'cart')
     cartHooksExecutors.afterSync(result)
+    commit(types.CART_SET_ITEMS_HASH, getters.getCurrentCartHash)
     return createDiffLog()
   },
-  async stockSync ({ dispatch, commit }, stockTask) {
+  async stockSync ({ dispatch, commit, getters }, stockTask) {
     const product = { sku: stockTask.product_sku }
 
     const cartItem = await dispatch('getItem', { product })
@@ -102,6 +103,7 @@ const synchronizeActions = {
       product: { info: { stock: i18n.t('In stock!') }, sku: stockTask.product_sku, is_in_stock: true }
     })
     EventBus.$emit('cart-after-itemchanged', { item: cartItem })
+    commit(types.CART_SET_ITEMS_HASH, getters.getCurrentCartHash)
   }
 }
 

--- a/core/modules/cart/test/unit/store/synchronizeActions.spec.ts
+++ b/core/modules/cart/test/unit/store/synchronizeActions.spec.ts
@@ -224,7 +224,11 @@ describe('Cart synchronizeActions', () => {
     config.cart = {
       synchronize: false
     }
-    const contextMock = createContextMock();
+    const contextMock = createContextMock({
+      getters: {
+        getCurrentCartHash: 'zyx'
+      }
+    });
 
     (contextMock.dispatch as jest.Mock).mockImplementationOnce(() => product)
 


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
After we made sync with backend we need to update cart hash, because there may be change in cart items. This fix problem with duplicate product in cart:
Steps:
- login
- add product to cart
- logout
- login
- refresh


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

