### PR TITLE
Setup test environment fix

### DIFF
--- a/test/unit/setupTestEnvironment.ts
+++ b/test/unit/setupTestEnvironment.ts
@@ -1,6 +1,6 @@
 import '@babel/polyfill'
-import {GlobalWithFetchMock} from 'jest-fetch-mock';
+import { GlobalWithFetchMock } from 'jest-fetch-mock';
 
-const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
+const customGlobal: GlobalWithFetchMock = (global as unknown) as GlobalWithFetchMock;
 customGlobal.fetch = require('jest-fetch-mock');
 customGlobal.fetchMock = customGlobal.fetch;


### PR DESCRIPTION
It fixes error:
```
Conversion of type 'Global & typeof globalThis' to type 'GlobalWithFetchMock' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  Property 'fetchMock' is missing in type 'Global & typeof globalThis' but required in type 'GlobalWithFetchMock'.
```