### PR TITLE
Export getCustomQuery from CT-api package

### DIFF
--- a/packages/commercetools/api-client/src/index.ts
+++ b/packages/commercetools/api-client/src/index.ts
@@ -82,4 +82,5 @@ export * from './types/Api';
 export * from './types/GraphQL';
 export * from './types/setup';
 export * from './helpers/token';
+export * from './helpers/queries';
 export * as cartActions from './helpers/cart/actions';


### PR DESCRIPTION
### Short Description and Why It's Useful
Recent modifications introduced breaking change and `getCustomQuery` method is no longer exported by CommerceTools api-client.

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature