### PR TITLE
Update Enterprise docs for useReview

### DIFF
--- a/packages/core/docs/commercetools/enterprise/use-review.md
+++ b/packages/core/docs/commercetools/enterprise/use-review.md
@@ -39,9 +39,11 @@ interface ReviewDraft {
 
 ## Usage
 
-When `@vsf-enterprise/ct-reviews` plugin is installed as a dependency, it requires minor modifications in the code to work.
+When you already installed `@vsf-enterprise/ct-reviews` as a dependency, there are few minor modifications required to make it work.
 
-In the codebase we're importing `useReview` and `reviewGetters` from `@vue-storefront/commercetools`. To use this plugin, simply import them from `@vsf-enterprise/ct-reviews` instead of `@vue-storefront/commercetools`:
+The first step is to add `@vsf-enterprise/ct-reviews` to `build > traspile` array in `nuxt.config.js`.
+
+Then we need to replace the import of `useReview` and `reviewGetters` everywhere they are used from `@vue-storefront/commercetools` to `@vsf-enterprise/ct-reviews`:
 
 ```javascript
 // Before


### PR DESCRIPTION
### Short Description and Why It's Useful
Update Enterprise docs for `useReview`.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [X] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature