### PR TITLE
add setConfig plugin for cypress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ npm-debug.log
 .vscode/
 .idea/
 config/local.json
+config/local-test.json
 var
 build/config.json
 core/build/config.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce initial client-side bundle-size by lazy-loading `i18n` translations - @cewald (#4821)
 - Replaced deprecated action product/list call with product/findProducts (#4769)
 - Add sort options to `CategoryService` class to be able to add a sorting in `storefront-query-builder` style - @cewald (#4926)
+- Added `setConfig` plugin for cypress - @gibkigonzo (#5047)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "build": "rimraf dist && yarn generate-files && npm-run-all -p build:*",
     "test:unit": "jest -c test/unit/jest.conf.js",
     "test:unit:watch": "jest -c test/unit/jest.conf.js --watch",
+    "test:e2e:open": "npm-run-all -p test:e2e:app test:e2e",
     "test:e2e:app": "NODE_ENV=test yarn dev",
-    "test:e2e:cypress": "cypress open",
-    "test:e2e": "npm-run-all -p test:e2e:app test:e2e:cypress",
+    "test:e2e": "cypress open",
     "test:e2e:ci": "cypress run",
     "lint": "cross-env NODE_ENV=production  eslint --ext .js,.vue,.ts core src --fix",
     "lerna": "lerna"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "build": "rimraf dist && yarn generate-files && npm-run-all -p build:*",
     "test:unit": "jest -c test/unit/jest.conf.js",
     "test:unit:watch": "jest -c test/unit/jest.conf.js --watch",
-    "test:e2e": "cypress open",
+    "test:e2e:app": "NODE_ENV=test yarn dev",
+    "test:e2e:cypress": "cypress open",
+    "test:e2e": "npm-run-all -p test:e2e:app test:e2e:cypress",
     "test:e2e:ci": "cypress run",
     "lint": "cross-env NODE_ENV=production  eslint --ext .js,.vue,.ts core src --fix",
     "lerna": "lerna"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "build": "rimraf dist && yarn generate-files && npm-run-all -p build:*",
     "test:unit": "jest -c test/unit/jest.conf.js",
     "test:unit:watch": "jest -c test/unit/jest.conf.js --watch",
-    "test:e2e:open": "npm-run-all -p test:e2e:app test:e2e",
+    "test:e2e:all": "npm-run-all -p test:e2e:app test:e2e",
     "test:e2e:app": "NODE_ENV=test yarn dev",
     "test:e2e": "cypress open",
     "test:e2e:ci": "cypress run",

--- a/test/e2e/integration/set-config.js
+++ b/test/e2e/integration/set-config.js
@@ -1,0 +1,42 @@
+/* eslint no-undef: 0 */
+describe('setConfig', () => {
+  it('should resolve homepage after config is changed', () => {
+    cy.task('setConfig', {
+      storeViews: {
+        multistore: false, // disable multistore
+        de: {
+          storeCode: 'de',
+          appendStoreCode: true,
+          elasticsearch: {
+            index: 'vue_storefront_catalog'
+          }
+        }
+      }
+    })
+    cy.visit('de', { failOnStatusCode: false })
+      .then(() => {
+        cy.get('h1').should(($h1) => {
+          expect($h1).to.not.contain('Neue Wege beschreiten.')
+        })
+        cy.task('setConfig', {
+          storeViews: {
+            multistore: true, // enable multistore
+            de: {
+              storeCode: 'de',
+              appendStoreCode: true,
+              elasticsearch: {
+                index: 'vue_storefront_catalog'
+              }
+            }
+          }
+        })
+        cy.visit('de')
+          .then(() => {
+            cy.get('h1').should(($h1) => {
+              expect($h1).to.contain('Neue Wege beschreiten.')
+            })
+            cy.task('setConfig', {})
+          })
+      })
+  })
+})

--- a/test/e2e/plugins/index.js
+++ b/test/e2e/plugins/index.js
@@ -11,7 +11,20 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-module.exports = (on, config) => {
+const fs = require('fs')
+const path = require('path')
+
+module.exports = (on) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  on('task', {
+    setConfig (newConfig) {
+      fs.writeFileSync(
+        path.join(__dirname, '../../../config/local-test.json'),
+        JSON.stringify(newConfig)
+      )
+
+      return null
+    }
+  })
 }


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Added `setConfig` plugin for cypress. It allows to test different configuration for each test. I've added example with testing multistore.


### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

