### PR TITLE
Add support for boolean filter aggregations in ES7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.13.0] - UNRELEASED
 
 ### Added
+
 - Reduce initial client-side bundle-size by lazy-loading `i18n` translations - @cewald (#4821)
 - Replaced deprecated action product/list call with product/findProducts (#4769)
+
+### Fixed
+
+- Add support for boolean filter aggregations in ES7 - @cewald (#4887)
 
 ## [1.12.2] - 2020.07.28
 

--- a/core/modules/catalog-next/store/category/getters.ts
+++ b/core/modules/catalog-next/store/category/getters.ts
@@ -62,7 +62,7 @@ const getters: GetterTree<CategoryState, RootState> = {
             }
 
             for (let option of buckets) {
-              uniqueFilterValues.add(toString(option.key))
+              uniqueFilterValues.add(toString(option.key_as_string || option.key))
             }
           }
 


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

If you're using ElasticSearch 7+ and boolean filters in CPL, they won't work because they are filtering for `1`/`0`. In ES7 and up only `true` and `false` are valid values for boolean mapped fields. This means we need to filter for `true`/`false`. As the filter-values coming from the filter aggregations of the API catalog request we need to update this part to let the VSF know which field of the aggregations bucket to use.
In ES 7 `term` aggregations with boolean values return `1`/`0` as `key` but their actually value under `key_as_string` – so we need to get the value like `key_as_string || key` to probably get a boolean value or the key of "normal" term requests.

See the documentation of the boolean filter: https://www.elastic.co/guide/en/elasticsearch/reference/7.9/boolean.html
> Aggregations like the terms aggregation use 1 and 0 for the key, and the strings "true" and "false" for the key_as_string. Boolean fields when used in scripts, return 1 and 0


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

