### PR TITLE
Bugfix/4619

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - remove deprecated value from attributesListQuery query - @gibkigonzo (#4572)
 - Fixed dutch translations - @1070rik (#4587)
 - localForage memory overload fixed. `localForage.preserveCollections` keeps names of collections to be preserved from being cleared. - @prakowski
+- Fixed bug in `restoreQuantity` - getItem never returns cart item - @gibkigonzo (#4619)
 
 ### Changed / Improved
 

--- a/core/modules/cart/store/actions/mergeActions.ts
+++ b/core/modules/cart/store/actions/mergeActions.ts
@@ -43,7 +43,7 @@ const mergeActions = {
       return diffLog
     }
 
-    if (!wasUpdatedSuccessfully && clientItem.server_item_id) {
+    if (!wasUpdatedSuccessfully && (clientItem.server_item_id || clientItem.item_id)) {
       await dispatch('restoreQuantity', { product: clientItem })
       return diffLog
     }

--- a/core/modules/cart/store/actions/mergeActions.ts
+++ b/core/modules/cart/store/actions/mergeActions.ts
@@ -43,8 +43,8 @@ const mergeActions = {
       return diffLog
     }
 
-    if (!wasUpdatedSuccessfully && clientItem.item_id) {
-      await dispatch('restoreQuantity', { cartItem, clientItem })
+    if (!wasUpdatedSuccessfully && clientItem.server_item_id) {
+      await dispatch('restoreQuantity', { product: clientItem })
       return diffLog
     }
 

--- a/core/modules/cart/store/actions/quantityActions.ts
+++ b/core/modules/cart/store/actions/quantityActions.ts
@@ -4,15 +4,20 @@ import { Logger } from '@vue-storefront/core/lib/logger'
 import { createDiffLog } from '@vue-storefront/core/modules/cart/helpers'
 
 const quantityActions = {
-  async restoreQuantity ({ dispatch }, { cartItem, clientItem }) {
-    const currentCartItem = await dispatch('getItem', clientItem)
+  async restoreQuantity ({ dispatch }, { product }) {
+    const currentCartItem = await dispatch('getItem', { product })
     if (currentCartItem) {
-      Logger.log('Restoring qty after error' + clientItem.sku + currentCartItem.prev_qty, 'cart')()
-      if (cartItem.prev_qty > 0) {
-        dispatch('updateItem', { product: { qty: currentCartItem.prev_qty } })
+      Logger.log('Restoring qty after error' + product.sku + currentCartItem.prev_qty, 'cart')()
+      if (currentCartItem.prev_qty > 0) {
+        await dispatch('updateItem', {
+          product: {
+            ...product,
+            qty: currentCartItem.prev_qty
+          }
+        })
         EventBus.$emit('cart-after-itemchanged', { item: currentCartItem })
       } else {
-        dispatch('removeItem', { product: currentCartItem, removeByParentSku: false })
+        await dispatch('removeItem', { product: currentCartItem, removeByParentSku: false })
       }
     }
   },

--- a/core/modules/cart/test/unit/store/mergeActions.spec.ts
+++ b/core/modules/cart/test/unit/store/mergeActions.spec.ts
@@ -154,11 +154,11 @@ describe('Cart mergeActions', () => {
 
     await (cartActions as any).updateServerItem(contextMock, { clientItem, serverItem });
     expect(contextMock.commit).not.toBeCalledWith(types.CART_DEL_ITEM, { product: clientItem, removeByParentSku: false })
-    expect(contextMock.dispatch).toBeCalledWith('restoreQuantity', { cartItem: clientItem, clientItem })
+    expect(contextMock.dispatch).toBeCalledWith('restoreQuantity', { product: clientItem })
   })
 
   it('updates server item - deletes non confirmed item', async () => {
-    const clientItem = { sku: '1', name: 'product1', qty: 2, server_item_id: 1 };
+    const clientItem = { sku: '1', name: 'product1', qty: 2 };
     const serverItem = {
       sku: '1',
       name: 'product1',
@@ -181,7 +181,7 @@ describe('Cart mergeActions', () => {
 
     await (cartActions as any).updateServerItem(contextMock, { clientItem, serverItem });
     expect(contextMock.commit).not.toBeCalledWith(types.CART_DEL_ITEM, { product: clientItem, removeByParentSku: false })
-    expect(contextMock.dispatch).not.toBeCalledWith('restoreQuantity', { cartItem: clientItem, clientItem })
+    expect(contextMock.dispatch).not.toBeCalledWith('restoreQuantity', { product: clientItem })
     expect(contextMock.commit).toBeCalledWith(types.CART_DEL_NON_CONFIRMED_ITEM, { product: clientItem })
   })
 
@@ -212,7 +212,7 @@ describe('Cart mergeActions', () => {
 
     await (cartActions as any).updateServerItem(contextMock, { clientItem, serverItem });
     expect(contextMock.commit).not.toBeCalledWith(types.CART_DEL_ITEM, { product: clientItem, removeByParentSku: false })
-    expect(contextMock.dispatch).not.toBeCalledWith('restoreQuantity', { cartItem: clientItem, clientItem })
+    expect(contextMock.dispatch).not.toBeCalledWith('restoreQuantity', { product: clientItem })
     expect(contextMock.commit).not.toBeCalledWith(types.CART_DEL_NON_CONFIRMED_ITEM, { product: clientItem })
     expect(contextMock.dispatch).toBeCalledWith('updateClientItem', { clientItem, serverItem: serverItem })
   })

--- a/core/modules/cart/test/unit/store/quantityActions.spec.ts
+++ b/core/modules/cart/test/unit/store/quantityActions.spec.ts
@@ -78,8 +78,9 @@ describe('Cart quantityActions', () => {
     const contextMock = createContextMock();
 
     (contextMock.dispatch as jest.Mock).mockImplementationOnce(() => cartItem);
-    await (cartActions as any).restoreQuantity(contextMock, { cartItem, clientItem })
-    expect(contextMock.dispatch).toBeCalledWith('updateItem', { product: { qty: 2 } })
+    await (cartActions as any).restoreQuantity(contextMock, { product: clientItem })
+    expect(contextMock.dispatch).toBeCalledWith('getItem', { product: clientItem })
+    expect(contextMock.dispatch).toBeCalledWith('updateItem', { product: { ...clientItem, qty: 2 } })
   });
 
   it('removes item that has not quantity', async () => {
@@ -89,7 +90,8 @@ describe('Cart quantityActions', () => {
     const contextMock = createContextMock();
 
     (contextMock.dispatch as jest.Mock).mockImplementationOnce(() => cartItem);
-    await (cartActions as any).restoreQuantity(contextMock, { cartItem, clientItem });
+    await (cartActions as any).restoreQuantity(contextMock, { product: clientItem });
+    expect(contextMock.dispatch).toBeCalledWith('getItem', { product: clientItem })
     expect(contextMock.dispatch).toBeCalledWith('removeItem', { product: cartItem, removeByParentSku: false })
   });
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #4619

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
we need to pass `{product}` to `getItem` method to get currentItem. 
before: `await dispatch('getItem', clientItem)`
after: `await dispatch('getItem', { product })`

Also second change which I'm not sure about is that we check `item_id` instead of `server_item_id` for `clientItem`. What I see is that `clientItem` doesn't have `item_id`. `cartItem` has it because it is added by `createCartItemForUpdate`. I couldn't find any info about this change https://github.com/DivanteLtd/vue-storefront/commit/e073566eb1423881a7f285e958cf0a08f0ff2405#diff-2101c92c40c144e3e56fb400ac211e3dL580-R605

```
-        if (clientItem.server_item_id) {
+        if (!serverItem) {
+          commit(types.CART_DEL_ITEM, { product: clientItem, removeByParentSku: false })
+        } else if (clientItem.item_id) {
```


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

