### PR TITLE
Fix ssr transitions

### DIFF
--- a/packages/core/docs/contributing/changelog.md
+++ b/packages/core/docs/contributing/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.9
+- fix ssr transitions
+
 ## 2.0.8
 
 - renamed `refreshUser` to `load` in `useUser`, user shouldn't be automatically loaded now (#4917)

--- a/packages/core/nuxt-module/lib/plugins/ssr.js
+++ b/packages/core/nuxt-module/lib/plugins/ssr.js
@@ -3,19 +3,17 @@ import { configureSSR } from '@vue-storefront/core'
 import { ssrRef, getCurrentInstance, onServerPrefetch } from '@nuxtjs/composition-api';
 
 const ssrPlugin = () => {
-  let previousRoute = '';
-
   configureSSR({
     vsfRef: ssrRef,
     onSSR: (fn) => {
       onServerPrefetch(fn);
       if (typeof window !== 'undefined') {
         const vm = getCurrentInstance();
-        if (previousRoute !== vm.$route.fullPath) {
+        const { _startLocation, current } = vm.$router.history
+
+        if (_startLocation !== current.fullPath) {
           fn();
         }
-
-        previousRoute = vm.$route.fullPath;
       }
     }
   });


### PR DESCRIPTION
The `onSSR` didn't call a function when you have multiple `onSSR` statements on the page, on the client-side transition.