### PR TITLE
Reduce initial client-side bundle-size by lazy-loading `i18n` translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - UNRELEASED
+
+### Added
+- Reduce initial client-side bundle-size by lazy-loading `i18n` translations - @cewald (#4821)
+
 ## [1.12.2] - 2020.07.28
 
 ### Added
@@ -15,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   More info about helmet configuration https://helmetjs.github.io/docs/
 - Add config `users.tokenInHeader` which allows to send token in header instead in query. Require to set on true same config in vsf-api.
 - Make calculation of bundled products price by options optional - @cewald (#4556)
-- Reduce initial client-side bundle-size by lazy-loading `i18n` translations - @cewald (#4821)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   More info about helmet configuration https://helmetjs.github.io/docs/
 - Add config `users.tokenInHeader` which allows to send token in header instead in query. Require to set on true same config in vsf-api.
 - Make calculation of bundled products price by options optional - @cewald (#4556)
+- Reduce initial client-side bundle-size by lazy-loading `i18n` translations - @cewald (#4821)
 
 ### Fixed
 

--- a/config/default.json
+++ b/config/default.json
@@ -73,6 +73,10 @@
   },
   "initialResources": [
     {
+      "filters": ["lang-.*"],
+      "onload": false
+    },
+    {
       "filters": ["vsf-newsletter-modal", "vsf-languages-modal", "vsf-layout-empty", "vsf-layout-minimal", "vsf-order-confirmation", "vsf-search-panel"],
       "type": "script",
       "onload": true,

--- a/core/i18n/index.ts
+++ b/core/i18n/index.ts
@@ -14,7 +14,7 @@ const i18n = new VueI18n({
   locale: defaultLocale, // set locale
   fallbackLocale: defaultLocale,
   messages: config.i18n.bundleAllStoreviewLanguages ? require('./resource/i18n/multistoreLanguages.json') : {
-    [defaultLocale]: require(`./resource/i18n/${defaultLocale}.json`)
+    [defaultLocale]: require(`./resource/i18n/default.json`)
   }
 })
 
@@ -49,12 +49,13 @@ export async function loadLanguageAsync (lang: string): Promise<string> {
     if (i18n.locale !== lang) {
       if (!loadedLanguages.includes(lang)) {
         try {
-          const msgs = await import(/* webpackChunkName: "lang-[request]" */ `./resource/i18n/${lang}.json`)
+          const filename = lang === defaultLocale ? 'default' : lang
+          const msgs = await import(/* webpackChunkName: "lang-[request]" */ `./resource/i18n/${filename}.json`)
           i18n.setLocaleMessage(lang, msgs.default)
           loadedLanguages.push(lang)
           return setI18nLanguage(lang)
-        } catch (e) { // eslint-disable-line handle-callback-err
-          Logger.debug('Unable to load translation')()
+        } catch (e) {
+          Logger.debug('Unable to load translation', e.message)()
           return ''
         }
       }

--- a/core/i18n/intl.ts
+++ b/core/i18n/intl.ts
@@ -1,7 +1,7 @@
 import areIntlLocalesSupported from 'intl-locales-supported'
 
 export const importIntlPolyfill = async () => {
-  const IntlPolyfill = await import('intl')
+  const IntlPolyfill = await import(/* webpackChunkName: 'intl-polyfill' */ 'intl')
   global.Intl = IntlPolyfill.default
 }
 

--- a/core/i18n/scripts/translation.preprocessor.js
+++ b/core/i18n/scripts/translation.preprocessor.js
@@ -42,8 +42,8 @@ module.exports = function (csvDirectories, config = null) {
   })
 
   // create fallback
-  console.debug(`Writing JSON file fallback: ${fallbackLocale}.json`)
-  fs.writeFileSync(path.join(__dirname, '../resource/i18n', `${fallbackLocale}.json`), JSON.stringify(messages[fallbackLocale] || {}))
+  console.debug(`Writing fallback JSON file (${fallbackLocale}): default.json`)
+  fs.writeFileSync(path.join(__dirname, '../resource/i18n', `default.json`), JSON.stringify(messages[fallbackLocale] || {}))
 
   // bundle all messages in one file
   if (config && config.i18n.bundleAllStoreviewLanguages) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #4813

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

> If you are using a VSF shop with a lot of store-views, the app.js inside the bundle will automatically blow up because of the many different translation files it's possibly needs.

More detailed informations are in the issue #4813


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

