### PR TITLE
Next: Support for using ', " and ` in the config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@
 !**/.vuepress/**/*
 packages/about-you/composables/nuxt/plugin.js
 packages/commercetools/composables/nuxt/plugin.js
+packages/checkout-com/nuxt/plugin.js

--- a/packages/checkout-com/nuxt/plugin.js
+++ b/packages/checkout-com/nuxt/plugin.js
@@ -1,5 +1,5 @@
 import { setup } from '@vue-storefront/checkout-com';
 
 export default () => {
-  setup(JSON.parse('<%= JSON.stringify(options) %>'));
+  setup(<%= serialize(options) %>);
 };


### PR DESCRIPTION
Support for using ', " and ` in the config
Based on: https://github.com/nuxt-community/analytics-module/blob/master/lib/plugin.js