### PR TITLE
Fix types for CT api-client and composables

### DIFF
--- a/packages/commercetools/api-client/__tests__/api/getMyOrders/getMyOrders.spec.ts
+++ b/packages/commercetools/api-client/__tests__/api/getMyOrders/getMyOrders.spec.ts
@@ -1,10 +1,10 @@
 import getOrders from '../../../src/api/getMyOrders';
 import { apolloClient } from '../../../src/index';
 import defaultQuery from '../../../src/api/getMyOrders/defaultQuery';
-import { OrderSearch } from '../../../src/types/Api';
+import { OrderWhereSearch } from '../../../src/types/Api';
 
 describe('[commercetools-api-client] getMyOrders', () => {
-  const params: OrderSearch = {
+  const params: OrderWhereSearch = {
     id: 'fvdrt8gaw4r',
     limit: 10,
     offset: 0

--- a/packages/commercetools/api-client/__tests__/helpers/search.spec.ts
+++ b/packages/commercetools/api-client/__tests__/helpers/search.spec.ts
@@ -3,7 +3,7 @@ import {
   buildCategoryWhere,
   buildOrderWhere
 } from './../../src/helpers/search';
-import { AttributeType, ProductSearch } from '../../src/types/Api';
+import { AttributeType, ProductWhereSearch } from '../../src/types/Api';
 import { getSettings } from '../../src';
 
 describe('[commercetools-api-client] search', () => {
@@ -54,7 +54,7 @@ describe('[commercetools-api-client] search', () => {
     });
 
     it(`returns product search query by ${AttributeType.STRING}`, () => {
-      const search: ProductSearch = {
+      const search: ProductWhereSearch = {
         filters: [
           { type: AttributeType.STRING, value: 'stringValue', name: 'whatever' }
         ]
@@ -65,7 +65,7 @@ describe('[commercetools-api-client] search', () => {
 
     describe(`returns product search query by ${AttributeType.DATE}`, () => {
       it('when single value', () => {
-        const search: ProductSearch = {
+        const search: ProductWhereSearch = {
           filters: [
             { type: AttributeType.STRING, value: 'dateValue', name: 'whatever' }
           ]
@@ -75,7 +75,7 @@ describe('[commercetools-api-client] search', () => {
       });
 
       it('when multiple value', () => {
-        const search: ProductSearch = {
+        const search: ProductWhereSearch = {
           filters: [
             { type: AttributeType.DATE, value: ['dateValue1', 'dateValue2'], name: 'whatever' }
           ]
@@ -87,7 +87,7 @@ describe('[commercetools-api-client] search', () => {
 
     describe(`returns product search query by ${AttributeType.NUMBER}`, () => {
       it('when single value', () => {
-        const search: ProductSearch = {
+        const search: ProductWhereSearch = {
           filters: [
             { type: AttributeType.NUMBER, value: 1, name: 'whatever' }
           ]
@@ -96,7 +96,7 @@ describe('[commercetools-api-client] search', () => {
         expect(buildProductWhere(search)).toEqual('masterData(current(masterVariant(attributes(name = "whatever" and value = 1))))');
       });
       it('when pair of values', () => {
-        const search: ProductSearch = {
+        const search: ProductWhereSearch = {
           filters: [
             { type: AttributeType.NUMBER, value: [100, 200], name: 'whatever' }
           ]
@@ -106,7 +106,7 @@ describe('[commercetools-api-client] search', () => {
     });
 
     it(`returns product search query by ${AttributeType.ENUM}`, () => {
-      const search: ProductSearch = {
+      const search: ProductWhereSearch = {
         filters: [
           { type: AttributeType.ENUM, value: 'enumValue', name: 'whatever' }
         ]
@@ -116,7 +116,7 @@ describe('[commercetools-api-client] search', () => {
     });
 
     it(`returns product search query by ${AttributeType.LOCALIZED_STRING}`, () => {
-      const search: ProductSearch = {
+      const search: ProductWhereSearch = {
         filters: [
           { type: AttributeType.LOCALIZED_STRING, value: 'locStringValue', name: 'whatever' }
         ]
@@ -128,7 +128,7 @@ describe('[commercetools-api-client] search', () => {
 
     describe(`returns product search query by ${AttributeType.MONEY}`, () => {
       it('when single value', () => {
-        const search: ProductSearch = {
+        const search: ProductWhereSearch = {
           filters: [
             { type: AttributeType.MONEY, value: 200, name: 'whatever' }
           ]
@@ -139,7 +139,7 @@ describe('[commercetools-api-client] search', () => {
         expect(buildProductWhere(search)).toEqual(`masterData(current(masterVariant(attributes(name = "whatever" and value(centAmount = 200 and currencyCode = "${currency.toUpperCase()}")))))`);
       });
       it('when pair of values', () => {
-        const search: ProductSearch = {
+        const search: ProductWhereSearch = {
           filters: [
             { type: AttributeType.MONEY, value: [100, 200], name: 'whatever' }
           ]
@@ -153,7 +153,7 @@ describe('[commercetools-api-client] search', () => {
 
     it(`returns product search query by ${AttributeType.BOOLEAN}`, () => {
 
-      const search: ProductSearch = {
+      const search: ProductWhereSearch = {
         filters: [
           { type: AttributeType.BOOLEAN, value: true, name: 'whatever' }
         ]

--- a/packages/commercetools/api-client/package.json
+++ b/packages/commercetools/api-client/package.json
@@ -4,7 +4,7 @@
   "sideEffects": false,
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
-  "types": "lib/index.d.ts",
+  "types": "lib/commercetools/api-client/src/index.d.ts",
   "scripts": {
     "build": "rimraf lib && rollup -c",
     "dev": "rollup -c -w",

--- a/packages/commercetools/api-client/src/api/getCategory/index.ts
+++ b/packages/commercetools/api-client/src/api/getCategory/index.ts
@@ -1,8 +1,7 @@
-import { ApolloQueryResult } from 'apollo-client';
 import gql from 'graphql-tag';
-import {apolloClient, getCustomQuery, getSettings} from './../../index';
-import { CategoryQueryResult } from './../../types/GraphQL';
 import defaultQuery from './defaultQuery';
+import { CategoryQueryResult } from './../../types/GraphQL';
+import { apolloClient, getCustomQuery, getSettings } from './../../index';
 import { buildCategoryWhere, resolveCustomQueryVariables } from './../../helpers/search';
 
 interface CategoryData {
@@ -18,11 +17,13 @@ const getCategory = async (params, customQueryFn?) => {
     offset: params.offset,
     acceptLanguage
   } : { acceptLanguage }, variables, 'category');
-  const request = await apolloClient.query<ApolloQueryResult<CategoryData>>({
+
+  const request = await apolloClient.query<CategoryData>({
     query: gql`${query}`,
     variables: resolvedVariables,
     fetchPolicy: 'no-cache'
   });
+
   return {
     ...request,
     query,

--- a/packages/commercetools/api-client/src/api/getMe/index.ts
+++ b/packages/commercetools/api-client/src/api/getMe/index.ts
@@ -1,12 +1,15 @@
-import { apolloClient, getCustomQuery, getSettings } from './../../index';
-import { ProfileResponse } from './../../types/Api';
+import { apolloClient, getCustomQuery, getSettings, MeQueryInterface } from './../../index';
 import { basicProfile, fullProfile } from './defaultQuery';
 import { resolveCustomQueryVariables } from '../../helpers/search';
-import { ApolloQueryResult } from 'apollo-client';
 import gql from 'graphql-tag';
 
 interface Options {
   customer?: boolean;
+}
+
+interface OrdersData {
+  // TODO: When https://github.com/DivanteLtd/vue-storefront/issues/4900 is finished, please change to Pick<MeQueryInterface, "activeCart" | "customer">;
+  me: Partial<MeQueryInterface>;
 }
 
 const getMe = async (params: Options = {}, customQueryFn?) => {
@@ -20,13 +23,15 @@ const getMe = async (params: Options = {}, customQueryFn?) => {
     },
     variables
   );
-  const request = await apolloClient.query<ApolloQueryResult<ProfileResponse>>({
+
+  const request = await apolloClient.query<OrdersData>({
     query: customer
       ? fullProfile
       : query ? gql`${query}` : basicProfile,
     variables: resolvedVariables,
     fetchPolicy: 'no-cache'
   });
+
   return {
     ...request,
     query: customer ? fullProfile : basicProfile,

--- a/packages/commercetools/api-client/src/api/getMe/index.ts
+++ b/packages/commercetools/api-client/src/api/getMe/index.ts
@@ -1,4 +1,4 @@
-import { apolloClient, getCustomQuery, getSettings, MeQueryInterface } from './../../index';
+import { apolloClient, getCustomQuery, getSettings } from './../../index';
 import { basicProfile, fullProfile } from './defaultQuery';
 import { resolveCustomQueryVariables } from '../../helpers/search';
 import gql from 'graphql-tag';
@@ -8,8 +8,8 @@ interface Options {
 }
 
 interface OrdersData {
-  // TODO: When https://github.com/DivanteLtd/vue-storefront/issues/4900 is finished, please change to Pick<MeQueryInterface, "activeCart" | "customer">;
-  me: Partial<MeQueryInterface>;
+  // TODO: When https://github.com/DivanteLtd/vue-storefront/issues/4900 is finished, please change "me: any" to "me: Pick<MeQueryInterface, "activeCart" | "customer">"
+  me: any;
 }
 
 const getMe = async (params: Options = {}, customQueryFn?) => {

--- a/packages/commercetools/api-client/src/api/getMyOrders/index.ts
+++ b/packages/commercetools/api-client/src/api/getMyOrders/index.ts
@@ -1,9 +1,11 @@
-import {apolloClient, getCustomQuery, getSettings} from './../../index';
+import { apolloClient, getCustomQuery, getSettings, MeQueryInterface } from './../../index';
 import defaultQuery from './defaultQuery';
 import { buildOrderWhere, resolveCustomQueryVariables } from './../../helpers/search';
-import { ProfileResponse } from './../../types/Api';
-import { ApolloQueryResult } from 'apollo-client';
 import gql from 'graphql-tag';
+
+interface OrdersData {
+  me: Pick<MeQueryInterface, 'orders'>;
+}
 
 const getOrders = async (params, customQueryFn?) => {
   const { query, variables } = getCustomQuery(customQueryFn, defaultQuery);
@@ -16,7 +18,7 @@ const getOrders = async (params, customQueryFn?) => {
     acceptLanguage,
     locale
   }, variables, 'order');
-  const request = await apolloClient.query<ApolloQueryResult<ProfileResponse>>({
+  const request = await apolloClient.query<OrdersData>({
     query: gql`${query}`,
     variables: resolvedVariables,
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/api/getProduct/index.ts
+++ b/packages/commercetools/api-client/src/api/getProduct/index.ts
@@ -3,7 +3,6 @@ import { apolloClient, getCustomQuery, getSettings } from './../../index';
 import { ProductQueryResult } from './../../types/GraphQL';
 import defaultQuery from './defaultQuery';
 import { buildProductWhere, resolveCustomQueryVariables } from './../../helpers/search';
-import { ApolloQueryResult } from 'apollo-client';
 
 export interface ProductData {
   products: ProductQueryResult;
@@ -22,7 +21,7 @@ const getProduct = async (params, customQueryFn?) => {
     currency,
     country
   }, variables);
-  const request = await apolloClient.query<ApolloQueryResult<ProductData>>({
+  const request = await apolloClient.query<ProductData>({
     query: gql`${query}`,
     variables: resolvedVariables,
     // temporary, seems like bug in apollo:

--- a/packages/commercetools/api-client/src/api/getShippingMethods/index.ts
+++ b/packages/commercetools/api-client/src/api/getShippingMethods/index.ts
@@ -1,4 +1,3 @@
-import { ApolloQueryResult } from 'apollo-client';
 import { apolloClient, getSettings } from '../../index';
 import defaultQuery from './defaultQuery';
 import { ShippingMethod } from './../../types/GraphQL';
@@ -7,9 +6,9 @@ interface ShippingMethodData {
   shippingMethods: ShippingMethod[];
 }
 
-const getShippingMethods = async (cartId?: string): Promise<ApolloQueryResult<ShippingMethodData>> => {
+const getShippingMethods = async (cartId?: string) => {
   const { acceptLanguage } = getSettings();
-  return await apolloClient.query({
+  return await apolloClient.query<ShippingMethodData>({
     query: defaultQuery,
     variables: { acceptLanguage, cartId },
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/helpers/search/index.ts
+++ b/packages/commercetools/api-client/src/helpers/search/index.ts
@@ -1,7 +1,7 @@
 import {
-  CategorySearch,
-  ProductSearch,
-  OrderSearch,
+  CategoryWhereSearch,
+  ProductWhereSearch,
+  OrderWhereSearch,
   Filter,
   AttributeType
 } from './../../types/Api';
@@ -43,7 +43,7 @@ const mapFilterToPredicate = (filter: Filter) => {
   return `masterData(current(masterVariant(attributes(name = "${filter.name}" and ${valuePredicate}))))`;
 };
 
-const buildProductWhere = (search: ProductSearch) => {
+const buildProductWhere = (search: ProductWhereSearch) => {
   const { acceptLanguage } = getSettings();
 
   const predicates: string[] = [];
@@ -72,7 +72,7 @@ const buildProductWhere = (search: ProductSearch) => {
   return predicates.join(' and ');
 };
 
-const buildCategoryWhere = (search: CategorySearch) => {
+const buildCategoryWhere = (search: CategoryWhereSearch) => {
   const { acceptLanguage } = getSettings();
 
   if (search?.catId) {
@@ -87,7 +87,7 @@ const buildCategoryWhere = (search: CategorySearch) => {
   return undefined;
 };
 
-const buildOrderWhere = (search: OrderSearch): string => {
+const buildOrderWhere = (search: OrderWhereSearch): string => {
   if (search?.id) {
     return `id="${search.id}"`;
   }

--- a/packages/commercetools/api-client/src/index.ts
+++ b/packages/commercetools/api-client/src/index.ts
@@ -24,9 +24,6 @@ import customerUpdateMe from './api/customerUpdateMe';
 import createAccessToken from './helpers/createAccessToken';
 import { apiClientFactory } from '@vue-storefront/core';
 import { Config, ConfigurableConfig } from './types/setup';
-export * from './types/Api';
-export * from './types/setup';
-export * as cartActions from './helpers/cart/actions';
 
 let apolloClient: ApolloClient<any> = null;
 
@@ -80,3 +77,8 @@ export {
   customerChangeMyPassword,
   customerUpdateMe
 };
+
+export * from './types/Api';
+export * from './types/GraphQL';
+export * from './types/setup';
+export * as cartActions from './helpers/cart/actions';

--- a/packages/commercetools/api-client/src/types/Api.ts
+++ b/packages/commercetools/api-client/src/types/Api.ts
@@ -1,6 +1,6 @@
 import { ApolloQueryResult } from 'apollo-client';
 import { FetchResult } from 'apollo-link';
-import { Cart, Me, Order, ShippingMethod, CustomerSignInResult, Customer } from './GraphQL';
+import { Cart, Order, ShippingMethod, CustomerSignInResult, Customer } from './GraphQL';
 
 export interface CustomQuery<T> {
   query: any;
@@ -23,7 +23,7 @@ export interface BaseSearch {
   sort?: string[];
 }
 
-export interface ProductSearch extends BaseSearch {
+export interface ProductWhereSearch extends BaseSearch {
   catId?: string | string[];
   skus?: string[];
   slug?: string;
@@ -43,12 +43,12 @@ export interface FilterOption {
   selected: boolean;
 }
 
-export interface CategorySearch extends BaseSearch {
+export interface CategoryWhereSearch extends BaseSearch {
   catId?: string;
   slug?: string;
 }
 
-export interface OrderSearch extends BaseSearch {
+export interface OrderWhereSearch extends BaseSearch {
   id?: string;
 }
 
@@ -67,7 +67,6 @@ export enum AttributeType {
 
 export type QueryResponse<K extends string, V> = ApolloQueryResult<Record<K, V>>;
 export type MutationResponse<K extends string, V> = FetchResult<Record<K, V>>;
-export type ProfileResponse = QueryResponse<'me', Me>;
 export type CartQueryResponse = QueryResponse<'cart', Cart>;
 export type OrderQueryResponse = QueryResponse<'order', Order>;
 export type CartMutationResponse = MutationResponse<'cart', Cart>;

--- a/packages/commercetools/composables/__tests__/useCart/useCart.spec.ts
+++ b/packages/commercetools/composables/__tests__/useCart/useCart.spec.ts
@@ -21,6 +21,8 @@ jest.mock('@vue-storefront/core', () => ({
   })
 }));
 
+const customQuery = undefined;
+
 describe('[commercetools-composables] useCart', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -39,7 +41,7 @@ describe('[commercetools-composables] useCart', () => {
     const response = await addToCart({ currentCart: 'current cart', product: 'product1', quantity: 3 });
 
     expect(response).toEqual('some cart');
-    expect(apiAddToCart).toBeCalledWith('current cart', 'product1', 3);
+    expect(apiAddToCart).toBeCalledWith('current cart', 'product1', 3, customQuery);
   });
 
   it('removes from cart', async () => {
@@ -47,7 +49,7 @@ describe('[commercetools-composables] useCart', () => {
     const response = await removeFromCart({ currentCart: 'current cart', product: 'product1' });
 
     expect(response).toEqual('some cart');
-    expect(apiRemoveFromCart).toBeCalledWith('current cart', 'product1');
+    expect(apiRemoveFromCart).toBeCalledWith('current cart', 'product1', customQuery);
   });
 
   it('updates quantity', async () => {
@@ -59,7 +61,7 @@ describe('[commercetools-composables] useCart', () => {
     });
 
     expect(response).toEqual('some cart');
-    expect(apiUpdateCartQuantity).toBeCalledWith('current cart', { name: 'product1', quantity: 5 });
+    expect(apiUpdateCartQuantity).toBeCalledWith('current cart', { name: 'product1', quantity: 5 }, customQuery);
   });
 
   it('clears cart', async () => {

--- a/packages/commercetools/composables/package.json
+++ b/packages/commercetools/composables/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
   "tsModule": "src/index.ts",
-  "types": "lib/index.d.ts",
+  "types": "lib/commercetools/composables/src/index.d.ts",
   "scripts": {
     "build": "rimraf lib && rollup -c",
     "dev": "rollup -c -w",

--- a/packages/commercetools/composables/src/helpers/internals/getFiltersFromProductsAttributes.ts
+++ b/packages/commercetools/composables/src/helpers/internals/getFiltersFromProductsAttributes.ts
@@ -6,9 +6,9 @@ const extractAttributes = (product: ProductVariant): Attribute[] => product.attr
 
 const flattenAttributes = (prev: Attribute[], curr: Attribute[]): Attribute[] => [...prev, ...(curr || [])];
 
-const getFilterFromAttribute = (attribute: Attribute, prev: Record<string, Filter>): Filter => {
+const getFilterFromAttribute = (attribute: Attribute, prev) => {
   const attrValue = getAttributeValue(attribute);
-  const filter: Filter = prev[attribute.name] || {
+  const filter = prev[attribute.name] || {
     type: (attribute as any).__typename,
     options: []
   };

--- a/packages/commercetools/composables/src/useProduct/index.ts
+++ b/packages/commercetools/composables/src/useProduct/index.ts
@@ -3,7 +3,7 @@ import { enhanceProduct, mapPaginationParams, getFiltersFromProductsAttributes }
 import { ProductVariant } from './../types/GraphQL';
 import { useProductFactory, ProductsSearchResult, UseProduct, AgnosticSortByOption, CustomQuery } from '@vue-storefront/core';
 import { ProductsSearchParams } from '../types';
-import { ProductSearch, Filter } from '@vue-storefront/commercetools-api';
+import { Filter } from '@vue-storefront/commercetools-api';
 
 const availableSortingOptions = [
   { value: 'latest', label: 'Latest' },
@@ -12,7 +12,7 @@ const availableSortingOptions = [
 ];
 
 const productsSearch = async (params: ProductsSearchParams, customQuery?: CustomQuery): Promise<ProductsSearchResult<ProductVariant, Record<string, Filter>, AgnosticSortByOption[]>> => {
-  const apiSearchParams: ProductSearch = {
+  const apiSearchParams = {
     ...params,
     ...mapPaginationParams(params)
   };

--- a/packages/commercetools/theme/composables/useUiHelpers/index.ts
+++ b/packages/commercetools/theme/composables/useUiHelpers/index.ts
@@ -1,7 +1,6 @@
 import { getCurrentInstance } from '@vue/composition-api';
 import { Category } from '@vue-storefront/commercetools-api';
 import { AgnosticFacet } from '@vue-storefront/core';
-import { FacetSearchInput } from '@vue-storefront/commercetools';
 
 const nonFilters = ['page', 'sort', 'itemsPerPage'];
 
@@ -30,7 +29,7 @@ const getFiltersDataFromUrl = (context, onlyFilters) => {
 const useUiHelpers = () => {
   const context = getContext();
 
-  const getFacetsFromURL = (): FacetSearchInput => {
+  const getFacetsFromURL = () => {
     const { query, params } = context.$router.history.current;
 
     const categorySlug = Object.keys(params).reduce((prev, curr) => params[curr] || prev, params.slug_1);

--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -76,7 +76,8 @@ export default {
       i18n: {
         useNuxtI18nConfig: true
       }
-    }]
+    }],
+    '~/../../../../Pro/commercetools/useReview'
   ],
   modules: [
     'nuxt-i18n',
@@ -128,6 +129,21 @@ export default {
     }
   },
   build: {
+    babel: {
+      plugins: [
+        '@babel/plugin-proposal-optional-chaining'
+      ],
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            targets: {
+              node: 'current'
+            }
+          }
+        ]
+      ]
+    },
     transpile: [
       'vee-validate/dist/rules'
     ],

--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -76,8 +76,7 @@ export default {
       i18n: {
         useNuxtI18nConfig: true
       }
-    }],
-    '~/../../../../Pro/commercetools/useReview'
+    }]
   ],
   modules: [
     'nuxt-i18n',
@@ -129,21 +128,6 @@ export default {
     }
   },
   build: {
-    babel: {
-      plugins: [
-        '@babel/plugin-proposal-optional-chaining'
-      ],
-      presets: [
-        [
-          '@babel/preset-env',
-          {
-            targets: {
-              node: 'current'
-            }
-          }
-        ]
-      ]
-    },
     transpile: [
       'vee-validate/dist/rules'
     ],

--- a/packages/core/docs/commercetools/changelog.md
+++ b/packages/core/docs/commercetools/changelog.md
@@ -2,11 +2,11 @@
 
 ## 0.2.0 (not released)
 
+- Fix types for CT api-client and composables packages ([#4924](https://github.com/DivanteLtd/vue-storefront/pull/4924))
 - fixed updateUser on useUser composable ([#4863](https://github.com/DivanteLtd/vue-storefront/issues/4863))
 - implemented useReviews on product page ([#4800](https://github.com/DivanteLtd/vue-storefront/issues/4800))
-- implemented faceting using useFacet factory (#4853)
+- implemented faceting using useFacet factory ([#4853](https://github.com/DivanteLtd/vue-storefront/issues/4853))
 
 ## 0.1.0
 
 - refactored setup using apiClientFactory ([#4777](https://github.com/DivanteLtd/vue-storefront/issues/4777))
-


### PR DESCRIPTION
### Related Issues
None

### Short Description and Why It's Useful
`package.json` files in "api-client" and "composables" packages for CommerceTools pointed to non-existing `types` files resulting in poor Typescript support and incorrect types.


### Screenshots of Visual Changes before/after (if There Are Any)
N/A

