### PR TITLE
Next: Copy language files from themes in addition to the other theme files …

### DIFF
--- a/packages/core/theme-module/index.js
+++ b/packages/core/theme-module/index.js
@@ -19,9 +19,10 @@ module.exports = async function DefaultThemeModule(moduleOptions) {
 
   const baseThemeDir = path.join(__dirname, 'theme');
   const projectLocalThemeDir = this.options.buildDir.replace('.nuxt', '.theme');
-  const themeComponentsDir = path.join(this.options.rootDir, 'pages');
-  const themePagesDir = path.join(this.options.rootDir, 'components');
+  const themeComponentsDir = path.join(this.options.rootDir, 'components');
+  const themePagesDir = path.join(this.options.rootDir, 'pages');
   const themeHelpersDir = path.join(this.options.rootDir, 'helpers');
+  const languageDir = path.join(this.options.rootDir, 'lang');
   const themeFiles = getAllFilesFromDir(baseThemeDir).filter(file => !file.includes(path.sep + 'static' + path.sep));
 
   const compileAgnosticTemplate = (filePath) => {
@@ -41,7 +42,8 @@ module.exports = async function DefaultThemeModule(moduleOptions) {
   await Promise.all([
     copyThemeFiles(themeComponentsDir),
     copyThemeFiles(themePagesDir),
-    copyThemeFiles(themeHelpersDir)
+    copyThemeFiles(themeHelpersDir),
+    copyThemeFiles(languageDir)
   ]);
 
   log.success(`Added ${themeFiles.length} theme file(s) to ${chalk.bold('.theme')} folder`);


### PR DESCRIPTION
…(also: NFC fix for components/pages dir being the wrong way around)

### Short Description and Why It's Useful

Most theme related files are copied, but languages aren't yet. This fixes that and does a typo tweak that fixes the component vs pages, which is for correctness only, since it doesn't affect the result. 

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Next.

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

