### PR TITLE
Next: Fix for CLI 

### DIFF
--- a/packages/core/cli/package.json
+++ b/packages/core/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/cli",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "",
   "main": "./lib/index.js",
   "bin": {
@@ -16,10 +16,10 @@
   "dependencies": {
     "inquirer": "^7.3.3",
     "chokidar": "^3.3.1",
-    "consola": "^2.10.1"
+    "consola": "^2.10.1",
+    "@vue-storefront/nuxt-theme": "^0.0.3"
   },
   "devDependencies": {
-    "@vue-storefront/nuxt-theme": "^0.0.3",
     "@vue-storefront/commercetools-theme": "^0.1.0"
   },
   "author": "Filip Jędrasik",

--- a/packages/core/cli/src/index.ts
+++ b/packages/core/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import log from './utils/log';
+import path from 'path';
 
 export const cli = async (args) => {
   const [command] = args.slice(2);
@@ -9,11 +10,11 @@ export const cli = async (args) => {
   }
 
   try {
-    const commandFn = require(`./commands/${command}.ts`);
+    const commandFn = require(path.join(__dirname, `./commands/${command}.ts`));
     return commandFn.default(args.slice(3));
   } catch (err) {
     try {
-      const commandFn = require(`./commands/${command}.js`);
+      const commandFn = require(path.join(__dirname, `./commands/${command}.js`));
       return commandFn.default(args.slice(3));
     } catch (err) {
       log.error('Bad command');

--- a/packages/core/docs/cli/CHANGELOG.md
+++ b/packages/core/docs/cli/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2.0.6
+
+- `@vue-storefront/nuxt-theme` as `dependency` not `devDependency` and using absolute paths in index of CLI to fix not working commands ([#4932](https://github.com/DivanteLtd/vue-storefront/issues/4932))


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
It fixes problems with not working CLI Init command.
Closes #4932

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
It was caused be one of these 2:
- `"@vue-storefront/nuxt-theme": "^0.0.3"` was devDependency so developers did not have it while installed globally - and CLI's code have been throwing an error because there are import from `"@vue-storefront/nuxt-theme"` inside the code.
- now using path.join while importing commands dynamicly

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

