### PR TITLE
Bugfix/release 1.12

### DIFF
--- a/core/filters/price.js
+++ b/core/filters/price.js
@@ -34,7 +34,7 @@ export function price (value, storeView) {
 
   const options = { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits };
 
-  let localePrice = Math.abs(value.toLocaleString(defaultLocale, options));
+  let localePrice = Math.abs(value.toLocaleString(defaultLocale, options)).toFixed(2);
 
   if (currencyDecimal !== '' || currencyGroup !== '') {
     localePrice = replaceSeparators(localePrice, { decimal: currencyDecimal, group: currencyGroup }, getLocaleSeparators(defaultLocale));

--- a/core/filters/price.js
+++ b/core/filters/price.js
@@ -27,7 +27,7 @@ export function price (value, storeView) {
   }
   const _storeView = storeView || currentStoreView();
   if (!_storeView.i18n) {
-    return value;
+    return Number(value).toFixed(2)
   }
 
   const { defaultLocale, currencySign, currencyDecimal, currencyGroup, fractionDigits, priceFormat } = _storeView.i18n;

--- a/core/modules/catalog/events.ts
+++ b/core/modules/catalog/events.ts
@@ -76,8 +76,8 @@ export const productAfterCustomoptions = async (payload, store) => {
         priceDeltaInclTax += optionValue.price
       }
       if (optionValue.price_type === 'percent' && optionValue.price !== 0) {
-        priceDelta += ((optionValue.price / 100) * store.getters['product/getCurrentProduct'].original_price)
-        priceDeltaInclTax += ((optionValue.price / 100) * store.getters['product/getCurrentProduct'].original_price_incl_tax)
+        priceDelta += ((optionValue.price / 100) * store.getters['product/getCurrentProduct'].price)
+        priceDeltaInclTax += ((optionValue.price / 100) * store.getters['product/getCurrentProduct'].price_incl_tax)
       }
     }
   })
@@ -86,8 +86,8 @@ export const productAfterCustomoptions = async (payload, store) => {
     {},
     store.getters['product/getCurrentProduct'],
     {
-      price: store.getters['product/getCurrentProduct'].original_price + priceDelta,
-      price_incl_tax: store.getters['product/getCurrentProduct'].original_price_incl_tax + priceDeltaInclTax
+      price: store.getters['product/getCurrentProduct'].price + priceDelta,
+      price_incl_tax: store.getters['product/getCurrentProduct'].price_incl_tax + priceDeltaInclTax
     }
   ), { root: true })
 }

--- a/core/modules/catalog/helpers/associatedProducts/getBundleProductPrice.ts
+++ b/core/modules/catalog/helpers/associatedProducts/getBundleProductPrice.ts
@@ -1,0 +1,15 @@
+import {
+  getBundleOptionsValues,
+  getBundleOptionPrice,
+  getSelectedBundleOptions
+} from '@vue-storefront/core/modules/catalog/helpers/bundleOptions'
+import Product from '@vue-storefront/core/modules/catalog/types/Product';
+
+export default function getBundleProductPrice (product: Product) {
+  const selectedBundleOptions = getSelectedBundleOptions(product)
+  const { price, priceInclTax } = getBundleOptionPrice(
+    getBundleOptionsValues(selectedBundleOptions, product.bundle_options)
+  )
+
+  return { price, priceInclTax }
+}

--- a/core/modules/catalog/helpers/associatedProducts/getGroupedProductPrice.ts
+++ b/core/modules/catalog/helpers/associatedProducts/getGroupedProductPrice.ts
@@ -1,0 +1,8 @@
+import Product, { ProductLink } from '@vue-storefront/core/modules/catalog/types/Product';
+import { getProductLinkPrice } from './getProductLinkPrice';
+
+export default function getGroupedProductPrice (product: Product) {
+  const productLinks: ProductLink[] = (product.product_links || [])
+
+  return getProductLinkPrice(productLinks)
+}

--- a/core/modules/catalog/helpers/associatedProducts/getProductLinkPrice.ts
+++ b/core/modules/catalog/helpers/associatedProducts/getProductLinkPrice.ts
@@ -1,0 +1,36 @@
+import Product from '@vue-storefront/core/modules/catalog/types/Product';
+
+interface BaseProductLink {
+  product?: Product,
+  qty?: number
+}
+
+export const calculateProductLinkPrice = ({ price = 1, priceInclTax = 1, qty = 1 }) => {
+  const product = {
+    price: 0,
+    priceInclTax: 0
+  }
+  const qtyNum = typeof qty === 'string' ? parseInt(qty) : qty
+  if (qtyNum >= 0) {
+    product.price += price * qtyNum
+    product.priceInclTax += priceInclTax * qtyNum
+  }
+  return product
+}
+
+export const getProductLinkPrice = (productLinks: BaseProductLink[]) => productLinks
+  .map((productLink) => {
+    const product = productLink.product || { price: 1, price_incl_tax: 1, priceInclTax: 1 }
+    return calculateProductLinkPrice({
+      price: product.price,
+      priceInclTax: product.price_incl_tax || product.priceInclTax,
+      qty: productLink.qty
+    })
+  })
+  .reduce(
+    (priceDelta, currentPriceDelta) => ({
+      price: currentPriceDelta.price + priceDelta.price,
+      priceInclTax: currentPriceDelta.priceInclTax + priceDelta.priceInclTax
+    }),
+    { price: 0, priceInclTax: 0 }
+  )

--- a/core/modules/catalog/helpers/associatedProducts/setBundleProducts.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setBundleProducts.ts
@@ -3,6 +3,7 @@ import { isBundleProduct } from './..';
 import buildQuery from './buildQuery'
 import setProductLink from './setProductLink'
 import { ProductService } from '@vue-storefront/core/data-resolver/ProductService'
