### PR TITLE
Add `attributeMetadata` to response of `api-search-query` adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - removed possible memory leak in ssr - @resubaka (#4247)
 - Bugfix for reactivity of `current_configuration` in `populateProductConfigurationAsync` - @cewald (#4258)
 - Bugfix for build exception in Node v13.13+ - @cewald (#4249)
+- Add `attributeMetadata` to response object of `api-search-query` search adapter to support `loadByAttributeMetadata` feature - @cewald (#4544)
 
 ### Changed / Improved
 

--- a/core/lib/search/adapter/api-search-query/searchAdapter.ts
+++ b/core/lib/search/adapter/api-search-query/searchAdapter.ts
@@ -117,6 +117,7 @@ export class SearchAdapter {
         start: start,
         perPage: size,
         aggregations: resp.aggregations,
+        attributeMetadata: resp.attribute_metadata,
         suggestions: resp.suggest
       }
     } else {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Add `attributeMetadata` to response object of `api-search-query` search adapter to support `loadByAttributeMetadata` feature.

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

It is missing yet and `api-search-query` wouldn't support the `loadByAttributeMetadata` feature.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

