### PR TITLE
Prepublish

### DIFF
--- a/packages/about-you/api-client/package.json
+++ b/packages/about-you/api-client/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "test": "jest"
+    "test": "jest",
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@aboutyou/backbone": "^7.0.0",

--- a/packages/about-you/composables/package.json
+++ b/packages/about-you/composables/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "rimraf lib && rollup -c",
     "dev": "rollup -c -w",
-    "test": "jest"
+    "test": "jest",
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@vue-storefront/about-you-api": "^0.1.0",

--- a/packages/boilerplate/api-client/package.json
+++ b/packages/boilerplate/api-client/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "test": "jest"
+    "test": "jest",
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@vue-storefront/core": "2.0.8"

--- a/packages/boilerplate/composables/package.json
+++ b/packages/boilerplate/composables/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "rimraf lib && rollup -c",
     "dev": "rollup -c -w",
-    "test": "jest"
+    "test": "jest",
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@vue-storefront/boilerplate-api": "^0.0.1",

--- a/packages/checkout-com/package.json
+++ b/packages/checkout-com/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "rimraf lib && rollup -c",
     "dev": "rollup -c -w",
-    "test": "jest"
+    "test": "jest",
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@vue/composition-api": "1.0.0-beta.14",

--- a/packages/commercetools/api-client/package.json
+++ b/packages/commercetools/api-client/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "rimraf lib && rollup -c",
     "dev": "rollup -c -w",
-    "test": "cross-env APP_ENV=test jest --rootDir ."
+    "test": "cross-env APP_ENV=test jest --rootDir .",
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@vue-storefront/core": "2.0.9",

--- a/packages/commercetools/composables/package.json
+++ b/packages/commercetools/composables/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "rimraf lib && rollup -c",
     "dev": "rollup -c -w",
-    "test": "jest"
+    "test": "jest",
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@vue-storefront/commercetools-api": "0.2.5",

--- a/packages/core/cli/package.json
+++ b/packages/core/cli/package.json
@@ -23,5 +23,5 @@
     "@vue-storefront/commercetools-theme": "^0.1.0"
   },
   "author": "Filip Jędrasik",
-  "license": "ISC"
+  "license": "MIT"
 }

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -10,7 +10,8 @@
     "build:client": "rollup -c rollup-client.config.js",
     "build:server": "rollup -c rollup-server.config.js",
     "build": "yarn build:client && yarn build:server",
-    "dev": "rollup -c rollup-client.config.js -w"
+    "dev": "rollup -c rollup-client.config.js -w",
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@vue/composition-api": "1.0.0-beta.14",

--- a/packages/core/nuxt-module/lib/module.js
+++ b/packages/core/nuxt-module/lib/module.js
@@ -38,10 +38,14 @@ module.exports = function VueStorefrontNuxtModule (moduleOptions) {
   })
 
   log.info(chalk.green('Starting Vue Storefront Nuxt Module'))
-  log.success('Installed Composition API plugin for Vue 2')
 
+  this.options.head.meta.push({
+    name: 'generator',
+    content: 'Vue Storefront 2'
+  })
+  
   this.addPlugin(path.resolve(__dirname, 'plugins/ssr.js'))
-  log.success('Installed VSF SSR plugin');
+  log.success('Installed Vue Storefront SSR plugin');
 
   this.addPlugin({
     src: path.resolve(__dirname, 'plugins/logger.js'),
@@ -50,7 +54,7 @@ module.exports = function VueStorefrontNuxtModule (moduleOptions) {
   log.success('Installed VSF Logger plugin');
 
   this.addModule('@nuxtjs/composition-api')
-  log.success('Installed nuxt composition api module');
+  log.success('Installed nuxt Composition API Module');
 
   //-------------------------------------
 

--- a/packages/core/nuxt-module/package.json
+++ b/packages/core/nuxt-module/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Vue Storefront",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@nuxt/typescript-build": "^2.0.0",
     "@vue/composition-api": "1.0.0-beta.14",

--- a/packages/core/nuxt-theme-module/package.json
+++ b/packages/core/nuxt-theme-module/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Vue Storefront",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "chalk": "^2.4.2",
     "chokidar": "^3.3.1",

--- a/packages/shopify/api-client/package.json
+++ b/packages/shopify/api-client/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "test": "jest"
+    "test": "jest",
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@types/node-fetch": "^2.5.7",

--- a/packages/shopify/composables/package.json
+++ b/packages/shopify/composables/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "test": "jest"
+    "test": "jest",
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@vue-storefront/shopify-api": "^0.0.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -9,5 +9,5 @@
     "release": "ts-node ./release/index.ts"
   },
   "author": "",
-  "license": "ISC"
+  "license": "MIT"
 }


### PR DESCRIPTION
- added tracking code so we can track vsf next websites (will be improved soon to also contain information about integrations)
![image](https://user-images.githubusercontent.com/15185752/95901608-df248c00-0d93-11eb-8ee9-3f07a7cdd663.png)
- corrected licenses that for some reason were not MIT
- added `prepublish` script to build packages before publication

closes https://github.com/DivanteLtd/vue-storefront/issues/5009