### PR TITLE
add purge-config loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.12.0] - UNRELEASED
+## [1.12.1] - UNRELEASED
 
 ### Added
 
 - Add `purgeConfig` to default.json and purge-config loader - @gibkigonzo (#4540)
 
-## [1.12.0] - 2020.06.01
-
-### Added
 ### Fixed
 
 - use `config.i18n.defaultLocale` as fallback locale instead of `'en-US'` - @gibkigonzo (#4489)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - UNRELEASED
+
+### Added
+
+- Add `purgeConfig` to default.json and purge-config loader - @gibkigonzo (#4540)
+
 ## [1.12.0] - 2020.06.01
 
 ### Added

--- a/config/default.json
+++ b/config/default.json
@@ -871,5 +871,16 @@
   },
   "varnish": {
     "enabled":false
-  }
+  },
+  "purgeConfig": [
+    "server.invalidateCacheKey",
+    "server.invalidateCacheForwardUrl",
+    "server.trace",
+    "redis",
+    "install",
+    "expireHeaders",
+    "fastly",
+    "nginx",
+    "varnish"
+  ]
 }

--- a/core/build/purge-config.js
+++ b/core/build/purge-config.js
@@ -1,0 +1,16 @@
+const omit = require('lodash/omit')
+
+/**
+ * clear config properties that shouldn't be visible on frontend
+ */
+module.exports = function loader(source) {
+  let config = JSON.parse(source);
+
+  const purgeConfig = (config.purgeConfig || []).slice()
+
+  config = omit(config, purgeConfig)
+
+  delete config['purgeConfig']
+
+  return JSON.stringify(config);
+}

--- a/core/build/webpack.base.config.ts
+++ b/core/build/webpack.base.config.ts
@@ -193,6 +193,10 @@ export default {
         test: /\.(graphqls|gql)$/,
         exclude: /node_modules/,
         loader: ['graphql-tag/loader']
+      },
+      {
+        test: /core\/build\/config\.json$/,
+        loader: path.resolve('core/build/purge-config.js')
       }
     ]
   }


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Adds loader that clears properties from config in build. Those properties list can be extended by adding to config.purgeConfig (**add properties that are used only for `server.ts` and related**) 


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

