### PR TITLE
Fix newsletter subscribtion of an email address with symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug in `restoreQuantity` - getItem never returns cart item - @gibkigonzo (#4619)
 - Separate variant in findProductOption to get parent sku - @gibkigonzo (#4641)
 - Fix wrong value in Cache-Control header for max-age - boehsermoe (#4657)
+- Fix newsletter subscribtion of an email address with symbols - @rozzilla
 
 ### Changed / Improved
 

--- a/core/modules/newsletter/mixins/Subscribe.ts
+++ b/core/modules/newsletter/mixins/Subscribe.ts
@@ -27,7 +27,7 @@ export default {
     subscribe (success?: Function, failure?: Function) {
       // argument omitted for validation purposes
       if (!this.$v.$invalid) {
-        return this.$store.dispatch('newsletter/subscribe', this.email).then(res => {
+        return this.$store.dispatch('newsletter/subscribe', encodeURIComponent(this.email)).then(res => {
           if (success) success(res)
         }).catch(err => {
           if (failure) failure(err)

--- a/core/modules/newsletter/mixins/SubscriptionStatus.ts
+++ b/core/modules/newsletter/mixins/SubscriptionStatus.ts
@@ -31,7 +31,7 @@ export default {
   },
   methods: {
     async onLoggedIn () {
-      this.email = this.$store.state.user.current.email
+      this.email = encodeURIComponent(this.$store.state.user.current.email)
       this.user.isSubscribed = await this.$store.dispatch('newsletter/status', this.email)
     }
   },

--- a/core/modules/newsletter/mixins/Unsubscribe.ts
+++ b/core/modules/newsletter/mixins/Unsubscribe.ts
@@ -27,7 +27,7 @@ export default {
     unsubscribe (success?: Function, failure?: Function) {
       // argument omitted for validation purposes
       if (!this.$v.$invalid) {
-        return this.$store.dispatch('newsletter/unsubscribe', this.email).then(res => {
+        return this.$store.dispatch('newsletter/unsubscribe', encodeURIComponent(this.email)).then(res => {
           if (success) success(res)
           this.$emit('unsubscribed', res)
         }).catch(err => {


### PR DESCRIPTION
### Short Description and Why It's Useful
This PR solves the problem of the newsletter subscribe with an email containing symbols (like '+' for example). Since the email is sent as part of the URL request, now the chars are encoded.


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

