### PR TITLE
[BP] - Add mocked products to facet

### DIFF
--- a/packages/boilerplate/composables/src/composables/getters/facetGetters.ts
+++ b/packages/boilerplate/composables/src/composables/getters/facetGetters.ts
@@ -21,7 +21,45 @@ const getSortOptions = (searchData): AgnosticSort => ({ options: [], selected: '
 const getCategoryTree = (searchData): AgnosticCategoryTree => ({} as any);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const getProducts = (searchData): any => [];
+const getProducts = (searchData): any => {
+  return [
+    {
+      _id: 1,
+      _description: 'Some description',
+      _categoriesRef: [
+        '1',
+        '2'
+      ],
+      name: 'Black jacket',
+      sku: 'black-jacket',
+      images: [
+        'https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/081223_1_large.jpg'
+      ],
+      price: {
+        original: 12.34,
+        current: 10.00
+      }
+    },
+    {
+      _id: 2,
+      _description: 'Some different description',
+      _categoriesRef: [
+        '1',
+        '2',
+        '3'
+      ],
+      name: 'White shirt',
+      sku: 'white-shirt',
+      images: [
+        'https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/081223_1_large.jpg'
+      ],
+      price: {
+        original: 15.11,
+        current: 11.00
+      }
+    }
+  ];
+};
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const getPagination = (searchData): AgnosticPagination => ({


### PR DESCRIPTION
### Short Description and Why It's Useful
This PR adds mocked products to `facetGetters` in Boilerplate, so the Category page is not empty.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [X] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature
