### PR TITLE
Issue: #4735 Replace 'like' with 'eq' operator for CMS queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug in `restoreQuantity` - getItem never returns cart item - @gibkigonzo (#4619)
 - Separate variant in findProductOption to get parent sku - @gibkigonzo (#4641)
 - Fix wrong value in Cache-Control header for max-age - boehsermoe (#4657)
+- Replace use of 'like' operator with 'eq' for CMS page and block queries - @timdk (#4735)
 
 ### Changed / Improved
 

--- a/core/modules/cms/helpers/createSingleBlockQuery.ts
+++ b/core/modules/cms/helpers/createSingleBlockQuery.ts
@@ -4,7 +4,7 @@ const createSingleBlockQuery = ({ key, value }): SearchQuery => {
   let query = new SearchQuery()
 
   if (value) {
-    query = query.applyFilter({ key, value: { like: value } })
+    query = query.applyFilter({ key, value: { eq: value } })
   }
 
   return query

--- a/core/modules/cms/helpers/createSinglePageLoadQuery.ts
+++ b/core/modules/cms/helpers/createSinglePageLoadQuery.ts
@@ -4,7 +4,7 @@ const createSinglePageLoadQuery = ({ key, value }): SearchQuery => {
   let query = new SearchQuery()
 
   if (value) {
-    query = query.applyFilter({ key, value: { like: value } })
+    query = query.applyFilter({ key, value: { eq: value } })
   }
 
   return query

--- a/core/modules/cms/test/unit/createSingleBlockQuery.spec.ts
+++ b/core/modules/cms/test/unit/createSingleBlockQuery.spec.ts
@@ -8,7 +8,7 @@ describe('createSingleBlockLoadQuery should', () => {
     let [ appliedFilter ] = mockSingleBlockQuery.getAppliedFilters()
 
     expect(appliedFilter).toHaveProperty('attribute', argsMock.key)
-    expect(appliedFilter).toHaveProperty('value', { like: argsMock.value })
+    expect(appliedFilter).toHaveProperty('value', { eq: argsMock.value })
   })
 
   it('return create single block load query with base hierarchy if value is not provided', () => {

--- a/core/modules/cms/test/unit/createSinglePageLoadQuery.spec.ts
+++ b/core/modules/cms/test/unit/createSinglePageLoadQuery.spec.ts
@@ -8,7 +8,7 @@ describe('createSinglePageLoadQuery should', () => {
     let [ appliedFilter ] = singlePageMockQuery.getAppliedFilters()
 
     expect(appliedFilter).toHaveProperty('attribute', filter.key)
-    expect(appliedFilter).toHaveProperty('value', { like: filter.value })
+    expect(appliedFilter).toHaveProperty('value', { eq: filter.value })
   })
 
   it('return page loading query with base hierarchy if value is not provided', () => {


### PR DESCRIPTION
### Related Issues
closes #4735

### Short Description and Why It's Useful
CMS queries use the `like` operator which is not handled by storefront-query-builder. Using the `eq` instead works for the use case of getting a single page or block by its identifier.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

