### PR TITLE
Pass theme options to app instance

### DIFF
--- a/core/app.ts
+++ b/core/app.ts
@@ -17,7 +17,7 @@ import { getApolloProvider } from './scripts/resolvers/resolveGraphQL'
 
 // TODO simplify by removing global mixins, plugins and filters - it can be done in normal 'vue' way
 import { registerTheme } from '@vue-storefront/core/lib/themes'
-import { themeEntry } from 'theme/index.js'
+import { themeEntry, themeOptions } from 'theme/index.js'
 import { registerModules } from '@vue-storefront/core/lib/module'
 import { prepareStoreView, currentStoreView } from '@vue-storefront/core/lib/multistore'
 
@@ -103,15 +103,16 @@ const createApp = async (ssrContext, config, storeCode = null): Promise<{app: Vu
     Vue.filter(key, coreFilters[key])
   })
 
+  const apolloProvider = await getApolloProvider()
+
   let vueOptions = {
     router,
     store,
     i18n,
-    render: h => h(themeEntry)
+    render: h => h(themeEntry),
+    ...apolloProvider ? { provider: apolloProvider } : {},
+    ...themeOptions ? themeOptions : {}
   }
-
-  const apolloProvider = await getApolloProvider()
-  if (apolloProvider) Object.assign(vueOptions, {provider: apolloProvider})
 
   const app = new Vue(vueOptions)
 

--- a/core/build/webpack.base.config.ts
+++ b/core/build/webpack.base.config.ts
@@ -1,3 +1,4 @@
+import { buildLocaleIgnorePattern } from './../i18n/helpers';
 import path from 'path';
 import config from 'config';
 import fs from 'fs';
@@ -48,6 +49,7 @@ const isProd = process.env.NODE_ENV === 'production'
 // todo: usemultipage-webpack-plugin for multistore
 export default {
   plugins: [
+    new webpack.ContextReplacementPlugin(/dayjs[/\\]locale$/, buildLocaleIgnorePattern()),
     new webpack.ProgressPlugin(),
     // new BundleAnalyzerPlugin({
     //   generateStatsFile: true

--- a/core/client-entry.ts
+++ b/core/client-entry.ts
@@ -27,11 +27,7 @@ const invokeClientEntry = async () => {
   await store.dispatch('url/registerDynamicRoutes')
   function _commonErrorHandler (err, reject) {
     if (err.message.indexOf('query returned empty result') > 0) {
-      rootStore.dispatch('notification/spawnNotification', {
-        type: 'error',
-        message: i18n.t('The product, category or CMS page is not available in Offline mode. Redirecting to Home.'),
-        action1: { label: i18n.t('OK') }
-      })
+      Logger.error('[Error-(core/client-entry.ts)] : function_commonErrorHandler -> err', 'client-entry', err)()
       router.push(localizedRoute('/', currentStoreView().storeCode))
     } else {
       rootStore.dispatch('notification/spawnNotification', {

--- a/core/i18n/helpers.ts
+++ b/core/i18n/helpers.ts
@@ -6,7 +6,7 @@ export const currentBuildLocales = (): string[] => {
     ? Object.values(config.storeViews)
       .map((store: any) => store && typeof store === 'object' && store.i18n && store.i18n.defaultLocale)
       .filter(Boolean)
-    : []
+    : config.i18n.availableLocale
   const locales = multistoreLocales.includes(defaultLocale)
     ? multistoreLocales
     : [defaultLocale, ...multistoreLocales]

--- a/core/i18n/helpers.ts
+++ b/core/i18n/helpers.ts
@@ -1,0 +1,29 @@
+import config from 'config'
+
+export const currentBuildLocales = (): string[] => {
+  const defaultLocale = config.i18n.defaultLocale || 'en-US'
+  const multistoreLocales = config.storeViews.multistore
+    ? Object.values(config.storeViews)
+      .map((store: any) => store && typeof store === 'object' && store.i18n && store.i18n.defaultLocale)
+      .filter(Boolean)
+    : []
+  const locales = multistoreLocales.includes(defaultLocale)
+    ? multistoreLocales
+    : [defaultLocale, ...multistoreLocales]
+
+  return locales
+}
+
+export const transformToShortLocales = (locales: string[]): string[] => locales.map(locale => {
+  const separatorIndex = locale.indexOf('-')
+  const shortLocale = separatorIndex ? locale.substr(0, separatorIndex) : locale
+
+  return shortLocale
+})
+
+export const buildLocaleIgnorePattern = (): RegExp => {
+  const locales = transformToShortLocales(currentBuildLocales())
+  const localesRegex = locales.map(locale => `${locale}$`).join('|')
+
+  return new RegExp(localesRegex)
+}

--- a/core/i18n/index.ts
+++ b/core/i18n/index.ts
@@ -28,12 +28,12 @@ function setI18nLanguage (lang: string): string {
 const loadDateLocales = async (lang: string = 'en'): Promise<void> => {
   let localeCode = lang.toLocaleLowerCase()
   try { // try to load full locale name
-    await import(/* webpackChunkName: "dayjs-locales" */ `dayjs/locale/${localeCode}`)
+    await import(/* webpackChunkName: "dayjs-locales-[request]" */ `dayjs/locale/${localeCode}`)
   } catch (e) { // load simplified locale name, example: de-DE -> de
     const separatorIndex = localeCode.indexOf('-')
     if (separatorIndex) {
       localeCode = separatorIndex ? localeCode.substr(0, separatorIndex) : localeCode
-      await import(/* webpackChunkName: "dayjs-locales" */ `dayjs/locale/${localeCode}`)
+      await import(/* webpackChunkName: "dayjs-locales-[request]" */ `dayjs/locale/${localeCode}`)
     }
   }
 }

--- a/core/i18n/scripts/translation.preprocessor.js
+++ b/core/i18n/scripts/translation.preprocessor.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const dsvFormat = require('d3-dsv').dsvFormat
 const dsv = dsvFormat(',')
+const { currentBuildLocales } = require('../helpers')
 
 /**
  *  Converts an Array to an Object
@@ -15,14 +16,18 @@ function convertToObject (array) {
 }
 
 module.exports = function (csvDirectories, config = null) {
+  const currentLocales = currentBuildLocales()
+  const fallbackLocale = 'en-US'
   let messages = {}
   let languages = []
 
+  // get messages from CSV files
   csvDirectories.forEach(directory => {
     fs.readdirSync(directory).forEach(file => {
       const fullFileName = path.join(directory, file)
       const extName = path.extname(fullFileName)
       const baseName = path.posix.basename(file, extName)
+
       if (extName === '.csv') {
         const fileContent = fs.readFileSync(fullFileName, 'utf8')
         if (languages.indexOf(baseName) === -1) {
@@ -34,26 +39,27 @@ module.exports = function (csvDirectories, config = null) {
     })
   })
 
-  languages.forEach((language) => {
-    if (!config || !config.i18n.bundleAllStoreviewLanguages || (config.i18n.bundleAllStoreviewLanguages && language === 'en-US')) {
-      console.debug(`Writing JSON file: ${language}.json`)
-      fs.writeFileSync(path.join(__dirname, '../resource/i18n', `${language}.json`), JSON.stringify(messages[language]))
-    }
-  })
+  // create fallback
+  console.debug(`Writing JSON file fallback: ${fallbackLocale}.json`)
+  fs.writeFileSync(path.join(__dirname, '../resource/i18n', `${fallbackLocale}.json`), JSON.stringify(messages[fallbackLocale]))
 
+  // bundle all messages in one file
   if (config && config.i18n.bundleAllStoreviewLanguages) {
-    const bundledLanguages = { 'en-US': messages['en-US'] } // fallback locale
+    const bundledLanguages = { [fallbackLocale]: messages[fallbackLocale] } // fallback locale
     bundledLanguages[config.i18n.defaultLocale] = messages[config.i18n.defaultLocale] // default locale
-    Object.keys(config.storeViews).forEach((storeCode) => {
-      const store = config.storeViews[storeCode]
-      if (store.hasOwnProperty('storeCode')) {
-        if (!store.disabled && store.i18n) {
-          bundledLanguages[store.i18n.defaultLocale] = messages[store.i18n.defaultLocale]
-        }
-      }
+    currentLocales.forEach((locale) => {
+      bundledLanguages[locale] = messages[locale]
     })
+
+    console.debug(`Writing JSON file multistoreLanguages`)
     fs.writeFileSync(path.join(__dirname, '../resource/i18n', `multistoreLanguages.json`), JSON.stringify(bundledLanguages))
   } else {
+    currentLocales.forEach((language) => {
+      if (language !== fallbackLocale) return // it's already loaded
+      const filePath = path.join(__dirname, '../resource/i18n', `${language}.json`)
+      console.debug(`Writing JSON file: ${language}.json`)
+      fs.writeFileSync(filePath, JSON.stringify(messages[language]))
+    })
     fs.writeFileSync(path.join(__dirname, '../resource/i18n', `multistoreLanguages.json`), JSON.stringify({})) // fix for webpack compilation error in case of `bundleAllStoreviewLanguages` = `false` (#3188)
   }
 }

--- a/core/i18n/scripts/translation.preprocessor.js
+++ b/core/i18n/scripts/translation.preprocessor.js
@@ -55,7 +55,7 @@ module.exports = function (csvDirectories, config = null) {
     fs.writeFileSync(path.join(__dirname, '../resource/i18n', `multistoreLanguages.json`), JSON.stringify(bundledLanguages))
   } else {
     currentLocales.forEach((language) => {
-      if (language !== fallbackLocale) return // it's already loaded
+      if (language === fallbackLocale) return // it's already loaded
       const filePath = path.join(__dirname, '../resource/i18n', `${language}.json`)
       console.debug(`Writing JSON file: ${language}.json`)
       fs.writeFileSync(filePath, JSON.stringify(messages[language]))

--- a/core/pages/Category.js
+++ b/core/pages/Category.js
@@ -248,11 +248,7 @@ export default {
         }
       }).catch(err => {
         if (err.message.indexOf('query returned empty result') > 0) {
-          this.$store.dispatch('notification/spawnNotification', {
-            type: 'error',
-            message: i18n.t('The product, category or CMS page is not available in Offline mode. Redirecting to Home.'),
-            action1: { label: i18n.t('OK') }
-          })
+          Logger.error('[Error-(core/pages/Category.js)] : validateRoute -> err', 'Category', err)()
           this.$router.push(localizedRoute('/', currentStoreView().storeCode))
         }
       })


### PR DESCRIPTION
### Short Description and Why It's Useful
Some plugin needs to be initialized with options passed on to the vue instance during its creation e.g. [Vuetify](https://vuetifyjs.com/en/) library. Theme developers can pass on options to vue instance during its creation which gets merged with the initial vue instance options. 

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

