### PR TITLE
clear vuex warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - UNRELEASED
+
+### Fixed
+
+- Clears vuex warnings about overriding state by module - @gibkigonzo (#4541)
+
 ## [1.12.0] - 2020.06.01
 
 ### Added

--- a/core/lib/multistore.ts
+++ b/core/lib/multistore.ts
@@ -66,7 +66,10 @@ export async function prepareStoreView (storeCode: string): Promise<StoreView> {
   if (storeView.storeCode && config.storeViews.multistore === true && config.storeViews[storeView.storeCode]) {
     storeView = merge(storeView, getExtendedStoreviewConfig(config.storeViews[storeView.storeCode]))
   }
-  rootStore.state.user.current_storecode = storeView.storeCode
+
+  if (rootStore.state.user) {
+    rootStore.state.user.current_storecode = storeView.storeCode
+  }
 
   if (storeViewHasChanged) {
     storeView = coreHooksExecutors.beforeStoreViewChanged(storeView)

--- a/core/store/index.ts
+++ b/core/store/index.ts
@@ -10,46 +10,17 @@ once('__VUE_EXTEND_VUEX__', () => {
   Vue.use(Vuex)
 })
 
-const state = {
+const state: any = {
   version: '',
   __DEMO_MODE__: false,
   config: {},
-  cart: {},
-  checkout: {},
-  cms: {},
-  compare: {},
-  product: {},
-  shipping: {},
-  user: {},
-  ui: {},
-  newsletter: {},
-  wishlist: {},
-  attribute: {
-    list_by_code: {},
-    list_by_id: {},
-    blacklist: [],
-    labels: {}
-  },
-  category: {
-    current_path: '',
-    current_product_query: {},
-    current: {
-      slug: '',
-      name: ''
-    },
-    filters: {}
-  },
-  stock: {
-    cache: []
-  },
   storeView: {},
   twoStageCachingDelta1: 0,
   twoStageCachingDelta2: 0,
   twoStageCachingDisabled: false,
   userTokenInvalidated: null,
   userTokenInvalidateAttemptsCount: 0,
-  userTokenInvalidateLock: 0,
-  url: {}
+  userTokenInvalidateLock: 0
 }
 
 let rootStore = new Vuex.Store<RootState>({


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Clears vuex warnings about overriding state by module. related https://github.com/vuejs/vuex/issues/1652


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

