### PR TITLE
Next: CKO - remove ckoWebHookUrl

### DIFF
--- a/packages/checkout-com/README.md
+++ b/packages/checkout-com/README.md
@@ -30,7 +30,7 @@ If you are Developing Core of Vue Storefront Next you might need to add `@vue-st
         en: {
             publicKey: 'pk_test_your-public-key',
             secretKey: 'sk_test_your-secret-key',
-            ctApiUrl: 'https://your-commerctools-instance.com/api'
+            ctApiUrl: 'https://your-commerctools-instance.com'
         }
     },
     defaultChannel: 'en'
@@ -39,7 +39,7 @@ If you are Developing Core of Vue Storefront Next you might need to add `@vue-st
 `defaultChannel` is the channel which will be chosen by default. Value should be keyname from `channels`
 `channels` allows us to define many variants of attributes. Developer is able to change them just by calling `setChannel` 
 `publicKey` and `secretKey` comes from Checkout COM
-`ctApiUrl` is base URL to the CT CKO API
+`ctApiUrl` is base URL to the CT CKO API - do not put slash at the end!
 
 ## Render payment handlers & finalize payment
 1. Import `useCko`:

--- a/packages/checkout-com/README.md
+++ b/packages/checkout-com/README.md
@@ -30,8 +30,7 @@ If you are Developing Core of Vue Storefront Next you might need to add `@vue-st
         en: {
             publicKey: 'pk_test_your-public-key',
             secretKey: 'sk_test_your-secret-key',
-            ctApiUrl: 'https://your-commerctools-instance.com/api',
-            ckoWebHookUrl: 'https://your-commerctools-instance.com/api'
+            ctApiUrl: 'https://your-commerctools-instance.com/api'
         }
     },
     defaultChannel: 'en'
@@ -40,9 +39,7 @@ If you are Developing Core of Vue Storefront Next you might need to add `@vue-st
 `defaultChannel` is the channel which will be chosen by default. Value should be keyname from `channels`
 `channels` allows us to define many variants of attributes. Developer is able to change them just by calling `setChannel` 
 `publicKey` and `secretKey` comes from Checkout COM
-`ctApiUrl` is URL to the API endpoints which needs `secretKey` & `publicKey` it will be proxied by Express API create inside CKO Nuxt's module
-`ckoWebHookUrl` is URL to the API endpoints which needs only `publicKey` it will be used in frontend calls to the API
-We are still waiting for the confirmation if we could merge these 2 to one field.
+`ctApiUrl` is base URL to the CT CKO API
 
 ## Render payment handlers & finalize payment
 1. Import `useCko`:

