### PR TITLE
Feature/networks instead host mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The default config file is now in more human-readable format - @juho-jaakkola (#4197)
 - Create only once aside async component - @gibkigonzo (#4229, #4268)
+- Use docker network instead of `network_mode: host` to link this project to the api project (4399)
 
 ### Fixed
 - Fixes when having multiple custom options with overlapping option_type_id values, selecting 1 changes the others - @carlokok (#4196)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Changed / Improved
+- Use docker network instead of `network_mode: host` to link this project to the api project (4399)
 
 
 ### Fixed
@@ -26,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The default config file is now in more human-readable format - @juho-jaakkola (#4197)
 - Create only once aside async component - @gibkigonzo (#4229, #4268)
-- Use docker network instead of `network_mode: host` to link this project to the api project (4399)
 
 ### Fixed
 - Fixes when having multiple custom options with overlapping option_type_id values, selecting 1 changes the others - @carlokok (#4196)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     env_file: docker/vue-storefront/default.env
     environment:
       VS_ENV: dev
-    network_mode: host
     volumes:
       - './babel.config.js:/var/www/babel.config.js'
       - './config:/var/www/config'
@@ -26,5 +25,12 @@ services:
       - './packages:/var/www/packages'
     tmpfs:
       - /var/www/dist
+    networks:
+      - vue-storefront-api_default
     ports:
       - '3000:3000'
+
+networks:
+  vue-storefront-api_default:
+    external: true
+


### PR DESCRIPTION
### Related Issues
- #4399

closes #4399

### Short Description and Why It's Useful
On OS X the current setup is not working as described in #3299. This change would be improve the current setup and use a external docker network in the docker compose specifcation



### Screenshots of Visual Changes before/after (if There Are Any)

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

