### PR TITLE
Remove duplicate import of '@vue-storefront/core/helpers'

### DIFF
--- a/core/scripts/resolvers/resolveGraphQL.js
+++ b/core/scripts/resolvers/resolveGraphQL.js
@@ -1,8 +1,7 @@
 import { server, graphql } from 'config'
 import Vue from 'vue'
 import { Logger } from '@vue-storefront/core/lib/logger'
-import { once } from '@vue-storefront/core/helpers'
-import { isServer } from '@vue-storefront/core/helpers';
+import { once, isServer } from '@vue-storefront/core/helpers'
 
 export const getApolloProvider = async () => {
   if (server.api === 'graphql') {


### PR DESCRIPTION
### Related Issues
N/A

### Short Description and Why It's Useful
Module `''@vue-storefront/core/helpers"` is being exported twite (one for `once` and one for `isServer`) and it's causing a linting warning.

### Screenshots of Visual Changes before/after (if There Are Any)
N/A

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

