### PR TITLE
Support theme configuration via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `vsf-capybara` support as a dependency and extend CLI to support customization - @psmyrek (#4209)
+- Support theme configuration via CLI - @psmyrek (#4395)
 - Allow parent_ids field on product as an alternative to urlpath based breadcrumb navigation (#4219)
 - Pass the original item_id when updating/deleting a cart entry @carlokok (#4218)
 - Separating endpoints for CSR/SSR - @Fifciu (#2861)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
     "fs-extra": "^8.1.0",
     "inquirer": "^6.3.1",
     "listr": "^0.14.3",
+    "lodash": "^4.17.15",
     "replace-in-file": "^4.1.1",
     "semver": "^7.1.3"
   }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #4395 

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
This PR improves theme installation process via CLI. Previously, theme configuration step in CLI installation procedure was just merging `local.json` file (if it exists) from downloaded theme repository with `config/local.json` from Vue Storefront installation directory. This approach was not sufficient for all use cases, becasue it may happen that one and common `config.json` in theme repository is not enough for all possible combinations of Vue Storefront versions.

The improved procedure for theme configuration now checks if in downloaded theme there is:
- `local.config.js` - This file exports a function which is then called from CLI with selected Vue Storefront version. Basing on Vue Storefront version `local.config.js` is able to prepare valid configuration for theme for this particular version.
- `local.json` - This old approach is kept as a fallback scenario - the `local.json` file from theme is just merged with `config/local.json` from Vue Storefront installation directory.


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->
No visual changes - installation process form user perspective is the same as previously.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

