### PR TITLE
Block guest access to user profile

### DIFF
--- a/packages/core/nuxt-theme-module/theme/pages/MyAccount.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/MyAccount.vue
@@ -54,7 +54,6 @@ import MyNewsletter from './MyAccount/MyNewsletter';
 import OrderHistory from './MyAccount/OrderHistory';
 import MyReviews from './MyAccount/MyReviews';
 
-// TODO: protect this route: https://github.com/DivanteLtd/next/issues/379
 export default {
   name: 'MyAccount',
   components: {
@@ -68,6 +67,17 @@ export default {
     OrderHistory,
     MyReviews
   },
+
+  async middleware({ redirect }) {
+    const { load, isAuthenticated } = useUser();
+
+    await load();
+
+    if (!isAuthenticated.value) {
+      return redirect('/');
+    }
+  },
+
   setup(props, context) {
     const { $router, $route } = context.root;
     const { logout } = useUser();


### PR DESCRIPTION
### Short Description and Why It's Useful
This PR blocks acess to user profile pages for guests.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [X] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature