### PR TITLE
Add `sort`options to `CategoryService` and improve `category-next/getCategoryByParams` getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Reduce initial client-side bundle-size by lazy-loading `i18n` translations - @cewald (#4821)
 - Replaced deprecated action product/list call with product/findProducts (#4769)
+- Add sort options to `CategoryService` class to be able to add a sorting in `storefront-query-builder` style - @cewald (#4926)
+
+### Fixed
+
+- Improve `getCategoryByParams` as it will return the first value of `state.categoriesMap` if no route-params are set - @cewald (#4926)
+- Bugfix for type error in `omitSelectedVariantFields` return value - @cewald (#4926)
 
 ## [1.12.2] - 2020.07.28
 

--- a/core/data-resolver/CategoryService.ts
+++ b/core/data-resolver/CategoryService.ts
@@ -43,6 +43,12 @@ const getCategories = async ({
   if (onlyNotEmpty === true) {
     searchQuery = searchQuery.applyFilter({ key: 'product_count', value: { 'gt': 0 } })
   }
+
+  if (typeof sort === 'object') {
+    searchQuery.applySort(sort)
+    sort = undefined
+  }
+
   const response = await quickSearchByQuery({ entityType: 'category', query: searchQuery, sort: sort, size: size, start: start, includeFields: includeFields, excludeFields: excludeFields })
   return response.items as Category[]
 }

--- a/core/data-resolver/types/DataResolver.d.ts
+++ b/core/data-resolver/types/DataResolver.d.ts
@@ -18,7 +18,7 @@ declare namespace DataResolver {
     onlyNotEmpty?: boolean,
     size?: number,
     start?: number,
-    sort?: string,
+    sort?: string|any,
     includeFields?: string[],
     excludeFields?: string[],
     reloadAll?: boolean

--- a/core/modules/catalog-next/store/category/getters.ts
+++ b/core/modules/catalog-next/store/category/getters.ts
@@ -41,7 +41,7 @@ const getters: GetterTree<CategoryState, RootState> = {
       let valueCheck = []
       const searchOptions = getSearchOptionsFromRouteParams(params)
       forEach(searchOptions, (value, key) => valueCheck.push(category[key] && category[key] === (category[key].constructor)(value)))
-      return valueCheck.filter(check => check === true).length === Object.keys(searchOptions).length
+      return valueCheck.length > 0 && valueCheck.filter(check => check === true).length === Object.keys(searchOptions).length
     }) || {}
   },
   getCurrentCategory: (state, getters, rootState, rootGetters) => {

--- a/core/modules/catalog/helpers/variant/omitSelectedVariantFields.ts
+++ b/core/modules/catalog/helpers/variant/omitSelectedVariantFields.ts
@@ -3,7 +3,7 @@ import omit from 'lodash/omit'
 /**
  * Omit some variant fields to prevent overriding same base product fields
  */
-export default function omitSelectedVariantFields (selectedVariant): void {
+export default function omitSelectedVariantFields (selectedVariant): any {
   const hasImage = selectedVariant && selectedVariant.image && selectedVariant.image !== 'no_selection'
   const fieldsToOmit = ['name', 'visibility']
   if (!hasImage) fieldsToOmit.push('image')


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

These are small changes and bugfixes.

1. Add more complex sort options to `CategoryService. getCategories ()` method to be able to add a sorting in `storefront-query-builder` style like: `{ field: 'attribute', options: { ... } }`
2. Improve/fix `getCategoryByParams` as it will return the first value of `state.categoriesMap` if no route-params are set. This could lead into wrong results if you are watching the `category-next/getCurrentCategory` getter and switch to a page where no search-params are found in the route parameters.
3. Bugfix for type error in `omitSelectedVariantFields` return value

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

