### PR TITLE
Next: CKO hotfix cko params

### DIFF
--- a/packages/checkout-com/src/configuration.ts
+++ b/packages/checkout-com/src/configuration.ts
@@ -9,15 +9,17 @@ const config = {
   }
 };
 
+interface CardConfiguration {
+  styles?: any;
+  localization?: string | CustomLocalization;
+}
+
 interface Configuration {
   publicKey: string;
   ckoWebHookUrl?: string;
   tokenizedCardKey?: string;
   saveInstrumentKey?: string;
-  card?: {
-    styles?: any;
-    localization?: string | CustomLocalization;
-  };
+  card?: CardConfiguration;
 }
 
 interface CustomLocalization {
@@ -63,4 +65,4 @@ const getFramesLocalization = () => config.card.localization;
 const getTransactionTokenKey = () => config.tokenizedCardKey;
 const getSaveInstrumentKey = () => config.saveInstrumentKey;
 
-export { setup, getPublicKey, getCkoWebhookUrl, getFramesStyles, getFramesLocalization, getCkoProxyUrl, getTransactionTokenKey, getSaveInstrumentKey, Configuration };
+export { setup, getPublicKey, getCkoWebhookUrl, getFramesStyles, getFramesLocalization, getCkoProxyUrl, getTransactionTokenKey, getSaveInstrumentKey, Configuration, CardConfiguration };

--- a/packages/checkout-com/src/useCkoCard.ts
+++ b/packages/checkout-com/src/useCkoCard.ts
@@ -2,7 +2,7 @@
 
 import { createContext, createPayment, getCustomerCards, removeSavedCard } from './payment';
 import { Ref, ref, computed } from '@vue/composition-api';
-import { getPublicKey, getFramesStyles, getTransactionTokenKey, Configuration, getFramesLocalization } from './configuration';
+import { getPublicKey, getFramesStyles, getTransactionTokenKey, CardConfiguration, getFramesLocalization } from './configuration';
 import { CkoPaymentType, buildPaymentPayloadStrategies, PaymentPropeties, PaymentInstrument } from './helpers';
 
 declare const Frames: any;
@@ -59,11 +59,11 @@ const useCkoCard = (selectedPaymentMethod: Ref<CkoPaymentType>) => {
 
   const submitForm = async () => Frames.submitCard();
 
-  const initCardForm = (params?: Omit<Configuration, 'publicKey'>) => {
-    const localization = params?.card?.localization || getFramesLocalization();
+  const initCardForm = (params?: CardConfiguration) => {
+    const localization = params?.localization || getFramesLocalization();
     Frames.init({
       publicKey: getPublicKey(),
-      style: params?.card?.styles || getFramesStyles(),
+      style: params?.styles || getFramesStyles(),
       ...(localization ? { localization } : {}),
       cardValidationChanged: () => {
         isCardValid.value = Frames.isCardValid();

--- a/packages/checkout-com/src/useCkoCard.ts
+++ b/packages/checkout-com/src/useCkoCard.ts
@@ -59,11 +59,11 @@ const useCkoCard = (selectedPaymentMethod: Ref<CkoPaymentType>) => {
 
   const submitForm = async () => Frames.submitCard();
 
-  const initCardForm = (params?: CardConfiguration) => {
-    const localization = params?.localization || getFramesLocalization();
+  const initCardForm = (cardParams?: CardConfiguration) => {
+    const localization = cardParams?.localization || getFramesLocalization();
     Frames.init({
       publicKey: getPublicKey(),
-      style: params?.styles || getFramesStyles(),
+      style: cardParams?.styles || getFramesStyles(),
       ...(localization ? { localization } : {}),
       cardValidationChanged: () => {
         isCardValid.value = Frames.isCardValid();


### PR DESCRIPTION
Fix for sending configuration to `Frames`. Currently, we need double nested `card` attribute. With this fix, it will work as it supposed to