+import getBundleProductPrice from './getBundleProductPrice'
 
 /**
  * This function prepare all product_links for bundle products.
@@ -35,5 +36,10 @@ export default async function setBundleProducts (product: Product, { includeFiel
         setProductLink(productLink, associatedProduct)
       }
     }
+
+    const { price, priceInclTax } = getBundleProductPrice(product)
+    product.price = price
+    product.priceInclTax = priceInclTax
+    product.price_incl_tax = priceInclTax
   }
 }

--- a/core/modules/catalog/helpers/associatedProducts/setGroupedProduct.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setGroupedProduct.ts
@@ -3,6 +3,7 @@ import { isGroupedProduct } from './..';
 import buildQuery from './buildQuery'
 import setProductLink from './setProductLink'
 import { ProductService } from '@vue-storefront/core/data-resolver/ProductService'
+import getGroupedProductPrice from './getGroupedProductPrice'
 
 /**
  * This function prepare all product_links for grouped products.
@@ -32,5 +33,10 @@ export default async function setGroupedProduct (product: Product, { includeFiel
       const associatedProduct = items.find((associatedProduct) => associatedProduct.sku === productLink.linked_product_sku)
       setProductLink(productLink, associatedProduct)
     }
+
+    const { price, priceInclTax } = getGroupedProductPrice(product)
+    product.price = price
+    product.priceInclTax = priceInclTax
+    product.price_incl_tax = priceInclTax
   }
 }

--- a/core/modules/catalog/helpers/associatedProducts/setProductLink.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setProductLink.ts
@@ -10,7 +10,7 @@ import { BundleOptionsProductLink } from '@vue-storefront/core/modules/catalog/t
 export default async function setProductLink (productLink: BundleOptionsProductLink | ProductLink, associatedProduct: Product) {
   if (associatedProduct) {
     productLink.product = preConfigureProduct(associatedProduct)
-    productLink.product.qty = (productLink as BundleOptionsProductLink).qty || 1
+    productLink.product.qty = Number((productLink as BundleOptionsProductLink).qty || '1')
   } else {
     Logger.error('Product not found', (productLink as ProductLink).linked_product_sku || productLink.sku)()
   }

--- a/core/modules/catalog/helpers/transformMetadataToAttributes.ts
+++ b/core/modules/catalog/helpers/transformMetadataToAttributes.ts
@@ -10,7 +10,7 @@ const transformMetadataToAttributes = (attributeMetadata) => attributeMetadata
         if (attr.attribute_id === curr.attribute_id) {
           return {
             ...attr,
-            options: uniqBy([...attr.options, ...curr.options], (obj) => `${obj.label}_${obj.value}`)
+            options: uniqBy([...(attr.options || []), ...(curr.options || [])], (obj) => `${obj.label}_${obj.value}`)
           }
         }
 

--- a/core/modules/catalog/types/BundleOption.ts
+++ b/core/modules/catalog/types/BundleOption.ts
@@ -11,7 +11,7 @@ export interface BundleOption {
 }
 
 export interface BundleOptionsProductLink {
-  id: string,
+  id: string | number,
   sku: string,
   option_id: number,
   qty: number,
@@ -21,4 +21,10 @@ export interface BundleOptionsProductLink {
   price_type?: number,
   can_change_quantity: number,
   product?: Product
+}
+
+export interface SelectedBundleOption {
+  option_id: number,
+  option_qty: number,
+  option_selections: number[]
 }

--- a/core/modules/catalog/types/Product.ts
+++ b/core/modules/catalog/types/Product.ts
@@ -1,6 +1,6 @@
 import { ProductOption } from './ProductConfiguration';
 import { ConfigurableItemOption } from './ConfigurableOption';
-import { BundleOption } from './BundleOption';
+import { BundleOption, SelectedBundleOption } from './BundleOption';
 import { AttributesMetadata } from './Attribute';
 import { CustomOption } from './CustomOption';
 
@@ -90,6 +90,6 @@ export interface ProductOptions {
   extension_attributes: {
     custom_options: any[],
     configurable_item_options: ConfigurableItemOption[],
-    bundle_options: any[]
+    bundle_options: SelectedBundleOption[]
   }
 }

--- a/core/modules/checkout/components/Shipping.ts
+++ b/core/modules/checkout/components/Shipping.ts
@@ -121,7 +121,7 @@ export const Shipping = {
     },
     useMyAddress () {
       if (this.shipToMyAddress) {
-        this.shipping = {
+        this.$set(this, 'shipping', {
           firstName: this.myAddressDetails.firstname,
           lastName: this.myAddressDetails.lastname,
           country: this.myAddressDetails.country_id,
@@ -133,9 +133,9 @@ export const Shipping = {
           phoneNumber: this.myAddressDetails.telephone,
           shippingMethod: this.checkoutShippingDetails.shippingMethod,
           shippingCarrier: this.checkoutShippingDetails.shippingCarrier
-        }
+        })
       } else {
-        this.shipping = this.checkoutShippingDetails
+        this.$set(this, 'shipping', this.checkoutShippingDetails)
       }
       this.changeCountry()
     },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "redis-tag-cache": "^1.2.1",
     "reflect-metadata": "^0.1.12",
     "register-service-worker": "^1.5.2",
-    "storefront-query-builder": "^1.0.0",
+    "storefront-query-builder": "https://github.com/DivanteLtd/storefront-query-builder.git",
     "ts-node": "^8.6.2",
     "vue": "^2.6.11",
     "vue-analytics": "^5.16.1",


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
- add two numbers after dot to price by default
- calculate default price for bundle or grouped main product
- update typing
- add fallback to attribute options

TODO:
- publish storefront-query-builder to 1.0.1


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

