### PR TITLE
setupCalled fix in apiClientFactory

### DIFF
--- a/packages/about-you/api-client/package.json
+++ b/packages/about-you/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/about-you-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@aboutyou/backbone": "^7.0.0",
-    "@vue-storefront/core": "^2.0.3"
+    "@vue-storefront/core": "^2.0.4"
   },
   "files": [
     "lib/**/*"

--- a/packages/about-you/api-client/package.json
+++ b/packages/about-you/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/about-you-api",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",

--- a/packages/about-you/composables/package.json
+++ b/packages/about-you/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/about-you",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@vue-storefront/about-you-api": "^0.1.0",
-    "@vue-storefront/core": "^2.0.3",
+    "@vue-storefront/core": "^2.0.4",
     "vue": "^2.6.x"
   },
   "devDependencies": {

--- a/packages/about-you/composables/package.json
+++ b/packages/about-you/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/about-you",
-  "version": "0.0.4",
+  "version": "0.0.3",
   "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",

--- a/packages/commercetools/api-client/package.json
+++ b/packages/commercetools/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/commercetools-api",
-  "version": "0.0.8",
+  "version": "0.0.7",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",

--- a/packages/commercetools/api-client/package.json
+++ b/packages/commercetools/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/commercetools-api",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -11,7 +11,7 @@
     "test": "cross-env APP_ENV=test jest --rootDir ."
   },
   "dependencies": {
-    "@vue-storefront/core": "2.0.3",
+    "@vue-storefront/core": "2.0.4",
     "@commercetools/sdk-auth": "^3.0.1",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",

--- a/packages/commercetools/composables/package.json
+++ b/packages/commercetools/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/commercetools",
-  "version": "0.0.9",
+  "version": "0.0.8",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -11,7 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@vue-storefront/commercetools-api": "0.0.8",
+    "@vue-storefront/commercetools-api": "0.0.7",
     "@vue-storefront/core": "2.0.4",
     "js-cookie": "^2.2.1",
     "vue": "^2.6.x"

--- a/packages/commercetools/composables/package.json
+++ b/packages/commercetools/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/commercetools",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -11,8 +11,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@vue-storefront/commercetools-api": "0.0.7",
-    "@vue-storefront/core": "2.0.3",
+    "@vue-storefront/commercetools-api": "0.0.8",
+    "@vue-storefront/core": "2.0.4",
     "js-cookie": "^2.2.1",
     "vue": "^2.6.x"
   },

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/core",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",

--- a/packages/core/core/src/factories/apiClientFactory.ts
+++ b/packages/core/core/src/factories/apiClientFactory.ts
@@ -12,12 +12,12 @@ export function apiClientFactory<ALL_SETTINGS, CONFIGURABLE_SETTINGS>(factoryPar
     setup (config: ALL_SETTINGS) {
       settings = merge(factoryParams.defaultSettings, config);
       factoryParams.onSetup(settings);
-      setupCalled = true;
 
       // @ts-ignore
       if (setupCalled && __DEV__) {
         console.warn('[VSF core] "setup" function is being called multiple times. If you want to update config, please use "update" instead.');
       }
+      setupCalled = true;
     },
     update (config: CONFIGURABLE_SETTINGS) {
       settings = merge(settings, config);

--- a/packages/prismic/package.json
+++ b/packages/prismic/package.json
@@ -5,10 +5,10 @@
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
   "types": "lib/index.d.ts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sideEffect": false,
   "dependencies": {
-    "@vue-storefront/core": "^2.0.3",
+    "@vue-storefront/core": "^2.0.4",
     "prismic-dom": "^2.1.0",
     "prismic-javascript": "^2.1.5",
     "prismic-vue": "^2.0.0"

--- a/packages/prismic/package.json
+++ b/packages/prismic/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
   "types": "lib/index.d.ts",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "sideEffect": false,
   "dependencies": {
     "@vue-storefront/core": "^2.0.4",

--- a/packages/shopify/api-client/package.json
+++ b/packages/shopify/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/shopify-api",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -13,7 +13,7 @@
   "dependencies": {
     "@types/node-fetch": "^2.5.7",
     "@types/shopify-buy": "^1.11.1",
-    "@vue-storefront/core": "^2.0.3",
+    "@vue-storefront/core": "^2.0.4",
     "node-fetch": "^2.6.0",
     "shopify-buy": "^2.9.3"
   },

--- a/packages/shopify/api-client/package.json
+++ b/packages/shopify/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/shopify-api",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",

--- a/packages/shopify/composables/package.json
+++ b/packages/shopify/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/shopify",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",

--- a/packages/shopify/composables/package.json
+++ b/packages/shopify/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/shopify",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@vue-storefront/shopify-api": "^0.0.1",
-    "@vue-storefront/core": "^2.0.3",
+    "@vue-storefront/core": "^2.0.4",
     "js-cookie": "^2.2.1"
   },
   "files": [

--- a/packages/spryker/composables/package.json
+++ b/packages/spryker/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/spryker",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@vue-storefront/spryker-api": "^0.0.1",
-    "@vue-storefront/core": "2.0.3"
+    "@vue-storefront/core": "2.0.4"
   },
   "files": [
     "lib/**/*"

--- a/packages/spryker/composables/package.json
+++ b/packages/spryker/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/spryker",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "sideEffects": false,
   "main": "lib/index.cjs.js",


### PR DESCRIPTION
Simple bugfix for setupCalled in apiClientFactory that prevents from calling:
```js
console.warn('[VSF core] "setup" function is being called multiple times. If you want to update config, please use "update" instead.');
```
All the time in development mode.

Found by @Qrzy - approved by @andrzejewsky 