### PR TITLE
feature(commercetools): add missing fields in address mapping for cart

### DIFF
--- a/packages/commercetools/api-client/src/helpers/cart/actions.ts
+++ b/packages/commercetools/api-client/src/helpers/cart/actions.ts
@@ -1,4 +1,4 @@
-import { ProductVariant, Address, LineItem, ReferenceInput, ResourceIdentifierInput } from './../../types/GraphQL';
+import { ProductVariant, Address, LineItem, ReferenceInput, ResourceIdentifierInput, AddressInput } from './../../types/GraphQL';
 
 export const createAddLineItemAction = (variant: ProductVariant, quantity: number) => ({
   addLineItem: {
@@ -22,18 +22,31 @@ export const createChangeLineItemQuantityAction = (product: LineItem) => ({
   }
 });
 
-export const setShippingAddressAction = (shippingDetails: Address) => ({
+export const setShippingAddressAction = (shippingDetails: Address): { setShippingAddress: { address: AddressInput } } => ({
   setShippingAddress: {
     address: {
+      title: shippingDetails.title,
+      salutation: shippingDetails.salutation,
       firstName: shippingDetails.firstName,
       lastName: shippingDetails.lastName,
       streetName: shippingDetails.streetName,
       streetNumber: shippingDetails.streetNumber,
-      city: shippingDetails.city,
-      // state: shippingDetails.state,
+      additionalStreetInfo: shippingDetails.additionalStreetInfo,
       postalCode: shippingDetails.postalCode,
+      city: shippingDetails.city,
+      region: shippingDetails.region,
+      state: shippingDetails.state,
       country: shippingDetails.country,
-      phone: shippingDetails?.contactInfo?.phone
+      company: shippingDetails.company,
+      department: shippingDetails.department,
+      building: shippingDetails.building,
+      apartment: shippingDetails.apartment,
+      pOBox: shippingDetails.pOBox,
+      phone: shippingDetails.contactInfo?.phone,
+      mobile: shippingDetails.contactInfo?.mobile,
+      email: shippingDetails.contactInfo?.email,
+      fax: shippingDetails.contactInfo?.fax,
+      additionalAddressInfo: shippingDetails.additionalAddressInfo
     }
   }
 });
@@ -48,18 +61,31 @@ export const addPayment = (payment: ResourceIdentifierInput) => ({
   addPayment: { payment }
 });
 
-export const setBillingAddressAction = (billingDetails: Address) => ({
+export const setBillingAddressAction = (billingDetails: Address): { setBillingAddress: { address: AddressInput } } => ({
   setBillingAddress: {
     address: {
+      title: billingDetails.title,
+      salutation: billingDetails.salutation,
       firstName: billingDetails.firstName,
       lastName: billingDetails.lastName,
       streetName: billingDetails.streetName,
       streetNumber: billingDetails.streetNumber,
-      city: billingDetails.city,
-      // state: billingDetails.state,
+      additionalStreetInfo: billingDetails.additionalStreetInfo,
       postalCode: billingDetails.postalCode,
+      city: billingDetails.city,
+      region: billingDetails.region,
+      state: billingDetails.state,
       country: billingDetails.country,
-      phone: billingDetails.contactInfo.phone
+      company: billingDetails.company,
+      department: billingDetails.department,
+      building: billingDetails.building,
+      apartment: billingDetails.apartment,
+      pOBox: billingDetails.pOBox,
+      phone: billingDetails.contactInfo?.phone,
+      mobile: billingDetails.contactInfo?.mobile,
+      email: billingDetails.contactInfo?.email,
+      fax: billingDetails.contactInfo?.fax,
+      additionalAddressInfo: billingDetails.additionalAddressInfo
     }
   }
 });

--- a/packages/commercetools/composables/__tests__/useCheckout/useCheckout.spec.ts
+++ b/packages/commercetools/composables/__tests__/useCheckout/useCheckout.spec.ts
@@ -109,6 +109,15 @@ describe('[commercetools-composables] useCheckout/setShippingDetails', () => {
     expect(shippingDetails.value).toEqual({ ...shippingAddress, contactInfo: {} });
   });
 
+  it('overwrites contactInfo properly', async () => {
+    (shippingDetails.value as any).contactInfo = { email: 'test@test.com' };
+    const setShippingDetails = createSetShippingDetails({ factoryParams: {}, cartFields, setCart });
+    const shippingAddress = { firstName: 'John', lastName: 'Doe', contactInfo: { phone: '123456789' } };
+    await setShippingDetails(shippingAddress);
+
+    expect(shippingDetails.value).toEqual({ ...shippingAddress, contactInfo: { phone: '123456789', email: 'test@test.com' } });
+  });
+
   it('send shipping details to the api', async () => {
     const setShippingDetails = createSetShippingDetails({ factoryParams: {}, cartFields, setCart });
     const shippingAddress = { firstName: 'John', lastName: 'Doe' };

--- a/packages/commercetools/composables/src/useCheckout/createSetBillingDetails.ts
+++ b/packages/commercetools/composables/src/useCheckout/createSetBillingDetails.ts
@@ -7,7 +7,16 @@ import initFields from './initFields';
 const initialDetails = { contactInfo: {} };
 
 const createSetBillingDetails = ({ factoryParams, cartFields, setCart }) => async (data, options: any = {}) => {
-  billingDetails.value = { ...initialDetails, ...billingDetails.value, ...data };
+  billingDetails.value = {
+    ...initialDetails,
+    ...billingDetails.value,
+    ...data,
+    contactInfo: {
+      ...initialDetails.contactInfo,
+      ...billingDetails.value.contactInfo,
+      ...data.contactInfo
+    }
+  };
 
   if (!options.save) return;
   loading.value.billingAddress = true;

--- a/packages/commercetools/composables/src/useCheckout/createSetShippingDetails.ts
+++ b/packages/commercetools/composables/src/useCheckout/createSetShippingDetails.ts
@@ -7,9 +7,21 @@ import initFields from './initFields';
 const initialDetails = { contactInfo: {} };
 
 const createSetShippingDetails = ({ factoryParams, cartFields, setCart }) => async (data, options: any = {}) => {
-  shippingDetails.value = { ...initialDetails, ...shippingDetails.value, ...data };
+  shippingDetails.value = {
+    ...initialDetails,
+    ...shippingDetails.value,
+    ...data,
+    contactInfo: {
+      ...initialDetails.contactInfo,
+      ...shippingDetails.value.contactInfo,
+      ...data.contactInfo
+    }
+  };
 
-  if (!options.save) return;
+  if (!options.save) {
+    return;
+  }
+
   loading.value.shippingAddress = true;
 
   const cartResponse = await updateCart({


### PR DESCRIPTION
additionally fixed overwriting `contactInfo` nested object

### Short Description and Why It's Useful
This allows to fully use shipping and billing address of the cart in checkout steps.

***Important note**
Yes, I'm aware that `state` field in shipping/billing address is tightly coupled with tax rates and it should be used with caution, but we should not block this entirely from use for users of VSF Next with CT.*