### PR TITLE
CAPI v13 without ^, Core bump

### DIFF
--- a/packages/boilerplate/api-client/package.json
+++ b/packages/boilerplate/api-client/package.json
@@ -12,7 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@vue-storefront/core": "^2.0.4"
+    "@vue-storefront/core": "^2.0.6"
   },
   "files": [
     "lib/**/*"

--- a/packages/boilerplate/composables/package.json
+++ b/packages/boilerplate/composables/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@vue-storefront/boilerplate-api": "^0.0.1",
-    "@vue-storefront/core": "^2.0.4"
+    "@vue-storefront/core": "^2.0.6"
   },
   "files": [
     "lib/**/*"

--- a/packages/boilerplate/composables/package.json
+++ b/packages/boilerplate/composables/package.json
@@ -13,8 +13,7 @@
   },
   "dependencies": {
     "@vue-storefront/boilerplate-api": "^0.0.1",
-    "@vue-storefront/core": "^2.0.4",
-    "@vue/composition-api": "^1.0.0-beta.8"
+    "@vue-storefront/core": "^2.0.4"
   },
   "files": [
     "lib/**/*"

--- a/packages/boilerplate/theme/package.json
+++ b/packages/boilerplate/theme/package.json
@@ -22,7 +22,6 @@
     "nuxt-i18n": "^6.5.0",
     "core-js": "^2.6.5",
     "nuxt": "^2.13.3",
-    "nuxt-i18n": "^6.5.0",
     "vee-validate": "^3.2.3",
     "vue-scrollto": "^2.17.1"
   },

--- a/packages/commercetools/api-client/package.json
+++ b/packages/commercetools/api-client/package.json
@@ -11,7 +11,7 @@
     "test": "cross-env APP_ENV=test jest --rootDir ."
   },
   "dependencies": {
-    "@vue-storefront/core": "2.0.5",
+    "@vue-storefront/core": "2.0.6",
     "@commercetools/sdk-auth": "^3.0.1",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",

--- a/packages/commercetools/composables/package.json
+++ b/packages/commercetools/composables/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@vue-storefront/commercetools-api": "0.1.0",
-    "@vue-storefront/core": "2.0.5",
+    "@vue-storefront/core": "2.0.6",
     "js-cookie": "^2.2.1",
     "vue": "^2.6.x"
   },

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/core",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
@@ -10,7 +10,7 @@
     "dev": "rollup -c -w"
   },
   "dependencies": {
-    "@vue/composition-api": "^1.0.0-beta.8",
+    "@vue/composition-api": "1.0.0-beta.13",
     "vue": "^2.6.11",
     "lodash-es": "^4.17.15"
   },


### PR DESCRIPTION
CAPI v13 without ^, Core bump
Boilerplate & CT uses new core