### PR TITLE
use config.i18n.defaultLocale as fallback locale instead of 'en-US'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.0] - 2020.06.01
 
 ### Added
+### Fixed
+
+- use `config.i18n.defaultLocale` as fallback locale instead of `'es-US'` - @gibkigonzo (#4489)
+
+### Changed / Improved
+
+## [1.12.0] - 2020.06.01
+
+### Added
 
 - Add `vsf-capybara` support as a dependency and extend CLI to support customization - @psmyrek (#4209)
 - Support theme configuration via CLI - @psmyrek (#4395)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Fixed
 
-- use `config.i18n.defaultLocale` as fallback locale instead of `'es-US'` - @gibkigonzo (#4489)
+- use `config.i18n.defaultLocale` as fallback locale instead of `'en-US'` - @gibkigonzo (#4489)
 
 ### Changed / Improved
 

--- a/core/i18n/index.ts
+++ b/core/i18n/index.ts
@@ -8,12 +8,13 @@ once('__VUE_EXTEND_I18N__', () => {
   Vue.use(VueI18n)
 })
 
-const loadedLanguages = ['en-US']
+const defaultLocale = config.i18n.defaultLocale || 'en-US'
+const loadedLanguages = [defaultLocale]
 const i18n = new VueI18n({
-  locale: config.i18n.bundleAllStoreviewLanguages ? config.i18n.defaultLocale : 'en-US', // set locale
-  fallbackLocale: 'en-US',
+  locale: defaultLocale, // set locale
+  fallbackLocale: defaultLocale,
   messages: config.i18n.bundleAllStoreviewLanguages ? require('./resource/i18n/multistoreLanguages.json') : {
-    'en-US': require('./resource/i18n/en-US.json')
+    [defaultLocale]: require(`./resource/i18n/${defaultLocale}.json`)
   }
 })
 

--- a/core/i18n/scripts/translation.preprocessor.js
+++ b/core/i18n/scripts/translation.preprocessor.js
@@ -17,7 +17,7 @@ function convertToObject (array) {
 
 module.exports = function (csvDirectories, config = null) {
   const currentLocales = currentBuildLocales()
-  const fallbackLocale = 'en-US'
+  const fallbackLocale = config.i18n.defaultLocale || 'en-US'
   let messages = {}
   let languages = []
 
@@ -43,7 +43,7 @@ module.exports = function (csvDirectories, config = null) {
 
   // create fallback
   console.debug(`Writing JSON file fallback: ${fallbackLocale}.json`)
-  fs.writeFileSync(path.join(__dirname, '../resource/i18n', `${fallbackLocale}.json`), JSON.stringify(messages[fallbackLocale]))
+  fs.writeFileSync(path.join(__dirname, '../resource/i18n', `${fallbackLocale}.json`), JSON.stringify(messages[fallbackLocale] || {}))
 
   // bundle all messages in one file
   if (config && config.i18n.bundleAllStoreviewLanguages) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #4489

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
We should use `en-US` only when there is no `config.i18n.defaultLocale`


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

