### PR TITLE
Creating user session token on-demand

### DIFF
--- a/packages/commercetools/api-client/__tests__/helpers/createCommerceToolsLink.spec.ts
+++ b/packages/commercetools/api-client/__tests__/helpers/createCommerceToolsLink.spec.ts
@@ -30,14 +30,14 @@ describe('[commercetools-api-client] createCommerceToolsLink', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
     // @ts-ignore
     setContext = jest.fn().mockImplementation((handler) => {
-      handler(null, { headers: { test: 1 } }).then((res) => {
+      handler({ operationName: 'test' }, { headers: { test: 1 } }).then((res) => {
         expect(res).toEqual({ headers: { test: 1,
           authorization: 'Bearer access token' } });
         done();
       });
     });
 
-    createCommerceToolsLink();
+    await createCommerceToolsLink();
 
     expect(createHttpLink).toBeCalled();
     expect(setContext).toBeCalled();

--- a/packages/commercetools/api-client/__tests__/helpers/tokenFlow.spec.ts
+++ b/packages/commercetools/api-client/__tests__/helpers/tokenFlow.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase, @typescript-eslint/camelcase */
 import * as sdk from '@commercetools/sdk-auth';
-import { isTokenUserSession } from '@vue-storefront/commercetools-api';
+import { isTokenUserSession, isTokenActive } from './../../src/helpers/token';
 import createAccessToken from './../../src/helpers/createAccessToken';
 import { setup } from './../../src/index';
 
@@ -25,8 +25,9 @@ const introspectTokenMock = jest.fn(() => ({
   active: true
 }));
 
-jest.mock('@vue-storefront/commercetools-api', () => ({
-  isTokenUserSession: jest.fn()
+jest.mock('./../../src/helpers/token', () => ({
+  isTokenUserSession: jest.fn(),
+  isTokenActive: jest.fn()
 }));
 
 jest.spyOn(sdk, 'TokenProvider').mockImplementation((_, tokenInfo) => ({
@@ -58,7 +59,7 @@ describe('[commercetools-api-client] tokenFlow', () => {
   });
 
   it('return same token', async () => {
-    introspectTokenMock.mockReturnValue({ active: true });
+    (isTokenActive as any).mockReturnValue(true);
 
     const currentToken = {
       access_token: 'bbbbb',
@@ -70,7 +71,7 @@ describe('[commercetools-api-client] tokenFlow', () => {
   });
 
   it('creates access token when there is no token  set', async () => {
-    introspectTokenMock.mockReturnValue({ active: false });
+    (isTokenActive as any).mockReturnValue(false);
     const token = await createAccessToken();
 
     expect(token).toEqual({
@@ -80,8 +81,8 @@ describe('[commercetools-api-client] tokenFlow', () => {
   });
 
   it('creates anonymous token when user session is required', async () => {
-    isTokenUserSession.mockReturnValue(false);
-    introspectTokenMock.mockReturnValue({ active: false });
+    (isTokenUserSession as any).mockReturnValue(false);
+    (isTokenActive as any).mockReturnValue(false);
     const token = await createAccessToken();
 
     expect(token).toEqual({
@@ -91,7 +92,7 @@ describe('[commercetools-api-client] tokenFlow', () => {
   });
 
   it('creates anonymous token when token is invalid', async () => {
-    introspectTokenMock.mockReturnValue({ active: false });
+    (isTokenActive as any).mockReturnValue(false);
     const token = await createAccessToken({ currentToken: null, requireUserSession: true } as any);
 
     expect(token).toEqual({
@@ -115,7 +116,7 @@ describe('[commercetools-api-client] tokenFlow', () => {
   });
 
   it('returns same token as in the configuration', async () => {
-    introspectTokenMock.mockReturnValue({ active: true });
+    (isTokenActive as any).mockReturnValue(true);
 
     const currentToken = {
       access_token: 'current token',

--- a/packages/commercetools/api-client/__tests__/helpers/tokenFlow.spec.ts
+++ b/packages/commercetools/api-client/__tests__/helpers/tokenFlow.spec.ts
@@ -127,4 +127,22 @@ describe('[commercetools-api-client] tokenFlow', () => {
 
     expect(token).toEqual(currentToken);
   });
+
+  it('returns anonymous token when old one is invalid', async () => {
+    introspectTokenMock.mockReturnValue({ active: false });
+
+    const currentToken = {
+      access_token: 'current token',
+      refresh_token: 'current refresh token',
+      scope: ''
+    };
+    setup({ ...config, currentToken } as any);
+
+    const token = await createAccessToken({ currentToken, requireUserSession: true } as any);
+
+    expect(token).toEqual({
+      access_token: 'anonymous token',
+      refresh_token: 'anonymous refresh token'
+    });
+  });
 });

--- a/packages/commercetools/api-client/src/api/getCart/index.ts
+++ b/packages/commercetools/api-client/src/api/getCart/index.ts
@@ -4,6 +4,7 @@ import defaultQuery from './defaultQuery';
 
 const getCart = async (cartId: string): Promise<CartQueryResponse> => {
   const { locale, acceptLanguage } = getSettings();
+  return null as any;
   return await apolloClient.query({
     query: defaultQuery,
     variables: { cartId,

--- a/packages/commercetools/api-client/src/api/getCart/index.ts
+++ b/packages/commercetools/api-client/src/api/getCart/index.ts
@@ -4,7 +4,6 @@ import defaultQuery from './defaultQuery';
 
 const getCart = async (cartId: string): Promise<CartQueryResponse> => {
   const { locale, acceptLanguage } = getSettings();
-  return null as any;
   return await apolloClient.query({
     query: defaultQuery,
     variables: { cartId,

--- a/packages/commercetools/api-client/src/helpers/createAccessToken/index.ts
+++ b/packages/commercetools/api-client/src/helpers/createAccessToken/index.ts
@@ -34,7 +34,6 @@ const getTokenFlow = async (sdkAuth: SdkAuth, options: FlowOptions = {}) => {
   }
 
   if (options.requireUserSession && !isTokenUserSession(currentToken)) {
-    console.log('ANON FLOW');
     return sdkAuth.anonymousFlow();
   }
 

--- a/packages/commercetools/api-client/src/helpers/createAccessToken/index.ts
+++ b/packages/commercetools/api-client/src/helpers/createAccessToken/index.ts
@@ -45,6 +45,10 @@ const getTokenFlow = async (sdkAuth: SdkAuth, options: FlowOptions = {}) => {
     }
   }
 
+  if (options.requireUserSession) {
+    return sdkAuth.anonymousFlow();
+  }
+
   return sdkAuth.clientCredentialsFlow();
 };
 

--- a/packages/commercetools/api-client/src/helpers/createAccessToken/index.ts
+++ b/packages/commercetools/api-client/src/helpers/createAccessToken/index.ts
@@ -1,12 +1,8 @@
 import SdkAuth, { TokenProvider } from '@commercetools/sdk-auth';
-import { Token, ApiConfig, CustomerCredentials } from '../../types/setup';
+import { Token, ApiConfig } from '../../types/setup';
+import { FlowOptions } from '../../types/Api';
 import { getSettings } from './../../index';
-
-interface FlowOptions {
-  currentToken?: Token;
-  customerCredentials?: CustomerCredentials;
-  requireUserSession?: boolean;
-}
+import { isTokenActive, isTokenUserSession } from './../token';
 
 const createAuthClient = (config: ApiConfig): SdkAuth =>
   new SdkAuth({
@@ -30,16 +26,6 @@ const getCurrentToken = (options: FlowOptions = {}) => {
   return options.currentToken;
 };
 
-const isTokenActive = async (sdkAuth: SdkAuth, token: Token) => {
-  const tokenIntrospection = await sdkAuth.introspectToken(token.access_token);
-
-  return tokenIntrospection.active;
-};
-
-const isTokenUserSession = (token: Token) =>
-  token.scope.includes('customer_id') ||
-  token.scope.includes('anonymous_id');
-
 const getTokenFlow = async (sdkAuth: SdkAuth, options: FlowOptions = {}) => {
   const currentToken = getCurrentToken(options);
 
@@ -48,6 +34,7 @@ const getTokenFlow = async (sdkAuth: SdkAuth, options: FlowOptions = {}) => {
   }
 
   if (options.requireUserSession && !isTokenUserSession(currentToken)) {
+    console.log('ANON FLOW');
     return sdkAuth.anonymousFlow();
   }
 

--- a/packages/commercetools/api-client/src/helpers/createCommerceToolsLink/index.ts
+++ b/packages/commercetools/api-client/src/helpers/createCommerceToolsLink/index.ts
@@ -6,11 +6,20 @@ import createAccessToken from './../createAccessToken';
 import { getSettings } from './../../index';
 import { onError } from 'apollo-link-error';
 
+const restrictedOperations = [
+  'getMe',
+  'createCart'
+];
+
 const createCommerceToolsLink = (): ApolloLink => {
   const { api, currentToken, auth } = getSettings();
   const httpLink = createHttpLink({ uri: api.uri, fetch });
-  const authLink = setContext(async (_, { headers }) => {
-    const token = await createAccessToken({ currentToken });
+  const authLink = setContext(async (req, { headers }) => {
+    const token = await createAccessToken({
+      currentToken,
+      requireUserSession: restrictedOperations.includes(req.operationName)
+    });
+
     auth.onTokenChange(token);
 
     return {

--- a/packages/commercetools/api-client/src/helpers/token/index.ts
+++ b/packages/commercetools/api-client/src/helpers/token/index.ts
@@ -1,0 +1,16 @@
+import SdkAuth from '@commercetools/sdk-auth';
+import { Token } from '../../types/setup';
+
+const isTokenActive = async (sdkAuth: SdkAuth, token: Token) => {
+  const tokenIntrospection = await sdkAuth.introspectToken(token.access_token);
+
+  return tokenIntrospection.active;
+};
+
+const isTokenUserSession = (token: Token) =>
+  token && (
+    token.scope.includes('customer_id') ||
+    token.scope.includes('anonymous_id')
+  );
+
+export { isTokenUserSession, isTokenActive };

--- a/packages/commercetools/api-client/src/index.ts
+++ b/packages/commercetools/api-client/src/index.ts
@@ -27,6 +27,7 @@ import { Config, ConfigurableConfig } from './types/setup';
 export * from './types/Api';
 export * from './types/setup';
 export * as cartActions from './helpers/cart/actions';
+export * from './helpers/token';
 
 let apolloClient: ApolloClient<any> = null;
 

--- a/packages/commercetools/api-client/src/types/Api.ts
+++ b/packages/commercetools/api-client/src/types/Api.ts
@@ -1,6 +1,7 @@
 import { ApolloQueryResult } from 'apollo-client';
 import { FetchResult } from 'apollo-link';
 import { Cart, Me, Order, ShippingMethod, CustomerSignInResult, Customer } from './GraphQL';
+import { Token, CustomerCredentials } from './setup';
 
 export interface CustomQuery<T> {
   query: any;
@@ -63,6 +64,11 @@ export enum AttributeType {
   LOCALIZED_STRING = 'LocalizedStringAttribute',
   MONEY = 'MoneyAttribute',
   BOOLEAN = 'BooleanAttribute'
+}
+export interface FlowOptions {
+  currentToken?: Token;
+  customerCredentials?: CustomerCredentials;
+  requireUserSession?: boolean;
 }
 
 export type QueryResponse<K extends string, V> = ApolloQueryResult<Record<K, V>>;

--- a/packages/commercetools/composables/__tests__/useCart/useCart.spec.ts
+++ b/packages/commercetools/composables/__tests__/useCart/useCart.spec.ts
@@ -3,7 +3,8 @@ import loadCurrentCart from './../../src/useCart/currentCart';
 import {
   addToCart as apiAddToCart,
   removeFromCart as apiRemoveFromCart,
-  updateCartQuantity as apiUpdateCartQuantity
+  updateCartQuantity as apiUpdateCartQuantity,
+  isTokenUserSession
 } from '@vue-storefront/commercetools-api';
 
 jest.mock('./../../src/useCart/currentCart');
@@ -12,7 +13,9 @@ jest.mock('@vue-storefront/commercetools-api', () => ({
   removeFromCart: jest.fn(() => ({ data: { cart: 'some cart' } })),
   updateCartQuantity: jest.fn(() => ({ data: { cart: 'some cart' } })),
   applyCartCoupon: jest.fn(() => ({ data: { cart: 'some cart' } })),
-  removeCartCoupon: jest.fn(() => ({ data: { cart: 'current cart' } }))
+  removeCartCoupon: jest.fn(() => ({ data: { cart: 'current cart' } })),
+  getSettings: jest.fn(() => ({ currentToken: 1 })),
+  isTokenUserSession: jest.fn()
 }));
 
 jest.mock('@vue-storefront/core', () => ({
@@ -26,7 +29,8 @@ describe('[commercetools-composables] useCart', () => {
     jest.clearAllMocks();
   });
 
-  it('loads current cart', async () => {
+  it('loads current cart when there is user session', async () => {
+    (isTokenUserSession as any).mockReturnValue(true);
     const { loadCart } = useCart() as any;
 
     loadCart();
@@ -34,12 +38,31 @@ describe('[commercetools-composables] useCart', () => {
     expect(loadCurrentCart).toBeCalled();
   });
 
+  it('does not loads cart without user session', async () => {
+    (isTokenUserSession as any).mockReturnValue(false);
+    const { loadCart } = useCart() as any;
+
+    loadCart();
+
+    expect(loadCurrentCart).not.toBeCalled();
+  });
+
   it('adds to cart', async () => {
     const { addToCart } = useCart() as any;
     const response = await addToCart({ currentCart: 'current cart', product: 'product1', quantity: 3 });
 
     expect(response).toEqual('some cart');
-    expect(apiAddToCart).toBeCalledWith('current cart', 'product1', 3);
+    expect(apiAddToCart).toBeCalledWith('current cart', 'product1', 3, undefined);
+  });
+
+  it('creates a new cart and add an item', async () => {
+    const { addToCart } = useCart() as any;
+    (loadCurrentCart as any).mockReturnValue('some cart');
+    const response = await addToCart({ currentCart: null, product: 'product1', quantity: 3 });
+    expect(loadCurrentCart).toBeCalled();
+
+    expect(response).toEqual('some cart');
+    expect(apiAddToCart).toBeCalledWith('some cart', 'product1', 3, undefined);
   });
 
   it('removes from cart', async () => {
@@ -47,7 +70,7 @@ describe('[commercetools-composables] useCart', () => {
     const response = await removeFromCart({ currentCart: 'current cart', product: 'product1' });
 
     expect(response).toEqual('some cart');
-    expect(apiRemoveFromCart).toBeCalledWith('current cart', 'product1');
+    expect(apiRemoveFromCart).toBeCalledWith('current cart', 'product1', undefined);
   });
 
   it('updates quantity', async () => {
@@ -59,7 +82,7 @@ describe('[commercetools-composables] useCart', () => {
     });
 
     expect(response).toEqual('some cart');
-    expect(apiUpdateCartQuantity).toBeCalledWith('current cart', { name: 'product1', quantity: 5 });
+    expect(apiUpdateCartQuantity).toBeCalledWith('current cart', { name: 'product1', quantity: 5 }, undefined);
   });
 
   it('clears cart', async () => {

--- a/packages/commercetools/composables/__tests__/useUser/factoryParams.spec.ts
+++ b/packages/commercetools/composables/__tests__/useUser/factoryParams.spec.ts
@@ -3,7 +3,9 @@ import {
   getMe as apiGetMe,
   customerSignOut as apiCustomerSignOut,
   customerChangeMyPassword as apiCustomerChangeMyPassword,
-  createCart as apiCreateCart
+  createCart as apiCreateCart,
+  customerUpdateMe as apiCustomerUpdateMe,
+  isTokenUserSession
 } from '@vue-storefront/commercetools-api';
 import { authenticate } from '../../src/useUser/authenticate';
 import { useCart } from '../../src/useCart';
@@ -17,7 +19,14 @@ jest.mock('@vue-storefront/commercetools-api', () => ({
   getMe: jest.fn(),
   customerSignOut: jest.fn(),
   customerChangeMyPassword: jest.fn(),
-  createCart: jest.fn()
+  createCart: jest.fn(),
+  customerUpdateMe: jest.fn(),
+  getSettings: jest.fn(() => ({ currentToken: 1 })),
+  isTokenUserSession: jest.fn()
+}));
+
+jest.mock('../../src/useUser', () => ({
+  setUser: jest.fn()
 }));
 
 jest.mock('../../src/useUser/authenticate', () => ({
@@ -32,6 +41,7 @@ describe('[commercetools-composables] factoryParams', () => {
 
       return error;
     };
+    (isTokenUserSession as any).mockReturnValue(true);
 
     const customer = {email: 'test@test.pl', password: '123456'};
     (apiGetMe as jest.Mock).mockReturnValueOnce({ data: { me: { customer } }});
@@ -49,6 +59,13 @@ describe('[commercetools-composables] factoryParams', () => {
 
     await expect(params.loadUser()).rejects.toThrowError('some error');
   });
+
+  it('does not loading the user without user session', async () => {
+    (isTokenUserSession as any).mockReturnValue(false);
+
+    expect(await params.loadUser()).toEqual(null);
+  });
+
   it('logOut method calls API log out method', async () => {
     (apiCreateCart as jest.Mock).mockReturnValueOnce({ data: { cart: {} }});
     const refreshCartMock = jest.fn(() => {});
@@ -57,16 +74,27 @@ describe('[commercetools-composables] factoryParams', () => {
     expect(apiCustomerSignOut).toHaveBeenCalled();
     expect(apiCreateCart).toHaveBeenCalled();
   });
+
   it('updateUser return updated user', async () => {
-    // wait until the apiClient receive userUpdate method
-    const update = {currentUser: 'Jon', updatedUserData: 'Bob'} as any;
-    expect(await params.updateUser(update)).toEqual(update);
+    const user = {currentUser: 'Jon', updatedUserData: 'Bob'} as any;
+    (apiCustomerUpdateMe as jest.Mock).mockReturnValueOnce({ user });
+
+    expect(await params.updateUser(user)).toEqual(user);
   });
+
+  it('updates the user and loads when it is not available', async () => {
+    const user = {currentUser: null, updatedUserData: 'Bob'} as any;
+    (apiCustomerUpdateMe as jest.Mock).mockReturnValueOnce({ user });
+
+    expect(await params.updateUser(user)).toEqual(user);
+  });
+
   it('register method return a new customer', async () => {
     const customer = {email: 'test@test.pl', password: '123456', firstName: 'Don', lastName: 'Jon'};
     (authenticate as jest.Mock).mockReturnValueOnce({ customer });
     expect(await params.register(customer)).toEqual(customer);
   });
+
   it('logIn method return a logged in customer', async () => {
     const refreshCartMock = jest.fn(() => {});
     (useCart as jest.Mock).mockReturnValueOnce({refreshCart: refreshCartMock});

--- a/packages/commercetools/composables/src/getters/reviewGetters.ts
+++ b/packages/commercetools/composables/src/getters/reviewGetters.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import { ReviewGetters, AgnosticRateCount } from '@vue-storefront/core';
 
 // TODO: Replace with GraphQL types when they get updated

--- a/packages/commercetools/composables/src/useCart/currentCart.ts
+++ b/packages/commercetools/composables/src/useCart/currentCart.ts
@@ -3,8 +3,13 @@ import { createCart, getMe } from '@vue-storefront/commercetools-api';
 const loadCurrentCart = async (customQueryFn = (user = null, cart = null) => ({ cart, user })) => {
   const { user, cart } = customQueryFn();
   const { data: profileData } = await getMe({ customer: false }, user);
-  if (profileData.me.activeCart) return profileData.me.activeCart;
+
+  if (profileData.me.activeCart) {
+    return profileData.me.activeCart;
+  }
+
   const { data } = await createCart({}, cart);
+
   return data.cart;
 };
 

--- a/packages/commercetools/composables/src/useCart/index.ts
+++ b/packages/commercetools/composables/src/useCart/index.ts
@@ -15,6 +15,7 @@ const getBasketItemByProduct = ({ currentCart, product }) => {
   return currentCart.lineItems.find((item) => item.productId === product._id);
 };
 
+/** returns current cart or creates new one **/
 const getCurrentCart = async (currentCart) => {
   if (!currentCart) {
     return loadCurrentCart();

--- a/packages/commercetools/composables/src/useCart/index.ts
+++ b/packages/commercetools/composables/src/useCart/index.ts
@@ -13,31 +13,49 @@ const getBasketItemByProduct = ({ currentCart, product }) => {
   return currentCart.lineItems.find((item) => item.productId === product._id);
 };
 
+const getCurrentCart = async (currentCart) => {
+  if (!currentCart) {
+    return loadCurrentCart();
+  }
+
+  return currentCart;
+};
+
 const params: UseCartFactoryParams<Cart, LineItem, ProductVariant, any> = {
   loadCart: async (customQuery?: CustomQuery) => {
     return await loadCurrentCart(customQuery);
   },
   addToCart: async ({ currentCart, product, quantity }, customQuery?: CustomQuery) => {
-    const { data } = await apiAddToCart(currentCart, product, quantity, customQuery);
+    const loadedCart = await getCurrentCart(currentCart);
+
+    const { data } = await apiAddToCart(loadedCart, product, quantity, customQuery);
     return data.cart;
   },
   removeFromCart: async ({ currentCart, product }, customQuery?: CustomQuery) => {
-    const { data } = await apiRemoveFromCart(currentCart, product, customQuery);
+    const loadedCart = await getCurrentCart(currentCart);
+
+    const { data } = await apiRemoveFromCart(loadedCart, product, customQuery);
     return data.cart;
   },
   updateQuantity: async ({ currentCart, product, quantity }, customQuery?: CustomQuery) => {
-    const { data } = await apiUpdateCartQuantity(currentCart, { ...product, quantity }, customQuery);
+    const loadedCart = await getCurrentCart(currentCart);
+
+    const { data } = await apiUpdateCartQuantity(loadedCart, { ...product, quantity }, customQuery);
     return data.cart;
   },
   clearCart: async ({ currentCart }) => {
     return currentCart;
   },
   applyCoupon: async ({ currentCart, coupon }, customQuery?: CustomQuery) => {
-    const { data } = await apiApplyCartCoupon(currentCart, coupon, customQuery);
+    const loadedCart = await getCurrentCart(currentCart);
+
+    const { data } = await apiApplyCartCoupon(loadedCart, coupon, customQuery);
     return { updatedCart: data.cart, updatedCoupon: coupon };
   },
   removeCoupon: async ({ currentCart, coupon }, customQuery?: CustomQuery) => {
-    const { data } = await apiRemoveCartCoupon(currentCart, coupon, customQuery);
+    const loadedCart = await getCurrentCart(currentCart);
+
+    const { data } = await apiRemoveCartCoupon(loadedCart, coupon, customQuery);
     return { updatedCart: data.cart };
   },
   isOnCart: ({ currentCart, product }) => {

--- a/packages/commercetools/composables/src/useCart/index.ts
+++ b/packages/commercetools/composables/src/useCart/index.ts
@@ -3,7 +3,9 @@ import {
   removeFromCart as apiRemoveFromCart,
   updateCartQuantity as apiUpdateCartQuantity,
   applyCartCoupon as apiApplyCartCoupon,
-  removeCartCoupon as apiRemoveCartCoupon
+  removeCartCoupon as apiRemoveCartCoupon,
+  getSettings,
+  isTokenUserSession
 } from '@vue-storefront/commercetools-api';
 import { ProductVariant, Cart, LineItem } from './../types/GraphQL';
 import loadCurrentCart from './currentCart';
@@ -23,6 +25,12 @@ const getCurrentCart = async (currentCart) => {
 
 const params: UseCartFactoryParams<Cart, LineItem, ProductVariant, any> = {
   loadCart: async (customQuery?: CustomQuery) => {
+    const settings = getSettings();
+
+    if (!isTokenUserSession(settings.currentToken)) {
+      return null;
+    }
+
     return await loadCurrentCart(customQuery);
   },
   addToCart: async ({ currentCart, product, quantity }, customQuery?: CustomQuery) => {

--- a/packages/commercetools/composables/src/useReview/index.ts
+++ b/packages/commercetools/composables/src/useReview/index.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import { useReviewFactory, UseReview, UseReviewFactoryParams } from '@vue-storefront/core';
 
 const params: UseReviewFactoryParams<any, any, any> = {

--- a/packages/commercetools/composables/src/useUser/factoryParams.ts
+++ b/packages/commercetools/composables/src/useUser/factoryParams.ts
@@ -8,12 +8,20 @@ import {
   customerUpdateMe as apiCustomerUpdateMe,
   getMe as apiGetMe,
   createCart,
-  customerChangeMyPassword as apiCustomerChangeMyPassword
+  customerChangeMyPassword as apiCustomerChangeMyPassword,
+  getSettings,
+  isTokenUserSession
 } from '@vue-storefront/commercetools-api';
 import { setCart } from '../useCart';
 import { setUser } from '../useUser';
 
 const loadUser = async (customQuery?: CustomQuery) => {
+  const settings = getSettings();
+
+  if (!isTokenUserSession(settings.currentToken)) {
+    return null;
+  }
+
   try {
     const profile = await apiGetMe({ customer: true }, customQuery);
     return profile.data.me.customer;

--- a/packages/commercetools/theme/middleware/checkout.js
+++ b/packages/commercetools/theme/middleware/checkout.js
@@ -10,6 +10,9 @@ const canEnterReview = cart => Boolean(cart.billingAddress);
 
 export default async ({ app }) => {
   const currentPath = app.context.route.fullPath.split('/checkout/')[1];
+
+  if (!currentPath) return;
+
   const { data: { me: { activeCart } } } = await getMe();
 
   if (!activeCart) return;

--- a/packages/core/core/__tests__/factories/useUserFactory.spec.ts
+++ b/packages/core/core/__tests__/factories/useUserFactory.spec.ts
@@ -114,11 +114,11 @@ describe('[CORE - factories] useUserFactory', () => {
         expect(useUserMethods.loading.value).toBe(false);
       });
     });
-    describe('refreshUser', () => {
-      it('return refreshed user', async () => {
+    describe('loadUser', () => {
+      it('return loadedUser user', async () => {
         const user = {firstName: 'John', lastName: 'Galt'};
         factoryParams.loadUser.mockReturnValueOnce(user);
-        await useUserMethods.refreshUser();
+        await useUserMethods.loadUser();
         expect(factoryParams.loadUser).toHaveBeenCalled();
         expect(useUserMethods.user.value).toEqual(user);
       });
@@ -126,7 +126,7 @@ describe('[CORE - factories] useUserFactory', () => {
         factoryParams.loadUser.mockImplementationOnce(() => {
           throw 'Error';
         });
-        await expect(useUserMethods.refreshUser()).rejects.toThrow('Error');
+        await expect(useUserMethods.loadUser()).rejects.toThrow('Error');
       });
       it('finally loading go to false', () => {
         expect(useUserMethods.loading.value).toBe(false);

--- a/packages/core/core/__tests__/factories/useUserFactory.spec.ts
+++ b/packages/core/core/__tests__/factories/useUserFactory.spec.ts
@@ -118,7 +118,7 @@ describe('[CORE - factories] useUserFactory', () => {
       it('return loadedUser user', async () => {
         const user = {firstName: 'John', lastName: 'Galt'};
         factoryParams.loadUser.mockReturnValueOnce(user);
-        await useUserMethods.loadUser();
+        await useUserMethods.load();
         expect(factoryParams.loadUser).toHaveBeenCalled();
         expect(useUserMethods.user.value).toEqual(user);
       });
@@ -126,7 +126,7 @@ describe('[CORE - factories] useUserFactory', () => {
         factoryParams.loadUser.mockImplementationOnce(() => {
           throw 'Error';
         });
-        await expect(useUserMethods.loadUser()).rejects.toThrow('Error');
+        await expect(useUserMethods.load()).rejects.toThrow('Error');
       });
       it('finally loading go to false', () => {
         expect(useUserMethods.loading.value).toBe(false);

--- a/packages/core/core/src/factories/useUserFactory.ts
+++ b/packages/core/core/src/factories/useUserFactory.ts
@@ -1,6 +1,6 @@
 import { Ref, computed } from '@vue/composition-api';
 import { UseUser } from '../types';
-import { sharedRef, onSSR } from '../utils';
+import { sharedRef } from '../utils';
 
 export interface UseUserFactoryParams<USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS> {
   loadUser: () => Promise<USER>;
@@ -85,7 +85,7 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
       }
     };
 
-    const refreshUser = async () => {
+    const loadUser = async () => {
       loading.value = true;
       try {
         user.value = await factoryParams.loadUser();
@@ -96,13 +96,6 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
       }
     };
 
-    // Temporary enabled by default, related rfc: https://github.com/DivanteLtd/next/pull/330
-    onSSR(async () => {
-      if (!user.value) {
-        await refreshUser();
-      }
-    });
-
     return {
       user: computed(() => user.value),
       updateUser,
@@ -111,7 +104,7 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
       logout,
       isAuthenticated,
       changePassword,
-      refreshUser,
+      loadUser,
       loading: computed(() => loading.value)
     };
   };

--- a/packages/core/core/src/factories/useUserFactory.ts
+++ b/packages/core/core/src/factories/useUserFactory.ts
@@ -85,7 +85,7 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
       }
     };
 
-    const loadUser = async () => {
+    const load = async () => {
       loading.value = true;
       try {
         user.value = await factoryParams.loadUser();
@@ -104,7 +104,7 @@ export const useUserFactory = <USER, UPDATE_USER_PARAMS, REGISTER_USER_PARAMS ex
       logout,
       isAuthenticated,
       changePassword,
-      loadUser,
+      load,
       loading: computed(() => loading.value)
     };
   };

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -54,7 +54,7 @@ export interface UseUser
   changePassword: (
     currentPassword: string,
     newPassword: string) => Promise<void>;
-  loadUser: () => Promise<void>;
+  load: () => Promise<void>;
   isAuthenticated: Ref<boolean>;
   loading: ComputedProperty<boolean>;
 }

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -54,7 +54,7 @@ export interface UseUser
   changePassword: (
     currentPassword: string,
     newPassword: string) => Promise<void>;
-  refreshUser: () => Promise<void>;
+  loadUser: () => Promise<void>;
   isAuthenticated: Ref<boolean>;
   loading: ComputedProperty<boolean>;
 }

--- a/packages/core/docs/commercetools/changelog.md
+++ b/packages/core/docs/commercetools/changelog.md
@@ -5,6 +5,7 @@
 - fixed updateUser on useUser composable ([#4863](https://github.com/DivanteLtd/vue-storefront/issues/4863))
 - implemented useReviews on product page ([#4800](https://github.com/DivanteLtd/vue-storefront/issues/4800))
 - implemented faceting using useFacet factory (#4853)
+- fixed anonymous token loading (#4917)
 
 ## 0.1.0
 

--- a/packages/core/docs/contributing/changelog.md
+++ b/packages/core/docs/contributing/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 ## 2.1.0 (not released)
 
-- renamed refreshUser to load in useUser (#4917)
+- renamed `refreshUser` to `load` in `useUser`, user shouldn't be automatically loaded now (#4917)
 
 ## 2.0.6
 

--- a/packages/core/docs/contributing/changelog.md
+++ b/packages/core/docs/contributing/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 ## 2.1.0 (not released)
 
+- renamed refreshUser to load in useUser (#4917)
+
 ## 2.0.6
 
 - renamed useReviews factory to useReview (#4800)

--- a/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
+++ b/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
@@ -81,6 +81,8 @@ export default {
     };
 
     onSSR(async () => {
+      await loadUser();
+      await loadCart();
       await loadWishlist();
     });
 

--- a/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
+++ b/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
@@ -2,7 +2,7 @@
   <SfHeader
     data-cy="app-header"
     active-sidebar="activeSidebar"
-    @click:cart="handleSidebarOpen"
+    @click:cart="toggleCartSidebar"
     @click:wishlist="toggleWishlistSidebar"
     @click:account="handleAccountClick"
     :cartItemsQty="cartTotalItems"
@@ -65,14 +65,7 @@ export default {
 
     const accountIcon = computed(() => isAuthenticated.value ? 'profile_fill' : 'profile');
 
-    const handleSidebarOpen = async () => {
-      await loadCart();
-      toggleCartSidebar();
-    };
-
     const handleAccountClick = async () => {
-      await loadUser();
-
       if (isAuthenticated.value) {
         return root.$router.push('/my-account');
       }
@@ -90,7 +83,7 @@ export default {
       accountIcon,
       cartTotalItems,
       handleAccountClick,
-      handleSidebarOpen,
+      toggleCartSidebar,
       toggleWishlistSidebar
     };
   }

--- a/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
+++ b/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
@@ -2,9 +2,9 @@
   <SfHeader
     data-cy="app-header"
     active-sidebar="activeSidebar"
-    @click:cart="toggleCartSidebar"
+    @click:cart="handleSidebarOpen"
     @click:wishlist="toggleWishlistSidebar"
-    @click:account="onAccountClicked"
+    @click:account="handleAccountClick"
     :cartItemsQty="cartTotalItems"
     :accountIcon="accountIcon"
     class="sf-header--has-mobile-search"
@@ -55,7 +55,7 @@ export default {
     LocaleSelector
   },
   setup(props, { root }) {
-    const { isAuthenticated } = useUser();
+    const { isAuthenticated, loadUser } = useUser();
     const { cart, loadCart } = useCart();
     const { loadWishlist } = useWishlist();
     const cartTotalItems = computed(() => {
@@ -65,21 +65,30 @@ export default {
 
     const accountIcon = computed(() => isAuthenticated.value ? 'profile_fill' : 'profile');
 
-    const onAccountClicked = () => {
-      isAuthenticated && isAuthenticated.value ? root.$router.push('/my-account') : toggleLoginModal();
+    const handleSidebarOpen = async () => {
+      await loadCart();
+      toggleCartSidebar();
+    };
+
+    const handleAccountClick = async () => {
+      await loadUser();
+
+      if (isAuthenticated.value) {
+        return root.$router.push('/my-account');
+      }
+
+      toggleLoginModal();
     };
 
     onSSR(async () => {
-      await loadCart();
       await loadWishlist();
     });
 
     return {
       accountIcon,
       cartTotalItems,
-      toggleLoginModal,
-      onAccountClicked,
-      toggleCartSidebar,
+      handleAccountClick,
+      handleSidebarOpen,
       toggleWishlistSidebar
     };
   }

--- a/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
+++ b/packages/core/nuxt-theme-module/theme/components/AppHeader.vue
@@ -55,7 +55,7 @@ export default {
     LocaleSelector
   },
   setup(props, { root }) {
-    const { isAuthenticated, loadUser } = useUser();
+    const { isAuthenticated, load } = useUser();
     const { cart, loadCart } = useCart();
     const { loadWishlist } = useWishlist();
     const cartTotalItems = computed(() => {
@@ -65,6 +65,7 @@ export default {
 
     const accountIcon = computed(() => isAuthenticated.value ? 'profile_fill' : 'profile');
 
+    // TODO: https://github.com/DivanteLtd/vue-storefront/issues/4927
     const handleAccountClick = async () => {
       if (isAuthenticated.value) {
         return root.$router.push('/my-account');
@@ -74,7 +75,7 @@ export default {
     };
 
     onSSR(async () => {
-      await loadUser();
+      await load();
       await loadCart();
       await loadWishlist();
     });

--- a/packages/core/nuxt-theme-module/theme/components/CartSidebar.vue
+++ b/packages/core/nuxt-theme-module/theme/components/CartSidebar.vue
@@ -89,6 +89,7 @@ import {
 import { computed } from '@vue/composition-api';
 import { useCart, useUser, cartGetters } from '<%= options.generate.replace.composables %>';
 import uiState from '~/assets/ui-state';
+import { onSSR } from '@vue-storefront/core';
 
 const { isCartSidebarOpen, toggleCartSidebar } = uiState;
 
@@ -104,11 +105,15 @@ export default {
     SfCollectedProduct
   },
   setup() {
-    const { cart, removeFromCart, updateQuantity } = useCart();
+    const { cart, removeFromCart, updateQuantity, loadCart } = useCart();
     const { isAuthenticated } = useUser();
     const products = computed(() => cartGetters.getItems(cart.value));
     const totals = computed(() => cartGetters.getTotals(cart.value));
     const totalItems = computed(() => cartGetters.getTotalItems(cart.value));
+
+    onSSR(async () => {
+      await loadCart();
+    });
 
     return {
       isAuthenticated,

--- a/packages/core/nuxt-theme-module/theme/components/CartSidebar.vue
+++ b/packages/core/nuxt-theme-module/theme/components/CartSidebar.vue
@@ -88,7 +88,6 @@ import {
 } from '@storefront-ui/vue';
 import { computed } from '@vue/composition-api';
 import { useCart, useUser, cartGetters } from '<%= options.generate.replace.composables %>';
-import { onSSR } from '@vue-storefront/core';
 import uiState from '~/assets/ui-state';
 
 const { isCartSidebarOpen, toggleCartSidebar } = uiState;
@@ -105,15 +104,11 @@ export default {
     SfCollectedProduct
   },
   setup() {
-    const { cart, removeFromCart, updateQuantity, loadCart } = useCart();
+    const { cart, removeFromCart, updateQuantity } = useCart();
     const { isAuthenticated } = useUser();
     const products = computed(() => cartGetters.getItems(cart.value));
     const totals = computed(() => cartGetters.getTotals(cart.value));
     const totalItems = computed(() => cartGetters.getTotalItems(cart.value));
-
-    onSSR(async () => {
-      await loadCart();
-    });
 
     return {
       isAuthenticated,

--- a/packages/core/nuxt-theme-module/theme/pages/Category.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Category.vue
@@ -122,7 +122,7 @@
             :isOnWishlist="false"
             :isAddedToCart="isOnCart(product)"
             @click:wishlist="addToWishlist(product)"
-            @click:add-to-cart="handleAddToCart(product, 1)"
+            @click:add-to-cart="addToCart(product, 1)"
             :link="localePath(`/p/${productGetters.getId(product)}/${productGetters.getSlug(product)}`)"
             class="products__product-card"
           />
@@ -261,7 +261,7 @@ export default {
   setup(props, context) {
     onMounted(() => context.root.$scrollTo(context.root.$el, 2000));
     const th = useUiHelpers();
-    const { addToCart, isOnCart, loadCart } = useCart();
+    const { addToCart, isOnCart } = useCart();
     const { addToWishlist } = useWishlist();
     const { result, search, loading } = useFacet();
 
@@ -276,11 +276,6 @@ export default {
       await search(th.getFacetsFromURL());
     });
 
-    const handleAddToCart = async (product, qty) => {
-      await loadCart();
-      await addToCart(product, qty);
-    };
-
     return {
       ...uiState,
       th,
@@ -293,7 +288,7 @@ export default {
       facets,
       breadcrumbs,
       addToWishlist,
-      handleAddToCart,
+      addToCart,
       isOnCart
     };
   },

--- a/packages/core/nuxt-theme-module/theme/pages/Category.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Category.vue
@@ -122,7 +122,7 @@
             :isOnWishlist="false"
             :isAddedToCart="isOnCart(product)"
             @click:wishlist="addToWishlist(product)"
-            @click:add-to-cart="addToCart(product, 1)"
+            @click:add-to-cart="handleAddToCart(product, 1)"
             :link="localePath(`/p/${productGetters.getId(product)}/${productGetters.getSlug(product)}`)"
             class="products__product-card"
           />
@@ -261,7 +261,7 @@ export default {
   setup(props, context) {
     onMounted(() => context.root.$scrollTo(context.root.$el, 2000));
     const th = useUiHelpers();
-    const { loadCart, addToCart, isOnCart } = useCart();
+    const { addToCart, isOnCart, loadCart } = useCart();
     const { addToWishlist } = useWishlist();
     const { result, search, loading } = useFacet();
 
@@ -274,8 +274,12 @@ export default {
 
     onSSR(async () => {
       await search(th.getFacetsFromURL());
-      await loadCart();
     });
+
+    const handleAddToCart = async (product, qty) => {
+      await loadCart();
+      await addToCart(product, qty);
+    };
 
     return {
       ...uiState,
@@ -289,7 +293,7 @@ export default {
       facets,
       breadcrumbs,
       addToWishlist,
-      addToCart,
+      handleAddToCart,
       isOnCart
     };
   },

--- a/packages/core/nuxt-theme-module/theme/pages/Product.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Product.vue
@@ -230,7 +230,7 @@ export default {
     const { id } = context.root.$route.params;
     const { products, search } = useProduct('products');
     const { products: relatedProducts, search: searchRelatedProducts, loading: relatedLoading } = useProduct('relatedProducts');
-    const { addToCart, loading, loadCart } = useCart();
+    const { addToCart, loading } = useCart();
     const { reviews: productReviews, search: searchReviews } = useReview('productReviews');
 
     const product = computed(() => productGetters.getFiltered(products.value, { master: true, attributes: context.root.$route.query })[0]);
@@ -248,7 +248,6 @@ export default {
     })));
 
     onSSR(async () => {
-      await loadCart();
       await search({ id });
       await searchRelatedProducts({ catId: [categories.value[0]], limit: 8 });
       await searchReviews({ productId: id });


### PR DESCRIPTION
We used to create an anonymous token (user session) each time user visited the page which can end up with so many opened user sessions. 

This PR introduces creating that token only on-demand when we really need to open user session eg. when we interact with the cart or user profile
