### PR TITLE
Make calculation of bundled products price by options optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `purgeConfig` to default.json and purge-config loader - @gibkigonzo (#4540)
 - Load attributes data of attribute-meta for bundled and grouped products - @cewald (#4551)
 - Separate theme installation and add it as yarn init:theme or as a step in yarn installer. - @gibkigonzo (4534, #4552)
+- Make calculation of bundled products price by options optional - @cewald (#4556)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add helmet - enabled by default, you can pass configuration by adding `config.server.helmet.config`.
   More info about helmet configuration https://helmetjs.github.io/docs/
 - Add config `users.tokenInHeader` which allows to send token in header instead in query. Require to set on true same config in vsf-api.
+- Make calculation of bundled products price by options optional - @cewald (#4556)
 
 ### Fixed
 
@@ -30,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `purgeConfig` to default.json and purge-config loader - @gibkigonzo (#4540)
 - Load attributes data of attribute-meta for bundled and grouped products - @cewald (#4551)
 - Separate theme installation and add it as yarn init:theme or as a step in yarn installer. - @gibkigonzo (4534, #4552)
-- Make calculation of bundled products price by options optional - @cewald (#4556)
 
 ### Fixed
 

--- a/config/default.json
+++ b/config/default.json
@@ -615,6 +615,7 @@
     "clearPricesBeforePlatformSync": false,
     "waitForPlatformSync": false,
     "setupVariantByAttributeCode": true,
+    "calculateBundlePriceByOptions": true,
     "endpoint": "/api/product",
     "defaultFilters": [
       "color",

--- a/core/modules/catalog/helpers/associatedProducts/setBundleProducts.ts
+++ b/core/modules/catalog/helpers/associatedProducts/setBundleProducts.ts
@@ -1,3 +1,4 @@
+import config from 'config'
 import Product from '@vue-storefront/core/modules/catalog/types/Product'
 import buildQuery from './buildQuery'
 import setProductLink from './setProductLink'
@@ -40,9 +41,11 @@ export default async function setBundleProducts (product: Product, { includeFiel
       }
     }
 
-    const { price, priceInclTax } = getBundleProductPrice(product)
-    product.price = price
-    product.priceInclTax = priceInclTax
-    product.price_incl_tax = priceInclTax
+    if (config.products.calculateBundlePriceByOptions) {
+      const { price, priceInclTax } = getBundleProductPrice(product)
+      product.price = price
+      product.priceInclTax = priceInclTax
+      product.price_incl_tax = priceInclTax
+    }
   }
 }


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Magento 1 has a feature to use the parent product price instead of a calculated price by the bundles option. If you use this feature the prices are wrong in VSF because the price are there calculated by their options.

I would suggest to be able to disable this feature by a config flag.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

