### PR TITLE
fix: Use path.sep instead of / for windows compatibility

### DIFF
--- a/packages/core/nuxt-theme-module/generate.js
+++ b/packages/core/nuxt-theme-module/generate.js
@@ -52,8 +52,8 @@ export default async function ({
 
   this.extendBuild(config => {
     delete config.resolve.alias['~'];
-    config.resolve.alias['~/components'] = path.join(projectLocalThemeDir, '/components');
-    config.resolve.alias['~/assets'] = path.join(projectLocalThemeDir, '/assets');
+    config.resolve.alias['~/components'] = path.join(projectLocalThemeDir, path.sep + 'components');
+    config.resolve.alias['~/assets'] = path.join(projectLocalThemeDir, path.sep + 'assets');
     config.resolve.alias['~'] = path.join(projectLocalThemeDir);
   });
 


### PR DESCRIPTION
### Short Description and Why It's Useful
There is a hardcoded use of / as a path seperator, which should be path.sep for Windows compatibility.


### Which Environment This Relates To

- [x] Next

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

