### PR TITLE
Next: Switch to acceptLanguage for fetching localised fields from commercetools

### DIFF
--- a/packages/commercetools/api-client/__tests__/api/createCart/createCart.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/createCart/createCart.spec.ts
@@ -5,6 +5,7 @@ import defaultMutation from '../../../src/api/createCart/defaultMutation';
 describe('[commercetools-api-client] createCart', () => {
   it('creates a new cart with draft', async () => {
     const givenVariables = {
+      acceptLanguage: ['en', 'de'],
       locale: 'en',
       draft: {
         currency: 'USD',
@@ -38,6 +39,7 @@ describe('[commercetools-api-client] createCart', () => {
 
   it('creates a new cart without draft', async () => {
     const givenVariables = {
+      acceptLanguage: ['en', 'de'],
       locale: 'en',
       draft: {
         currency: 'USD'

--- a/packages/commercetools/api-client/__tests__/api/createMyOrderFromCart/createMyOrderFromCart.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/createMyOrderFromCart/createMyOrderFromCart.spec.ts
@@ -11,6 +11,7 @@ describe('[commercetools-api-client] createMyOrderFromCart', () => {
         id: '123123',
         version: 2
       },
+      acceptLanguage: ['en', 'de'],
       locale: 'en'
     };
 

--- a/packages/commercetools/api-client/__tests__/api/customerSignMeIn/customerSignMeIn.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/customerSignMeIn/customerSignMeIn.spec.ts
@@ -14,6 +14,7 @@ describe('[commercetools-api-client] customerSignMeIn', () => {
         email: 'john@doe.com',
         password: 'xxxxx'
       },
+      acceptLanguage: ['en', 'de'],
       locale: 'en'
     };
 

--- a/packages/commercetools/api-client/__tests__/api/customerSignMeUp/customerSignMeUp.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/customerSignMeUp/customerSignMeUp.spec.ts
@@ -13,6 +13,7 @@ describe('[commercetools-api-client] customerSignMeUp', () => {
         email: 'john@doe.com',
         password: 'xxxxx'
       },
+      acceptLanguage: ['en', 'de'],
       locale: 'en'
     };
 

--- a/packages/commercetools/api-client/__tests__/api/getCart/getCart.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/getCart/getCart.spec.ts
@@ -5,6 +5,7 @@ import defaultQuery from '../../../src/api/getCart/defaultQuery';
 describe('[commercetools-api-client] getCart', () => {
   it('fetches cart', async () => {
     const givenVariables = {
+      acceptLanguage: ['en', 'de'],
       locale: 'en',
       cartId: 'cart id'
     };

--- a/packages/commercetools/api-client/__tests__/api/getCategory/getCategory.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/getCategory/getCategory.spec.ts
@@ -6,7 +6,7 @@ import defaultQuery from '../../../src/api/getCategory/defaultQuery';
 describe('[commercetools-api-client] getCategory', () => {
   it('fetches categories without search parameters', async () => {
     const givenVariables = {
-      locale: 'en'
+      acceptLanguage: ['en', 'de']
     };
 
     (apolloClient.query as any).mockImplementation(({ variables, query }) => {
@@ -24,7 +24,7 @@ describe('[commercetools-api-client] getCategory', () => {
   it('fetches categories with default query', async () => {
     const givenVariables = {
       where: 'id="724b250d-9805-4657-ae73-3c02a63a9a13"',
-      locale: 'en'
+      acceptLanguage: ['en', 'de']
     };
 
     (apolloClient.query as any).mockImplementation(({ variables, query }) => {
@@ -42,18 +42,18 @@ describe('[commercetools-api-client] getCategory', () => {
   it('fetches categories with customized query', async () => {
     const givenVariables = {
       where: 'test',
-      locale: 'de'
+      acceptLanguage: ['de', 'en']
     };
 
     const givenQuery = `
-      query categories($where: String, $sort: [String!], $limit: Int, $offset: Int, $locale: Locale) {
+      query categories($where: String, $sort: [String!], $limit: Int, $offset: Int, $acceptLanguage: [Locale!]) {
         categories(where: $where, sort: $sort, limit: $limit, offset: $offset) {
           offset
           count
           total
           results {
             id
-            name(locale: $locale)
+            name(acceptLanguage: $acceptLanguage)
           }
         }
       }

--- a/packages/commercetools/api-client/__tests__/api/getMe/getMe.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/getMe/getMe.spec.ts
@@ -5,6 +5,7 @@ import { basicProfile } from '../../../src/api/getMe/defaultQuery';
 describe('[commercetools-api-client] getMe', () => {
   it('fetches current user data', async () => {
     const givenVariables = {
+      acceptLanguage: ['en', 'de'],
       locale: 'en'
     };
 

--- a/packages/commercetools/api-client/__tests__/api/getMyOrders/getMyOrders.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/getMyOrders/getMyOrders.spec.ts
@@ -11,6 +11,7 @@ describe('[commercetools-api-client] getMyOrders', () => {
       offset: 0
     };
     const givenVariables = {
+      acceptLanguage: ['en', 'de'],
       locale: 'en',
       where: 'id="fvdrt8gaw4r"',
       limit: 10,

--- a/packages/commercetools/api-client/__tests__/api/getProducts/getProducts.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/getProducts/getProducts.spec.ts
@@ -7,6 +7,7 @@ describe('[commercetools-api-client] getProduct', () => {
   it('fetches product with default query', async () => {
     const givenVariables = {
       where: 'masterData(current(categories(id in ("724b250d-9805-4657-ae73-3c02a63a9a13"))))',
+      acceptLanguage: ['en', 'de'],
       locale: 'en',
       currency: 'USD',
       country: 'UK'
@@ -27,7 +28,7 @@ describe('[commercetools-api-client] getProduct', () => {
   it('fetches product with customized query', async () => {
     const givenVariables = {
       where: 'test',
-      locale: 'de',
+      acceptLanguage: ['de', 'en'],
       currency: 'eur'
     };
 
@@ -38,7 +39,7 @@ describe('[commercetools-api-client] getProduct', () => {
         $limit: Int
         $offset: Int
         $skus: [String!]
-        $locale: Locale
+        $acceptLanguage: [Locale!]
         $currency: Currency!
       ) {
         products(where: $where, sort: $sort, limit: $limit, offset: $offset, skus: $skus) {

--- a/packages/commercetools/api-client/__tests__/api/updateCart/updateCart.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/updateCart/updateCart.spec.ts
@@ -11,6 +11,7 @@ describe('[commercetools-api-client] updateCart', () => {
 
   it('updates cart', async () => {
     const givenVariables = {
+      acceptLanguage: ['en', 'de'],
       locale: 'en',
       id: 'cart id',
       version: 1,

--- a/packages/commercetools/api-client/__tests__/helpers/search.spec.ts
+++ b/packages/commercetools/api-client/__tests__/helpers/search.spec.ts
@@ -33,11 +33,11 @@ describe('[commercetools-api-client] search', () => {
   });
 
   it('returns category search query by slug', () => {
-    expect(buildCategoryWhere({ slug: 'cat slug' })).toBe('slug(en="cat slug")');
+    expect(buildCategoryWhere({ slug: 'cat slug' })).toBe('slug(en="cat slug" or de="cat slug")');
   });
 
   it('returns product search query by slug', () => {
-    expect(buildProductWhere({ slug: 'product-slug' })).toBe('masterData(current(slug(en="product-slug")))');
+    expect(buildProductWhere({ slug: 'product-slug' })).toBe('masterData(current(slug(en="product-slug" or de="product-slug")))');
   });
 
   it('returns product search query by id', () => {

--- a/packages/commercetools/api-client/__tests__/setup.ts
+++ b/packages/commercetools/api-client/__tests__/setup.ts
@@ -10,6 +10,7 @@ jest.mock('./../src/helpers/createAccessToken', () => jest.fn());
 setup({
   api: {} as any,
   locale: 'en',
+  acceptLanguage: ['en', 'de'],
   currency: 'USD',
   country: 'UK',
   cookies: {

--- a/packages/commercetools/api-client/src/api/createCart/defaultMutation.ts
+++ b/packages/commercetools/api-client/src/api/createCart/defaultMutation.ts
@@ -4,7 +4,7 @@ import { CartFragment } from './../../fragments';
 export default gql`
   ${CartFragment}
 
-  mutation createCart($draft: MyCartDraft!, $locale: Locale!, $storeKey: KeyReferenceInput) {
+  mutation createCart($draft: MyCartDraft!, $locale: Locale!, $acceptLanguage: [Locale!], $storeKey: KeyReferenceInput) {
     cart: createMyCart(draft: $draft, storeKey: $storeKey) {
       ...DefaultCart
     }

--- a/packages/commercetools/api-client/src/api/createCart/index.ts
+++ b/packages/commercetools/api-client/src/api/createCart/index.ts
@@ -1,5 +1,5 @@
 import { CartDraft } from './../../types/GraphQL';
-import { apolloClient, locale, currency } from './../../index';
+import { apolloClient, locale, acceptLanguage, currency } from './../../index';
 import CreateCartMutation from './defaultMutation';
 import { CartMutationResponse } from './../../types/Api';
 
@@ -11,6 +11,7 @@ const createCart = async (cartDraft: CartData = {}): Promise<CartMutationRespons
   return await apolloClient.mutate({
     mutation: CreateCartMutation,
     variables: {
+      acceptLanguage,
       locale,
       draft: {
         currency,

--- a/packages/commercetools/api-client/src/api/createMyOrderFromCart/defaultMutation.ts
+++ b/packages/commercetools/api-client/src/api/createMyOrderFromCart/defaultMutation.ts
@@ -4,7 +4,7 @@ import { OrderFragment } from '../../fragments';
 export default gql`
   ${OrderFragment}
 
-  mutation createMyOrderFromCart($draft: OrderMyCartCommand!, $locale: Locale!, $storeKey: KeyReferenceInput) {
+  mutation createMyOrderFromCart($draft: OrderMyCartCommand!, $locale: Locale!, $acceptLanguage: [Locale!], $storeKey: KeyReferenceInput) {
     order: createMyOrderFromCart(draft: $draft, storeKey: $storeKey) {
       ...DefaultOrder
     }

--- a/packages/commercetools/api-client/src/api/createMyOrderFromCart/index.ts
+++ b/packages/commercetools/api-client/src/api/createMyOrderFromCart/index.ts
@@ -1,5 +1,5 @@
 import { OrderMyCartCommand } from '../../types/GraphQL';
-import { apolloClient, locale } from '../../index';
+import { apolloClient, locale, acceptLanguage } from '../../index';
 import CreateMyOrderFromCartMutation from './defaultMutation';
 import { OrderMutationResponse } from '../../types/Api';
 
@@ -7,6 +7,7 @@ const createMyOrderFromCart = async (draft: OrderMyCartCommand): Promise<OrderMu
   return await apolloClient.mutate({
     mutation: CreateMyOrderFromCartMutation,
     variables: { locale,
+      acceptLanguage,
       draft },
     fetchPolicy: 'no-cache'
   });

--- a/packages/commercetools/api-client/src/api/customerSignMeIn/defaultMutation.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeIn/defaultMutation.ts
@@ -5,7 +5,7 @@ export default gql`
   ${CustomerFragment}
   ${CartFragment}
 
-  mutation customerSignMeIn($draft: CustomerSignMeInDraft!, $locale: Locale!, $storeKey: KeyReferenceInput) {
+  mutation customerSignMeIn($draft: CustomerSignMeInDraft!, $locale: Locale!, $acceptLanguage: [Locale!], $storeKey: KeyReferenceInput) {
     user: customerSignMeIn(draft: $draft, storeKey: $storeKey) {
       customer {
         ...DefaultCustomer

--- a/packages/commercetools/api-client/src/api/customerSignMeIn/index.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeIn/index.ts
@@ -1,5 +1,5 @@
 import { CustomerSignMeInDraft } from '../../types/GraphQL';
-import { apolloClient, locale, currentToken, auth } from '../../index';
+import { apolloClient, locale, acceptLanguage, currentToken, auth } from '../../index';
 import CustomerSignMeInMutation from './defaultMutation';
 import { SignInResponse } from './../../types/Api';
 import createAccessToken from './../../helpers/createAccessToken';
@@ -7,7 +7,7 @@ import createAccessToken from './../../helpers/createAccessToken';
 const customerSignMeIn = async (draft: CustomerSignMeInDraft): Promise<SignInResponse> => {
   const loginResponse = await apolloClient.mutate({
     mutation: CustomerSignMeInMutation,
-    variables: { draft, locale },
+    variables: { draft, locale, acceptLanguage },
     fetchPolicy: 'no-cache'
   }) as SignInResponse;
 

--- a/packages/commercetools/api-client/src/api/customerSignMeUp/defaultMutation.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeUp/defaultMutation.ts
@@ -5,7 +5,7 @@ export default gql`
   ${CustomerFragment}
   ${CartFragment}
 
-  mutation customerSignMeUp($draft: CustomerSignMeUpDraft!, $locale: Locale!, $storeKey: KeyReferenceInput) {
+  mutation customerSignMeUp($draft: CustomerSignMeUpDraft!, $locale: Locale!, $acceptLanguage: [Locale!], $storeKey: KeyReferenceInput) {
     user: customerSignMeUp(draft: $draft, storeKey: $storeKey) {
       customer {
         ...DefaultCustomer

--- a/packages/commercetools/api-client/src/api/customerSignMeUp/index.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeUp/index.ts
@@ -1,5 +1,5 @@
 import { CustomerSignMeUpDraft } from './../../types/GraphQL';
-import { apolloClient, locale, currentToken, auth } from './../../index';
+import { apolloClient, locale, acceptLanguage, currentToken, auth } from './../../index';
 import CustomerSignMeUpMutation from './defaultMutation';
 import { SignInResponse } from './../../types/Api';
 import createAccessToken from './../../helpers/createAccessToken';
@@ -7,7 +7,7 @@ import createAccessToken from './../../helpers/createAccessToken';
 const customerSignMeUp = async (draft: CustomerSignMeUpDraft): Promise<SignInResponse> => {
   const registerResponse = await apolloClient.mutate({
     mutation: CustomerSignMeUpMutation,
-    variables: { draft, locale },
+    variables: { draft, locale, acceptLanguage },
     fetchPolicy: 'no-cache'
   }) as SignInResponse;
 

--- a/packages/commercetools/api-client/src/api/getCart/defaultQuery.ts
+++ b/packages/commercetools/api-client/src/api/getCart/defaultQuery.ts
@@ -4,7 +4,7 @@ import { CartFragment } from './../../fragments';
 export default gql`
   ${CartFragment}
 
-  query getCart($cartId: String!, $locale: Locale!) {
+  query getCart($cartId: String!, $locale: Locale!, $acceptLanguage: [Locale!]) {
     cart(id: $cartId) {
       ...DefaultCart
     }

--- a/packages/commercetools/api-client/src/api/getCart/index.ts
+++ b/packages/commercetools/api-client/src/api/getCart/index.ts
@@ -1,4 +1,4 @@
-import { apolloClient, locale } from './../../index';
+import { apolloClient, locale, acceptLanguage } from './../../index';
 import { CartQueryResponse } from './../../types/Api';
 import defaultQuery from './defaultQuery';
 
@@ -6,7 +6,8 @@ const getCart = async (cartId: string): Promise<CartQueryResponse> => {
   return await apolloClient.query({
     query: defaultQuery,
     variables: { cartId,
-      locale },
+      locale,
+      acceptLanguage },
     fetchPolicy: 'no-cache'
   });
 };

--- a/packages/commercetools/api-client/src/api/getCategory/defaultQuery.ts
+++ b/packages/commercetools/api-client/src/api/getCategory/defaultQuery.ts
@@ -3,15 +3,15 @@ import gql from 'graphql-tag';
 export default gql`
   fragment Children on Category {
     id
-    slug(locale: $locale)
-    name(locale: $locale)
+    slug(acceptLanguage: $acceptLanguage)
+    name(acceptLanguage: $acceptLanguage)
     childCount
   }
 
   fragment DefaultCategory on Category {
     id
-    slug(locale: $locale)
-    name(locale: $locale)
+    slug(acceptLanguage: $acceptLanguage)
+    name(acceptLanguage: $acceptLanguage)
     childCount
     children {
       ...Children
@@ -24,16 +24,16 @@ export default gql`
     }
   }
 
-  query categories($where: String, $sort: [String!], $limit: Int, $offset: Int, $locale: Locale) {
+  query categories($where: String, $sort: [String!], $limit: Int, $offset: Int, $acceptLanguage: [Locale!]) {
     categories(where: $where, sort: $sort, limit: $limit, offset: $offset) {
       offset
       count
       total
       results {
         id
-        slug(locale: $locale)
-        name(locale: $locale)
-        description(locale: $locale)
+        slug(acceptLanguage: $acceptLanguage)
+        name(acceptLanguage: $acceptLanguage)
+        description(acceptLanguage: $acceptLanguage)
         childCount
         parent {
           ...DefaultCategory

--- a/packages/commercetools/api-client/src/api/getCategory/index.ts
+++ b/packages/commercetools/api-client/src/api/getCategory/index.ts
@@ -1,6 +1,6 @@
 import { ApolloQueryResult } from 'apollo-client';
 import gql from 'graphql-tag';
-import { apolloClient, locale } from './../../index';
+import { apolloClient, acceptLanguage } from './../../index';
 import { CategorySearch } from './../../types/Api';
 import { CategoryQueryResult } from './../../types/GraphQL';
 import defaultQuery from './defaultQuery';
@@ -14,7 +14,7 @@ const getCategory = async (search?: CategorySearch): Promise<ApolloQueryResult<C
   if (!search) {
     return await apolloClient.query<CategoryData>({
       query: defaultQuery,
-      variables: { locale }
+      variables: { acceptLanguage }
     });
   }
 
@@ -33,7 +33,7 @@ const getCategory = async (search?: CategorySearch): Promise<ApolloQueryResult<C
       where: buildCategoryWhere(search),
       limit: search.limit,
       offset: search.offset,
-      locale
+      acceptLanguage
     }
   });
 };

--- a/packages/commercetools/api-client/src/api/getMe/defaultQuery.ts
+++ b/packages/commercetools/api-client/src/api/getMe/defaultQuery.ts
@@ -4,7 +4,7 @@ import { CartFragment, CustomerFragment } from './../../fragments';
 const basicProfile = gql`
   ${CartFragment}
 
-  query getMe($locale: Locale!) {
+  query getMe($locale: Locale!, $acceptLanguage: [Locale!]) {
     me {
       activeCart {
         ...DefaultCart
@@ -17,7 +17,7 @@ const fullProfile = gql`
   ${CartFragment}
   ${CustomerFragment}
 
-  query getMe($locale: Locale!) {
+  query getMe($locale: Locale!, $acceptLanguage: [Locale!]) {
     me {
       activeCart {
         ...DefaultCart

--- a/packages/commercetools/api-client/src/api/getMe/index.ts
+++ b/packages/commercetools/api-client/src/api/getMe/index.ts
@@ -1,4 +1,4 @@
-import { apolloClient, locale } from './../../index';
+import { apolloClient, locale, acceptLanguage } from './../../index';
 import { ProfileResponse } from './../../types/Api';
 import { basicProfile, fullProfile } from './defaultQuery';
 
@@ -9,7 +9,7 @@ interface Options {
 const getMe = async (options: Options = {}): Promise<ProfileResponse> => {
   return await apolloClient.query({
     query: options.customer ? fullProfile : basicProfile,
-    variables: { locale },
+    variables: { locale, acceptLanguage },
     fetchPolicy: 'no-cache'
   });
 };

--- a/packages/commercetools/api-client/src/api/getMyOrders/defaultQuery.ts
+++ b/packages/commercetools/api-client/src/api/getMyOrders/defaultQuery.ts
@@ -4,7 +4,7 @@ import { OrderFragment } from './../../fragments';
 export default gql`
   ${OrderFragment}
 
-  query getMe($where: String, $sort: [String!], $limit: Int, $offset: Int, $locale: Locale!) {
+  query getMe($where: String, $sort: [String!], $limit: Int, $offset: Int, $locale: Locale!, $acceptLanguage: [Locale!]) {
     me {
       orders(where: $where, sort: $sort, limit: $limit, offset: $offset) {
         results {

--- a/packages/commercetools/api-client/src/api/getMyOrders/index.ts
+++ b/packages/commercetools/api-client/src/api/getMyOrders/index.ts
@@ -1,4 +1,4 @@
-import { apolloClient, locale } from './../../index';
+import { apolloClient, locale, acceptLanguage } from './../../index';
 import defaultQuery from './defaultQuery';
 import { buildOrderWhere } from './../../helpers/search';
 import { OrderSearch, ProfileResponse } from './../../types/Api';
@@ -11,6 +11,7 @@ export default async (search: OrderSearch): Promise<ProfileResponse> => {
       sort: search.sort,
       limit: search.limit,
       offset: search.offset,
+      acceptLanguage,
       locale
     },
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/api/getProduct/defaultQuery.ts
+++ b/packages/commercetools/api-client/src/api/getProduct/defaultQuery.ts
@@ -75,6 +75,7 @@ export default gql`
     $offset: Int
     $skus: [String!]
     $locale: Locale!
+    $acceptLanguage: [Locale!]
     $currency: Currency!
     $country: Country!
   ) {
@@ -92,12 +93,12 @@ export default gql`
         id
         masterData {
           current {
-            slug(locale: $locale)
-            name(locale: $locale)
-            metaTitle(locale: $locale)
-            metaKeywords(locale: $locale)
-            metaDescription(locale: $locale)
-            description(locale: $locale)
+            slug(acceptLanguage: $acceptLanguage)
+            name(acceptLanguage: $acceptLanguage)
+            metaTitle(acceptLanguage: $acceptLanguage)
+            metaKeywords(acceptLanguage: $acceptLanguage)
+            metaDescription(acceptLanguage: $acceptLanguage)
+            description(acceptLanguage: $acceptLanguage)
             categoriesRef {
               id
             }

--- a/packages/commercetools/api-client/src/api/getProduct/index.ts
+++ b/packages/commercetools/api-client/src/api/getProduct/index.ts
@@ -1,6 +1,6 @@
 import { ApolloQueryResult } from 'apollo-client';
 import gql from 'graphql-tag';
-import { apolloClient, locale, currency, country } from './../../index';
+import { apolloClient, currency, country, locale, acceptLanguage } from './../../index';
 import { ProductSearch } from './../../types/Api';
 import { ProductQueryResult } from './../../types/GraphQL';
 import defaultQuery from './defaultQuery';
@@ -28,6 +28,7 @@ const getProduct = async (search: ProductSearch): Promise<ApolloQueryResult<Prod
       limit: search.limit,
       offset: search.offset,
       locale,
+      acceptLanguage,
       currency,
       country
     },

--- a/packages/commercetools/api-client/src/api/getShippingMethods/defaultQuery.ts
+++ b/packages/commercetools/api-client/src/api/getShippingMethods/defaultQuery.ts
@@ -4,7 +4,7 @@ import { ShippingMethodFragment } from '../../fragments';
 export default gql`
   ${ShippingMethodFragment}
 
-  query shippingMethods($locale: Locale, $cartId: String!) {
+  query shippingMethods($acceptLanguage: [Locale!], $cartId: String!) {
     shippingMethods: shippingMethodsByCart(id: $cartId) {
       ...DefaultShippingMethod
     }

--- a/packages/commercetools/api-client/src/api/getShippingMethods/index.ts
+++ b/packages/commercetools/api-client/src/api/getShippingMethods/index.ts
@@ -1,5 +1,5 @@
 import { ApolloQueryResult } from 'apollo-client';
-import { apolloClient, locale } from '../../index';
+import { apolloClient, acceptLanguage } from '../../index';
 import defaultQuery from './defaultQuery';
 import { ShippingMethod } from './../../types/GraphQL';
 
@@ -10,7 +10,7 @@ interface ShippingMethodData {
 const getShippingMethods = async (cartId?: string): Promise<ApolloQueryResult<ShippingMethodData>> => {
   return await apolloClient.query({
     query: defaultQuery,
-    variables: { locale, cartId },
+    variables: { acceptLanguage, cartId },
     fetchPolicy: 'no-cache'
   });
 };

--- a/packages/commercetools/api-client/src/api/updateCart/defaultMutation.ts
+++ b/packages/commercetools/api-client/src/api/updateCart/defaultMutation.ts
@@ -4,7 +4,7 @@ import { CartFragment } from './../../fragments';
 export default gql`
   ${CartFragment}
 
-  mutation updateCart($id: String!, $version: Long!, $actions: [MyCartUpdateAction!]!, $locale: Locale!) {
+  mutation updateCart($id: String!, $version: Long!, $actions: [MyCartUpdateAction!]!, $locale: Locale!, $acceptLanguage: [Locale!]) {
     cart: updateMyCart(id: $id, version: $version, actions: $actions) {
       ...DefaultCart
     }

--- a/packages/commercetools/api-client/src/api/updateCart/index.ts
+++ b/packages/commercetools/api-client/src/api/updateCart/index.ts
@@ -1,5 +1,5 @@
 import { CartUpdateAction, MyCartUpdateAction } from '../../types/GraphQL';
-import { apolloClient, locale } from '../../index';
+import { apolloClient, locale, acceptLanguage } from '../../index';
 import CreateCartMutation from './defaultMutation';
 import { CartMutationResponse } from './../../types/Api';
 
@@ -14,6 +14,7 @@ const updateCart = async (cartData: UpdateCart): Promise<CartMutationResponse> =
     mutation: CreateCartMutation,
     variables: {
       locale,
+      acceptLanguage,
       ...cartData
     },
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/fragments/index.ts
+++ b/packages/commercetools/api-client/src/fragments/index.ts
@@ -12,7 +12,7 @@ export const ProductPriceFragment = `
         validFrom
         validUntil
         isActive
-        name(locale: $locale)
+        name(acceptLanguage: $acceptLanguage)
       }
     }
     value {
@@ -59,8 +59,8 @@ export const LineItemFragment = `
   fragment DefaultLineItem on LineItem {
     id
     productId
-    name(locale: $locale)
-    productSlug(locale: $locale)
+    name(acceptLanguage: $acceptLanguage)
+    productSlug(acceptLanguage: $acceptLanguage)
     quantity
     discountedPricePerQuantity {
       quantity
@@ -70,7 +70,7 @@ export const LineItemFragment = `
         }
         includedDiscounts {
           discount {
-            name(locale: $locale)
+            name(acceptLanguage: $acceptLanguage)
             isActive
           }
         }
@@ -94,7 +94,7 @@ export const LineItemFragment = `
           }
           discount {
             isActive
-            name(locale: $locale)
+            name(acceptLanguage: $acceptLanguage)
           }
         }
       }
@@ -156,7 +156,7 @@ export const ShippingMethodFragment = `
     name
     description
     isDefault
-    localizedDescription(locale: $locale)
+    localizedDescription(acceptLanguage: $acceptLanguage)
     zoneRates {
       zone {
         name
@@ -226,14 +226,14 @@ export const CartFragment = `
         isActive
         validFrom
         validUntil
-        name(locale: $locale)
+        name(acceptLanguage: $acceptLanguage)
       }
     }
     refusedGifts {
       isActive
       validFrom
       validUntil
-      name(locale: $locale)
+      name(acceptLanguage: $acceptLanguage)
     }
     cartState
     version

--- a/packages/commercetools/api-client/src/helpers/search/index.ts
+++ b/packages/commercetools/api-client/src/helpers/search/index.ts
@@ -6,7 +6,7 @@ import {
   FilterOption,
   AttributeType
 } from './../../types/Api';
-import { locale, currency } from './../../index';
+import { locale, currency, acceptLanguage } from './../../index';
 
 const buildAttributePredicate = (attrName: string, attrType: string) => (option: FilterOption): string => {
   if (!option.selected) {
@@ -65,7 +65,8 @@ const buildProductWhere = (search: ProductSearch) => {
   }
 
   if (search?.slug) {
-    predicates.push(`masterData(current(slug(${locale}="${search.slug}")))`);
+    const predicate = acceptLanguage.map(locale => `${locale}="${search.slug}"`).join(' or ');
+    predicates.push(`masterData(current(slug(${predicate})))`);
   }
 
   if (search?.id) {
@@ -88,7 +89,8 @@ const buildCategoryWhere = (search: CategorySearch) => {
   }
 
   if (search?.slug) {
-    return `slug(${locale}="${search.slug}")`;
+    const predicate = acceptLanguage.map(locale => `${locale}="${search.slug}"`).join(' or ');
+    return `slug(${predicate})`;
   }
 
   return '';

--- a/packages/commercetools/api-client/src/index.ts
+++ b/packages/commercetools/api-client/src/index.ts
@@ -43,10 +43,7 @@ let cookies = {
   countryCookieName: 'vsf-country',
   localeCookieName: 'vsf-locale'
 };
-const languageMap = {
-  en: ['en', 'de'],
-  de: ['de', 'en']
-};
+let languageMap = {};
 
 const setup = <TCacheShape>(setupConfig: SetupConfig<TCacheShape>): ApolloClient<TCacheShape> => {
   api = setupConfig.api || api;
@@ -60,7 +57,8 @@ const setup = <TCacheShape>(setupConfig: SetupConfig<TCacheShape>): ApolloClient
   auth = setupConfig.auth || auth;
   currentToken = setupConfig.forceToken ? setupConfig.currentToken : setupConfig.currentToken || currentToken;
 
-  acceptLanguage = languageMap[locale] || acceptLanguage;
+  languageMap = setupConfig.languageMap || languageMap;
+  acceptLanguage = languageMap[locale] || setupConfig.acceptLanguage || acceptLanguage;
 
   if (setupConfig.api) {
     apolloClient = new ApolloClient({

--- a/packages/commercetools/api-client/src/index.ts
+++ b/packages/commercetools/api-client/src/index.ts
@@ -31,6 +31,7 @@ let country = '';
 let countries = [];
 let currencies = [];
 let locales = [];
+let acceptLanguage = ['en'];
 let currentToken: Token = null;
 let api: ApiConfig = null;
 let auth: Auth = {
@@ -41,6 +42,10 @@ let cookies = {
   currencyCookieName: 'vsf-currency',
   countryCookieName: 'vsf-country',
   localeCookieName: 'vsf-locale'
+};
+const languageMap = {
+  en: ['en', 'de'],
+  de: ['de', 'en']
 };
 
 const setup = <TCacheShape>(setupConfig: SetupConfig<TCacheShape>): ApolloClient<TCacheShape> => {
@@ -54,6 +59,8 @@ const setup = <TCacheShape>(setupConfig: SetupConfig<TCacheShape>): ApolloClient
   cookies = setupConfig.cookies || cookies;
   auth = setupConfig.auth || auth;
   currentToken = setupConfig.forceToken ? setupConfig.currentToken : setupConfig.currentToken || currentToken;
+
+  acceptLanguage = languageMap[locale] || acceptLanguage;
 
   if (setupConfig.api) {
     apolloClient = new ApolloClient({
@@ -76,6 +83,7 @@ export {
   cookies,
   locale,
   locales,
+  acceptLanguage,
   country,
   currency,
   countries,

--- a/packages/commercetools/api-client/src/types/setup.ts
+++ b/packages/commercetools/api-client/src/types/setup.ts
@@ -45,6 +45,7 @@ export interface SetupConfig<TCacheShape> {
   countries?: LocaleItem[];
   currencies?: LocaleItem[];
   locales?: LocaleItem[];
+  acceptLanguage?: string[];
   cookies?: CookiesConfig;
   auth?: Auth;
   forceToken?: boolean;

--- a/packages/commercetools/api-client/src/types/setup.ts
+++ b/packages/commercetools/api-client/src/types/setup.ts
@@ -45,6 +45,7 @@ export interface SetupConfig<TCacheShape> {
   countries?: LocaleItem[];
   currencies?: LocaleItem[];
   locales?: LocaleItem[];
+  languageMap?: object;
   acceptLanguage?: string[];
   cookies?: CookiesConfig;
   auth?: Auth;

--- a/packages/commercetools/composables/src/getters/_utils.ts
+++ b/packages/commercetools/composables/src/getters/_utils.ts
@@ -1,6 +1,6 @@
 import { AgnosticAttribute, AgnosticPrice } from '@vue-storefront/core';
 import { ProductVariant, ProductPrice, DiscountedProductPriceValue, LineItem } from './../types/GraphQL';
-import { locale, currency, country } from '@vue-storefront/commercetools-api';
+import { locale, currency } from '@vue-storefront/commercetools-api';
 import { DiscountedLineItemPrice } from '@vue-storefront/commercetools-api/lib/types/GraphQL';
 
 export const getAttributeValue = (attribute) => {
@@ -99,5 +99,5 @@ export const createFormatPrice = (price: number) => {
     return null;
   }
 
-  return new Intl.NumberFormat(`${locale}-${country}`, { style: 'currency', currency }).format(price);
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(price);
 };

--- a/packages/commercetools/theme/plugins/commercetools-config.js
+++ b/packages/commercetools/theme/plugins/commercetools-config.js
@@ -16,6 +16,7 @@ export const config = {
     ]
   },
   locale: 'en',
+  acceptLanguage: ['en', 'de'],
   currency: 'USD',
   country: 'US',
   countries: [

--- a/packages/core/docs/commercetools/api-client.md
+++ b/packages/core/docs/commercetools/api-client.md
@@ -46,6 +46,8 @@ export interface ApiConfig {
 - `customOptions?: ApolloClientOptions<TCacheShape>`
 - `currency?: string`
 - `locale?: string`
+- `languageMap?: object`
+- `acceptLanguage?: string[]`
 - `country?: string`
 - `countries?: LocaleItem[]`
 ```js
@@ -113,6 +115,21 @@ const serverMiddleware = async ({ app }) => {
 };
 
 export default serverMiddleware;
+```
+
+### Localisation
+
+Commercetools supports querying localised fields via an array of accepted languages - `acceptLanguage`.
+```js
+acceptLanguage: ['en-gb', 'en-us']
+```
+
+If you supply a `languageMap` during setup this will be used to map a locale to the accepted languages.
+```js
+languageMap: {
+  'en-gb': ['en-gb', 'en-us'],
+  'en-us': ['en-us', 'en-gb'],
+}
 ```
 
 :::


### PR DESCRIPTION
Entries are not required in commercetools for all locales, switching to acceptLanguage instead of locale when querying allows for an array of locales in order of preference to be returned.

```
query {
  product(id:"f8038fde-67c1-4be6-8373-7d18495449e8") {
    masterData {
      current {
        description(acceptLanguage:["de", "en"])
      }
    }
  }
}
```
```
{
  "data": {
    "product": {
      "masterData": {
        "current": {
          "description": "This black sweater is a true Ralph Lauren classic. Slim cut, with embroidered logo and in pure merino wool it is an instant upgrade to any look."
        }
      }
    }
  }
}
```

locale is still needed for fetching product attributes via attributeList. I'll fire off a communication with commercetools to see if its possible to add acceptLanguage to the localised attribute types.

### Which Environment This Relates To
- [x] Next.

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)