### PR TITLE
Load attributes data of attribute-meta for bundled and grouped products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `purgeConfig` to default.json and purge-config loader - @gibkigonzo (#4540)
+- Load attributes data of attribute-meta for bundled and grouped products - @cewald (#4551)
 
 ### Fixed
 
@@ -51,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add vsf-cache-nginx and vsf-cache-varnish modules - @gibkigonzo (#4096)
 - Added meta info for CMS pages from Magento @mdanilowicz (#4392)
 - Add useful core events to server & logger - @cewald (#4419)
-- Load attributes data of attribute-meta for bundled and grouped products - @cewald (#4548)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add vsf-cache-nginx and vsf-cache-varnish modules - @gibkigonzo (#4096)
 - Added meta info for CMS pages from Magento @mdanilowicz (#4392)
 - Add useful core events to server & logger - @cewald (#4419)
+- Load attributes data of attribute-meta for bundled and grouped products - @cewald (#4548)
 
 ### Fixed
 

--- a/core/modules/catalog/helpers/associatedProducts/getAttributesFromMetadata.ts
+++ b/core/modules/catalog/helpers/associatedProducts/getAttributesFromMetadata.ts
@@ -4,7 +4,7 @@ import Product from '@vue-storefront/core/modules/catalog/types/Product'
 /**
  * Set associated attributes by meta data of product links
  */
-export default async function setAttributesMetaFromProducts (context: any, products: Product[]) {
+export default async function getAttributesFromMetadata (context: any, products: Product[]) {
   if (config.entities.attribute.loadByAttributeMetadata) {
     context.dispatch('attribute/loadProductAttributes', { products, merge: true }, { root: true })
   }

--- a/core/modules/catalog/helpers/associatedProducts/index.ts
+++ b/core/modules/catalog/helpers/associatedProducts/index.ts
@@ -1,9 +1,9 @@
 import setGroupedProduct from './setGroupedProduct'
 import setBundleProducts from './setBundleProducts'
-import setAttributesMetaFromProducts from './setAttributesMetaFromProducts'
+import getAttributesFromMetadata from './getAttributesFromMetadata'
 
 export {
   setGroupedProduct,
   setBundleProducts,
-  setAttributesMetaFromProducts
+  getAttributesFromMetadata
 }

--- a/core/modules/catalog/helpers/associatedProducts/index.ts
+++ b/core/modules/catalog/helpers/associatedProducts/index.ts
@@ -1,7 +1,9 @@
 import setGroupedProduct from './setGroupedProduct'
 import setBundleProducts from './setBundleProducts'
+import setAttributesMetaFromProducts from './setAttributesMetaFromProducts'
 
 export {
   setGroupedProduct,
-  setBundleProducts
+  setBundleProducts,
+  setAttributesMetaFromProducts
 }

--- a/core/modules/catalog/helpers/associatedProducts/setAttributesMetaFromProducts.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setAttributesMetaFromProducts.ts
@@ -1,8 +1,11 @@
+import config from 'config'
 import Product from '@vue-storefront/core/modules/catalog/types/Product'
 
 /**
  * Set associated attributes by meta data of product links
  */
 export default async function setAttributesMetaFromProducts (context: any, products: Product[]) {
-  context.dispatch('attribute/loadProductAttributes', { products, merge: true }, { root: true })
+  if (config.entities.attribute.loadByAttributeMetadata) {
+    context.dispatch('attribute/loadProductAttributes', { products, merge: true }, { root: true })
+  }
 }

--- a/core/modules/catalog/helpers/associatedProducts/setAttributesMetaFromProducts.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setAttributesMetaFromProducts.ts
@@ -1,0 +1,8 @@
+import Product from '@vue-storefront/core/modules/catalog/types/Product'
+
+/**
+ * Set associated attributes by meta data of product links
+ */
+export default async function setAttributesMetaFromProducts (context: any, products: Product[]) {
+  context.dispatch('attribute/loadProductAttributes', { products, merge: true }, { root: true })
+}

--- a/core/modules/catalog/helpers/associatedProducts/setBundleProducts.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setBundleProducts.ts
@@ -1,9 +1,10 @@
-import Product from '@vue-storefront/core/modules/catalog/types/Product';
-import { isBundleProduct } from './..';
+import Product from '@vue-storefront/core/modules/catalog/types/Product'
 import buildQuery from './buildQuery'
 import setProductLink from './setProductLink'
-import { ProductService } from '@vue-storefront/core/data-resolver/ProductService'
 import getBundleProductPrice from './getBundleProductPrice'
+import { isBundleProduct } from './..'
+import { ProductService } from '@vue-storefront/core/data-resolver/ProductService'
+import { catalogHooksExecutors } from './../../hooks'
 
 /**
  * This function prepare all product_links for bundle products.
@@ -29,6 +30,8 @@ export default async function setBundleProducts (product: Product, { includeFiel
         separateSelectedVariant: false
       }
     })
+
+    catalogHooksExecutors.afterSetBundleProducts(items)
 
     for (const bundleOption of product.bundle_options) {
       for (const productLink of bundleOption.product_links) {

--- a/core/modules/catalog/helpers/associatedProducts/setGroupedProduct.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setGroupedProduct.ts
@@ -1,9 +1,10 @@
-import Product from '@vue-storefront/core/modules/catalog/types/Product';
-import { isGroupedProduct } from './..';
+import Product from '@vue-storefront/core/modules/catalog/types/Product'
 import buildQuery from './buildQuery'
 import setProductLink from './setProductLink'
-import { ProductService } from '@vue-storefront/core/data-resolver/ProductService'
 import getGroupedProductPrice from './getGroupedProductPrice'
+import { isGroupedProduct } from './..'
+import { ProductService } from '@vue-storefront/core/data-resolver/ProductService'
+import { catalogHooksExecutors } from './../../hooks'
 
 /**
  * This function prepare all product_links for grouped products.
@@ -28,6 +29,8 @@ export default async function setGroupedProduct (product: Product, { includeFiel
         separateSelectedVariant: false
       }
     })
+
+    catalogHooksExecutors.afterSetGroupedProduct(items)
 
     for (const productLink of productLinks) {
       const associatedProduct = items.find((associatedProduct) => associatedProduct.sku === productLink.linked_product_sku)

--- a/core/modules/catalog/hooks/index.ts
+++ b/core/modules/catalog/hooks/index.ts
@@ -1,4 +1,4 @@
-import { createMutatorHook } from '@vue-storefront/core/lib/hooks'
+import { createMutatorHook, createListenerHook } from '@vue-storefront/core/lib/hooks'
 import Product from '../types/Product';
 
 const {
@@ -6,12 +6,26 @@ const {
   executor: beforeTaxesCalculatedExecutor
 } = createMutatorHook<Product[], Product[]>()
 
+const {
+  hook: afterSetBundleProductsHook,
+  executor: afterSetBundleProductsExecutor
+} = createListenerHook<Product[]>()
+
+const {
+  hook: afterSetGroupedProductHook,
+  executor: afterSetGroupedProductExecutor
+} = createListenerHook<Product[]>()
+
 const catalogHooksExecutors = {
-  beforeTaxesCalculated: beforeTaxesCalculatedExecutor
+  beforeTaxesCalculated: beforeTaxesCalculatedExecutor,
+  afterSetBundleProducts: afterSetBundleProductsExecutor,
+  afterSetGroupedProduct: afterSetGroupedProductExecutor
 }
 
 const catalogHooks = {
-  beforeTaxesCalculated: beforeTaxesCalculatedHook
+  beforeTaxesCalculated: beforeTaxesCalculatedHook,
+  afterSetBundleProducts: afterSetBundleProductsHook,
+  afterSetGroupedProduct: afterSetGroupedProductHook
 }
 
 export {

--- a/core/modules/catalog/index.ts
+++ b/core/modules/catalog/index.ts
@@ -5,7 +5,7 @@ import { stockModule } from './store/stock'
 import { taxModule } from './store/tax'
 import { categoryModule } from './store/category'
 import { catalogHooks } from './hooks'
-import { setAttributesMetaFromProducts } from './helpers/associatedProducts'
+import { getAttributesFromMetadata } from './helpers/associatedProducts'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 import config from 'config'
@@ -25,8 +25,8 @@ export const CatalogModule: StorefrontModule = async function ({ store, router, 
   store.registerModule('tax', taxModule)
   store.registerModule('category', categoryModule)
 
-  catalogHooks.afterSetBundleProducts(products => setAttributesMetaFromProducts(store, products))
-  catalogHooks.afterSetGroupedProduct(products => setAttributesMetaFromProducts(store, products))
+  catalogHooks.afterSetBundleProducts(products => getAttributesFromMetadata(store, products))
+  catalogHooks.afterSetGroupedProduct(products => getAttributesFromMetadata(store, products))
 
   if (!config.entities.attribute.loadByAttributeMetadata) {
     await store.dispatch('attribute/list', { // loading attributes for application use

--- a/core/modules/catalog/index.ts
+++ b/core/modules/catalog/index.ts
@@ -4,6 +4,8 @@ import { attributeModule } from './store/attribute'
 import { stockModule } from './store/stock'
 import { taxModule } from './store/tax'
 import { categoryModule } from './store/category'
+import { catalogHooks } from './hooks'
+import { setAttributesMetaFromProducts } from './helpers/associatedProducts'
 import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 import EventBus from '@vue-storefront/core/compatibility/plugins/event-bus'
 import config from 'config'
@@ -22,6 +24,9 @@ export const CatalogModule: StorefrontModule = async function ({ store, router, 
   store.registerModule('stock', stockModule)
   store.registerModule('tax', taxModule)
   store.registerModule('category', categoryModule)
+
+  catalogHooks.afterSetBundleProducts(products => setAttributesMetaFromProducts(store, products))
+  catalogHooks.afterSetGroupedProduct(products => setAttributesMetaFromProducts(store, products))
 
   if (!config.entities.attribute.loadByAttributeMetadata) {
     await store.dispatch('attribute/list', { // loading attributes for application use


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

If I want to show product attribute options of a bundled or grouped products on PDP, the attribute data isn't loaded. But as we already load the children in `setGroupedProduct` and `setBundleProducts` we can use the data of the product link request to populate the attributes options data in case it is used. E.g. to show the selected options in the shopping cart.

I added two events hooks: `afterSetGroupedProduct` and `afterSetBundleProducts` on which I bound a helper class (`getAttributesFromMetadata `) using the `attribute/loadProductAttributes` action to load the attribute data from response data.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

