### PR TITLE
Fix shared ref nullable assigning

### DIFF
--- a/packages/core/core/__tests__/utils/shared.spec.ts
+++ b/packages/core/core/__tests__/utils/shared.spec.ts
@@ -1,5 +1,6 @@
 
 import { sharedRef } from '../../src/utils/shared';
+import { vsfRef } from '../../src/utils';
 
 describe('[CORE - utils] shared', () => {
   beforeEach(() => {
@@ -12,6 +13,7 @@ describe('[CORE - utils] shared', () => {
     someRef1.value = 'test-update';
 
     expect(someRef1).toEqual(someRef2);
+    expect(vsfRef).toBeCalledWith('test', 'test-key');
   });
 
   it('different instances are not equal', () => {
@@ -20,6 +22,9 @@ describe('[CORE - utils] shared', () => {
     someRef1.value = 'test-update';
 
     expect(someRef1).not.toEqual(someRef2);
+    expect(vsfRef).toBeCalledWith('test', 'test-key1');
+    expect(vsfRef).toBeCalledWith('test', 'test-key2');
+
   });
 
   it('get shared ref', () => {
@@ -27,6 +32,19 @@ describe('[CORE - utils] shared', () => {
     const someRef2 = sharedRef('test-key3');
     someRef1.value = 'test-update-3';
 
+    expect(someRef1).toEqual(someRef2);
+    expect(vsfRef).toBeCalledWith('test', 'test-key3');
+    expect(vsfRef).toBeCalledWith('test', 'test-key3');
+  });
+
+  it('assign a value when ref does not exist', () => {
+    const someRef1 = sharedRef('no-exist-key');
+    someRef1.value = 'no-exist-update';
+
+    expect(someRef1.value).toEqual('no-exist-update');
+    expect(vsfRef).toBeCalledWith(null, 'no-exist-key');
+
+    const someRef2 = sharedRef('no-exist-key');
     expect(someRef1).toEqual(someRef2);
   });
 });

--- a/packages/core/core/src/utils/shared/index.ts
+++ b/packages/core/core/src/utils/shared/index.ts
@@ -14,8 +14,12 @@ function sharedRef<T>(value: T, key: string): Ref {
     return sharedMap.get(givenKey);
   }
 
-  const newRef = vsfRef(value, key);
-  sharedMap.set(key, newRef);
+  const newRef = vsfRef(
+    key ? value : null,
+    givenKey as string
+  );
+
+  sharedMap.set(givenKey, newRef);
 
   return newRef;
 }

--- a/packages/core/docs/contributing/changelog.md
+++ b/packages/core/docs/contributing/changelog.md
@@ -2,6 +2,7 @@
 
 ## 2.0.9
 - fix ssr transitions
+- fix `sharedRef` nullable assigning
 
 ## 2.0.8
 


### PR DESCRIPTION
Fixes a bug when the current key doesn't exist but we want to create a new one using the only key