### PR TITLE
extend the query for shipping methods with rates data

### DIFF
--- a/packages/commercetools/api-client/src/fragments/index.ts
+++ b/packages/commercetools/api-client/src/fragments/index.ts
@@ -159,9 +159,12 @@ export const ShippingMethodFragment = `
     localizedDescription(acceptLanguage: $acceptLanguage)
     zoneRates {
       zone {
+        id
         name
       }
       shippingRates {
+        freeAbove
+        isMatching
         price {
           centAmount
         }


### PR DESCRIPTION
### Short Description and Why It's Useful
Commercetools returns matching shipping methods but with all their rates so it's necessary to filter proper rates based on `isMatching` property, thus the need to query this property from ct.