--- a/packages/checkout-com/__tests__/configuration.spec.ts
+++ b/packages/checkout-com/__tests__/configuration.spec.ts
@@ -1,4 +1,4 @@
-import { defaultConfig, setup, getPublicKey, getCkoWebhookUrl, getFramesStyles, getFramesLocalization, getCkoProxyUrl, getTransactionTokenKey, getSaveInstrumentKey, getCurrentChannel, setChannel } from '../src/configuration';
+import { defaultConfig, setup, getPublicKey, getApiUrl, getFramesStyles, getFramesLocalization, getCkoProxyUrl, getTransactionTokenKey, getSaveInstrumentKey, getCurrentChannel, setChannel } from '../src/configuration';
 
 const consoleLogMock = {
   error: jest.fn()
@@ -24,7 +24,7 @@ describe('[checkout-com] configuration', () => {
     setup(config);
 
     expect(getPublicKey()).toBe(config.channels.en.publicKey);
-    expect(getCkoWebhookUrl()).toBe(defaultConfig.ckoWebHookUrl);
+    expect(getApiUrl()).toBe(defaultConfig.ctApiUrl);
     expect(getFramesStyles()).toEqual(defaultConfig.card.style);
     expect(getFramesLocalization()).toEqual(defaultConfig.card.localization);
     expect(getTransactionTokenKey()).toBe(defaultConfig.tokenizedCardKey);
@@ -38,7 +38,7 @@ describe('[checkout-com] configuration', () => {
       channels: {
         en: {
           publicKey: 'some-public-key',
-          ckoWebHookUrl: 'https://pwebhook.com/api/a',
+          ctApiUrl: 'https://pwebhook.com/api/a',
           card: {
             style: {ab: '12'},
             localization: 'en-US'
@@ -53,7 +53,7 @@ describe('[checkout-com] configuration', () => {
     setup(config);
 
     expect(getPublicKey()).toBe(config.channels.en.publicKey);
-    expect(getCkoWebhookUrl()).toBe(config.channels.en.ckoWebHookUrl);
+    expect(getApiUrl()).toBe(config.channels.en.ctApiUrl);
     expect(getFramesStyles()).toEqual(config.channels.en.card.style);
     expect(getFramesLocalization()).toEqual(config.channels.en.card.localization);
     expect(getTransactionTokenKey()).toBe(config.channels.en.tokenizedCardKey);
@@ -74,7 +74,7 @@ describe('[checkout-com] configuration', () => {
       channels: {
         en: {
           publicKey: 'some-public-key',
-          ckoWebHookUrl: 'https://pwebhook.com/api/a',
+          ctApiUrl: 'https://pwebhook.com/api/a',
           card: {
             style: {ab: '12'},
             localization: 'en-US'
@@ -84,7 +84,7 @@ describe('[checkout-com] configuration', () => {
         },
         it: {
           publicKey: 'some-public-xcxcxc-asdas',
-          ckoWebHookUrl: 'https://abcc.com/api/bbba',
+          ctApiUrl: 'https://abcc.com/api/bbba',
           card: {
             style: {asdas: '1552'},
             localization: 'it-IT'
@@ -101,7 +101,7 @@ describe('[checkout-com] configuration', () => {
     setChannel(newChannel);
 
     expect(getPublicKey()).toBe(config.channels.it.publicKey);
-    expect(getCkoWebhookUrl()).toBe(config.channels.it.ckoWebHookUrl);
+    expect(getApiUrl()).toBe(config.channels.it.ctApiUrl);
     expect(getFramesStyles()).toEqual(config.channels.it.card.style);
     expect(getFramesLocalization()).toEqual(config.channels.it.card.localization);
     expect(getTransactionTokenKey()).toBe(config.channels.it.tokenizedCardKey);
@@ -116,7 +116,7 @@ describe('[checkout-com] configuration', () => {
       channels: {
         en: {
           publicKey: 'some-public-key',
-          ckoWebHookUrl: 'https://pwebhook.com/api/a',
+          ctApiUrl: 'https://pwebhook.com/api/a',
           card: {
             style: {ab: '12'},
             localization: 'en-US'
@@ -139,7 +139,7 @@ describe('[checkout-com] configuration', () => {
       channels: {
         en: {
           publicKey: 'some-public-key',
-          ckoWebHookUrl: 'https://pwebhook.com/api/a',
+          ctApiUrl: 'https://pwebhook.com/api/a',
           card: {
             style: {ab: '12'},
             localization: 'en-US'

--- a/packages/checkout-com/__tests__/index.spec.ts
+++ b/packages/checkout-com/__tests__/index.spec.ts
@@ -1,9 +1,9 @@
-import { setup, getPublicKey, getCkoWebhookUrl, getFramesStyles, useCko, setChannel, CkoPaymentType } from '../src/index';
+import { setup, getPublicKey, getApiUrl, getFramesStyles, useCko, setChannel, CkoPaymentType } from '../src/index';
 
 jest.mock('../src/configuration.ts', () => ({
   setup: jest.fn(),
   getPublicKey: jest.fn(),
-  getCkoWebhookUrl: jest.fn(),
+  getApiUrl: jest.fn(),
   setChannel: jest.fn(),
   getFramesStyles: jest.fn()
 }));
@@ -22,7 +22,7 @@ describe('index.ts', () => {
       defaultChannel: 'en'
     });
     getPublicKey();
-    getCkoWebhookUrl();
+    getApiUrl();
     getFramesStyles();
     useCko();
 
@@ -31,7 +31,7 @@ describe('index.ts', () => {
 
     expect(setup).toHaveBeenCalled();
     expect(getPublicKey).toHaveBeenCalled();
-    expect(getCkoWebhookUrl).toHaveBeenCalled();
+    expect(getApiUrl).toHaveBeenCalled();
     expect(getFramesStyles).toHaveBeenCalled();
     expect(useCko).toHaveBeenCalled();
     expect(setChannel).toHaveBeenCalledWith(newChannel);

--- a/packages/checkout-com/__tests__/payment.spec.ts
+++ b/packages/checkout-com/__tests__/payment.spec.ts
@@ -1,7 +1,7 @@
 import { createContext, createPayment, getCustomerCards, removeSavedCard } from '../src/payment';
 
 const publicKey = 'public key';
-const ctApiUrl = 'https://webhook.com/api';
+const ctApiUrl = 'https://webhook.com';
 const ckoProxyUrl = 'https://proxy.com/api';
 const currentChannel = 'en';
 
@@ -32,7 +32,7 @@ describe('[checkout-com] payment', () => {
     createContext({ reference });
 
     expect(axios.post).toBeCalledWith(
-      `${ctApiUrl}/contexts`,
+      `${ctApiUrl}/api/contexts`,
       { reference },
       {
         crossDomain: true,
@@ -61,7 +61,7 @@ describe('[checkout-com] payment', () => {
     createContext(payload);
 
     expect(axios.post).toBeCalledWith(
-      `${ctApiUrl}/contexts`,
+      `${ctApiUrl}/api/contexts`,
       expectedPayload,
       {
         crossDomain: true,
@@ -100,7 +100,7 @@ describe('[checkout-com] payment', () => {
     createPayment(paymentPayload);
 
     expect(axios.post).toBeCalledWith(
-      `${ctApiUrl}/payments`,
+      `${ctApiUrl}/api/payments`,
       expectedRequestPayload,
       {
         crossDomain: true,

--- a/packages/checkout-com/__tests__/payment.spec.ts
+++ b/packages/checkout-com/__tests__/payment.spec.ts
@@ -1,7 +1,7 @@
 import { createContext, createPayment, getCustomerCards, removeSavedCard } from '../src/payment';
 
 const publicKey = 'public key';
-const ckoWebhookUrl = 'https://webhook.com/api';
+const ctApiUrl = 'https://webhook.com/api';
 const ckoProxyUrl = 'https://proxy.com/api';
 const currentChannel = 'en';
 
@@ -12,7 +12,7 @@ jest.mock('axios', () => ({
 }));
 jest.mock('@vue-storefront/checkout-com/src/configuration', () => ({
   getPublicKey: () => publicKey,
-  getCkoWebhookUrl: () => ckoWebhookUrl,
+  getApiUrl: () => ctApiUrl,
   getCkoProxyUrl: () => ckoProxyUrl,
   getCurrentChannel: () => currentChannel
 }));
@@ -32,7 +32,7 @@ describe('[checkout-com] payment', () => {
     createContext({ reference });
 
     expect(axios.post).toBeCalledWith(
-      `${ckoWebhookUrl}/contexts`,
+      `${ctApiUrl}/contexts`,
       { reference },
       {
         crossDomain: true,
@@ -61,7 +61,7 @@ describe('[checkout-com] payment', () => {
     createContext(payload);
 
     expect(axios.post).toBeCalledWith(
-      `${ckoWebhookUrl}/contexts`,
+      `${ctApiUrl}/contexts`,
       expectedPayload,
       {
         crossDomain: true,
@@ -100,7 +100,7 @@ describe('[checkout-com] payment', () => {
     createPayment(paymentPayload);
 
     expect(axios.post).toBeCalledWith(
-      `${ckoWebhookUrl}/payments`,
+      `${ctApiUrl}/payments`,
       expectedRequestPayload,
       {
         crossDomain: true,

--- a/packages/checkout-com/src/configuration.ts
+++ b/packages/checkout-com/src/configuration.ts
@@ -1,6 +1,6 @@
 const defaultConfig = {
   publicKey: null,
-  ckoWebHookUrl: 'https://play-commercetools.cko-playground.ckotech.co/api',
+  ctApiUrl: 'https://play-commercetools.cko-playground.ckotech.co/api',
   tokenizedCardKey: 'temporary-tokenized-card',
   saveInstrumentKey: 'save-instrument',
   card: {
@@ -22,7 +22,6 @@ interface CardConfiguration {
 
 interface Configuration {
   publicKey: string;
-  ckoWebHookUrl?: string;
   ctApiUrl?: string;
   tokenizedCardKey?: string;
   saveInstrumentKey?: string;
@@ -70,11 +69,11 @@ const setChannel = (channel: string) => {
   }
   const pickedChannel = config.channels[channel];
   config.publicKey = pickedChannel.publicKey;
-  config.ckoWebHookUrl = pickedChannel.ckoWebHookUrl || config.ckoWebHookUrl;
   config.card.style = pickedChannel.card?.style || defaultStyles;
   config.card.localization = pickedChannel.card?.localization || null;
   config.tokenizedCardKey = pickedChannel.tokenizedCardKey || config.tokenizedCardKey;
   config.saveInstrumentKey = pickedChannel.saveInstrumentKey || config.saveInstrumentKey;
+  config.ctApiUrl = pickedChannel.ctApiUrl || config.ctApiUrl;
   config.currentChannel = channel;
 };
 
@@ -88,7 +87,7 @@ const setup = ({ channels, defaultChannel }: MultichannelConfiguration) => {
 };
 
 const getPublicKey = () => config.publicKey;
-const getCkoWebhookUrl = () => config.ckoWebHookUrl;
+const getApiUrl = () => config.ctApiUrl;
 const getCkoProxyUrl = () => `${window.location.origin}/cko-api`;
 const getFramesStyles = () => config.card.style;
 const getFramesLocalization = () => config.card.localization;
@@ -96,4 +95,4 @@ const getTransactionTokenKey = () => config.tokenizedCardKey;
 const getSaveInstrumentKey = () => config.saveInstrumentKey;
 const getCurrentChannel = () => config.currentChannel;
 
-export { defaultConfig, setChannel, setup, getPublicKey, getCurrentChannel, getCkoWebhookUrl, getFramesStyles, getFramesLocalization, getCkoProxyUrl, getTransactionTokenKey, getSaveInstrumentKey, Configuration, CardConfiguration };
+export { defaultConfig, setChannel, setup, getPublicKey, getCurrentChannel, getApiUrl, getFramesStyles, getFramesLocalization, getCkoProxyUrl, getTransactionTokenKey, getSaveInstrumentKey, Configuration, CardConfiguration };

--- a/packages/checkout-com/src/index.ts
+++ b/packages/checkout-com/src/index.ts
@@ -1,6 +1,6 @@
-import { setup, getPublicKey, getCkoWebhookUrl, getFramesStyles, setChannel } from './configuration';
+import { setup, getPublicKey, getApiUrl, getFramesStyles, setChannel } from './configuration';
 import useCko from './useCko';
 import { CkoPaymentType } from './helpers';
 
-export { setup, getPublicKey, getCkoWebhookUrl, getFramesStyles, useCko, setChannel, CkoPaymentType };
+export { setup, getPublicKey, getApiUrl, getFramesStyles, useCko, setChannel, CkoPaymentType };
 

--- a/packages/checkout-com/src/payment.ts
+++ b/packages/checkout-com/src/payment.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase, @typescript-eslint/camelcase */
 import axios from 'axios';
-import { getPublicKey, getCkoWebhookUrl, getCkoProxyUrl, getCurrentChannel } from '@vue-storefront/checkout-com/src/configuration';
+import { getPublicKey, getApiUrl, getCkoProxyUrl, getCurrentChannel } from '@vue-storefront/checkout-com/src/configuration';
 import { PaymentMethodPayload } from './helpers';
 
 const createOptions = () => ({
@@ -11,14 +11,14 @@ const createOptions = () => ({
 });
 
 export const createContext = async ({ reference, email = null }) =>
-  axios.post(`${getCkoWebhookUrl()}/contexts`, {
+  axios.post(`${getApiUrl()}/contexts`, {
     reference,
     ...(email ? { customer_email: email } : {})
   }, createOptions());
 
 export const createPayment = async (payload: PaymentMethodPayload) =>
   axios.post(
-    `${getCkoWebhookUrl()}/payments`,
+    `${getApiUrl()}/payments`,
     payload,
     createOptions()
   );

--- a/packages/checkout-com/src/payment.ts
+++ b/packages/checkout-com/src/payment.ts
@@ -11,14 +11,14 @@ const createOptions = () => ({
 });
 
 export const createContext = async ({ reference, email = null }) =>
-  axios.post(`${getApiUrl()}/contexts`, {
+  axios.post(`${getApiUrl()}/api/contexts`, {
     reference,
     ...(email ? { customer_email: email } : {})
   }, createOptions());
 
 export const createPayment = async (payload: PaymentMethodPayload) =>
   axios.post(
-    `${getApiUrl()}/payments`,
+    `${getApiUrl()}/api/payments`,
     payload,
     createOptions()
   );

--- a/packages/core/docs/checkout-com/CHANGELOG.md
+++ b/packages/core/docs/checkout-com/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.0.7 (not released)
+
+- Removed `ckoWebHookUrl` ([#4910](https://github.com/DivanteLtd/vue-storefront/issues/4910))
+
+## 0.0.6 
+
+- Support for channels ([#4885](https://github.com/DivanteLtd/vue-storefront/issues/4885)) 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #4910

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
We had 2 fields in config and both were used - the thing is both had same value. I got rid of one of them - now we have only one field in config for that `ctApiUrl` - removed `ckoWebHookUrl`

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

