### PR TITLE
Fix yarn command in the Setup Cookbook

### DIFF
--- a/docs/guide/cookbook/setup.md
+++ b/docs/guide/cookbook/setup.md
@@ -137,7 +137,7 @@ You will see 4 containers are running, which is :
 
 4. Now that backend part is done, let's work on frontend part, install `@vue-storefront/cli`
 ```bash
-yarn add global @vue-storefront/cli 
+yarn global add @vue-storefront/cli 
 ```
 
 5. Run the `init` command in a directory where you want to install _Vue Storefront_ as follows : 


### PR DESCRIPTION
### Related Issues
None

closes #
n/a

### Short Description and Why It's Useful
The `yarn` command was incorrect in the documentation.

### Screenshots of Visual Changes before/after (if There Are Any)
n/a

### Which Environment This Relates To
n/a

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

