### PR TITLE
Next: Fix an issue with the apollo client from one request overwiting the client of another request

### DIFF
--- a/packages/commercetools/api-client/src/api/createCart/index.ts
+++ b/packages/commercetools/api-client/src/api/createCart/index.ts
@@ -1,6 +1,6 @@
-import { CartDraft } from './../../types/GraphQL';
-import { apolloClient, CustomQueryFn, getSettings } from './../../index';
-import { getCustomQuery } from './../../helpers/queries';
+import { CartDraft } from '../../types/GraphQL';
+import { CustomQueryFn, getSettings } from '../../index';
+import { getCustomQuery } from '../../helpers/queries';
 import defaultQuery from './defaultMutation';
 import gql from 'graphql-tag';
 
@@ -9,7 +9,7 @@ interface CartData extends Omit<CartDraft, 'currency'> {
 }
 
 const createCart = async (cartDraft: CartData = {}, customQueryFn?: CustomQueryFn) => {
-  const { locale, acceptLanguage, currency } = getSettings();
+  const { locale, acceptLanguage, currency, client } = getSettings();
 
   const defaultVariables = {
     acceptLanguage,
@@ -21,7 +21,7 @@ const createCart = async (cartDraft: CartData = {}, customQueryFn?: CustomQueryF
   };
   const { query, variables } = getCustomQuery(customQueryFn, { defaultQuery, defaultVariables });
 
-  const request = await apolloClient.mutate({
+  const request = await client.mutate({
     mutation: gql`${query}`,
     variables,
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/api/createMyOrderFromCart/index.ts
+++ b/packages/commercetools/api-client/src/api/createMyOrderFromCart/index.ts
@@ -1,17 +1,17 @@
 import { OrderMyCartCommand } from '../../types/GraphQL';
-import { apolloClient, CustomQueryFn, getCustomQuery, getSettings } from '../../index';
+import { getCustomQuery, CustomQueryFn, getSettings } from '../../index';
 import CreateMyOrderFromCartMutation from './defaultMutation';
 import { OrderMutationResponse } from '../../types/Api';
 import gql from 'graphql-tag';
 
 const createMyOrderFromCart = async (draft: OrderMyCartCommand, customQueryFn?: CustomQueryFn): Promise<OrderMutationResponse> => {
-  const { locale, acceptLanguage } = getSettings();
+  const { locale, acceptLanguage, client } = getSettings();
   const defaultVariables = { locale,
     acceptLanguage,
     draft
   };
   const { query, variables } = getCustomQuery(customQueryFn, { defaultQuery: CreateMyOrderFromCartMutation, defaultVariables });
-  return await apolloClient.mutate({
+  return await client.mutate({
     mutation: gql`${query}`,
     variables,
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/api/customerChangeMyPassword/index.ts
+++ b/packages/commercetools/api-client/src/api/customerChangeMyPassword/index.ts
@@ -1,9 +1,10 @@
-import { apolloClient } from '../../index';
+import { getSettings } from '../../index';
 import CustomerChangeMyPassword from './defaultMutation';
 import { ChangeMyPasswordResponse } from '../../types/Api';
 
 const customerChangeMyPassword = async (version: any, currentPassword: string, newPassword: string): Promise<ChangeMyPasswordResponse> => {
-  return await apolloClient.mutate({
+  const { client } = getSettings();
+  return await client.mutate({
     mutation: CustomerChangeMyPassword,
     variables: {
       version,

--- a/packages/commercetools/api-client/src/api/customerSignMeIn/index.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeIn/index.ts
@@ -1,12 +1,12 @@
 import { CustomerSignMeInDraft } from '../../types/GraphQL';
-import { apolloClient, getSettings } from '../../index';
+import { getSettings } from '../../index';
 import CustomerSignMeInMutation from './defaultMutation';
 import { SignInResponse } from './../../types/Api';
 import createAccessToken from './../../helpers/createAccessToken';
 
 const customerSignMeIn = async (draft: CustomerSignMeInDraft): Promise<SignInResponse> => {
-  const { locale, acceptLanguage, currentToken, auth } = getSettings();
-  const loginResponse = await apolloClient.mutate({
+  const { locale, acceptLanguage, currentToken, auth, client } = getSettings();
+  const loginResponse = await client.mutate({
     mutation: CustomerSignMeInMutation,
     variables: { draft, locale, acceptLanguage },
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/api/customerSignMeUp/index.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeUp/index.ts
@@ -1,12 +1,12 @@
-import { CustomerSignMeUpDraft } from './../../types/GraphQL';
-import { apolloClient, getSettings } from './../../index';
+import { CustomerSignMeUpDraft } from '../../types/GraphQL';
+import { getSettings } from '../../index';
 import CustomerSignMeUpMutation from './defaultMutation';
-import { SignInResponse } from './../../types/Api';
-import createAccessToken from './../../helpers/createAccessToken';
+import { SignInResponse } from '../../types/Api';
+import createAccessToken from '../../helpers/createAccessToken';
 
 const customerSignMeUp = async (draft: CustomerSignMeUpDraft): Promise<SignInResponse> => {
-  const { locale, acceptLanguage, currentToken, auth } = getSettings();
-  const registerResponse = await apolloClient.mutate({
+  const { locale, acceptLanguage, currentToken, auth, client } = getSettings();
+  const registerResponse = await client.mutate({
     mutation: CustomerSignMeUpMutation,
     variables: { draft, locale, acceptLanguage },
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/api/customerUpdateMe/index.ts
+++ b/packages/commercetools/api-client/src/api/customerUpdateMe/index.ts
@@ -1,9 +1,10 @@
 import { changeCustomerEmailAction, setCustomerFirstNameAction, setCustomerLastNameAction } from '../../helpers/customer';
-import { apolloClient } from '../../index';
+import { getSettings } from '../../index';
 import CustomerUpdateMeMutation from './defaultMutation';
 
 const customerUpdateMe = async (currentUser, updatedUserData) => {
-  const updateResponse = await apolloClient.mutate({
+  const { client } = getSettings();
+  const updateResponse = await client.mutate({
     mutation: CustomerUpdateMeMutation,
     variables: {
       version: currentUser.version,

--- a/packages/commercetools/api-client/src/api/getCart/index.ts
+++ b/packages/commercetools/api-client/src/api/getCart/index.ts
@@ -1,10 +1,10 @@
-import { apolloClient, getSettings } from './../../index';
-import { CartQueryResponse } from './../../types/Api';
+import { getSettings } from '../../index';
+import { CartQueryResponse } from '../../types/Api';
 import defaultQuery from './defaultQuery';
 
 const getCart = async (cartId: string): Promise<CartQueryResponse> => {
-  const { locale, acceptLanguage } = getSettings();
-  return await apolloClient.query({
+  const { locale, acceptLanguage, client } = getSettings();
+  return await client.query({
     query: defaultQuery,
     variables: { cartId,
       locale,

--- a/packages/commercetools/api-client/src/api/getCategory/index.ts
+++ b/packages/commercetools/api-client/src/api/getCategory/index.ts
@@ -1,16 +1,16 @@
 import gql from 'graphql-tag';
 import defaultQuery from './defaultQuery';
-import { CategoryQueryResult } from './../../types/GraphQL';
-import { apolloClient, CustomQueryFn, getSettings } from './../../index';
-import { buildCategoryWhere } from './../../helpers/search';
-import { getCustomQuery } from './../../helpers/queries';
+import { CategoryQueryResult } from '../../types/GraphQL';
+import { CustomQueryFn, getSettings } from '../../index';
+import { buildCategoryWhere } from '../../helpers/search';
+import { getCustomQuery } from '../../helpers/queries';
 
 interface CategoryData {
   categories: CategoryQueryResult;
 }
 
 const getCategory = async (params, customQueryFn?: CustomQueryFn) => {
-  const { acceptLanguage } = getSettings();
+  const { acceptLanguage, client } = getSettings();
   const defaultVariables = params ? {
     where: buildCategoryWhere(params),
     limit: params.limit,
@@ -20,7 +20,7 @@ const getCategory = async (params, customQueryFn?: CustomQueryFn) => {
 
   const { query, variables } = getCustomQuery(customQueryFn, { defaultQuery, defaultVariables });
 
-  const request = await apolloClient.query<CategoryData>({
+  const request = await client.query<CategoryData>({
     query: gql`${query}`,
     variables,
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/api/getMe/index.ts
+++ b/packages/commercetools/api-client/src/api/getMe/index.ts
@@ -1,7 +1,7 @@
-import { apolloClient, CustomQueryFn, getSettings } from './../../index';
+import { CustomQueryFn, getSettings } from '../../index';
 import { basicProfile, fullProfile } from './defaultQuery';
 import gql from 'graphql-tag';
-import { getCustomQuery } from './../../helpers/queries';
+import { getCustomQuery } from '../../helpers/queries';
 
 interface Options {
   customer?: boolean;
@@ -13,7 +13,8 @@ interface OrdersData {
 }
 
 const getMe = async (params: Options = {}, customQueryFn?: CustomQueryFn) => {
-  const { locale, acceptLanguage } = getSettings();
+  const { locale, acceptLanguage, client } = getSettings();
+
   const { customer }: Options = params;
   const defaultQuery = customer ? fullProfile : basicProfile;
   const defaultVariables = {
@@ -22,7 +23,7 @@ const getMe = async (params: Options = {}, customQueryFn?: CustomQueryFn) => {
   };
   const { query, variables } = getCustomQuery(customQueryFn, { defaultQuery, defaultVariables });
 
-  const request = await apolloClient.query<OrdersData>({
+  const request = await client.query<OrdersData>({
     query: gql`${query}`,
     variables,
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/api/getMyOrders/index.ts
+++ b/packages/commercetools/api-client/src/api/getMyOrders/index.ts
@@ -1,15 +1,15 @@
-import { apolloClient, CustomQueryFn, getSettings, MeQueryInterface } from './../../index';
+import { CustomQueryFn, getSettings, MeQueryInterface } from '../../index';
 import defaultQuery from './defaultQuery';
-import { buildOrderWhere } from './../../helpers/search';
+import { buildOrderWhere } from '../../helpers/search';
 import gql from 'graphql-tag';
-import { getCustomQuery } from './../../helpers/queries';
+import { getCustomQuery } from '../../helpers/queries';
 
 interface OrdersData {
   me: Pick<MeQueryInterface, 'orders'>;
 }
 
 const getOrders = async (params, customQueryFn?: CustomQueryFn) => {
-  const { locale, acceptLanguage } = getSettings();
+  const { locale, acceptLanguage, client } = getSettings();
   const defaultVariables = {
     where: buildOrderWhere(params),
     sort: params.sort,
@@ -20,7 +20,7 @@ const getOrders = async (params, customQueryFn?: CustomQueryFn) => {
   };
   const { query, variables } = getCustomQuery(customQueryFn, { defaultQuery, defaultVariables });
 
-  const request = await apolloClient.query<OrdersData>({
+  const request = await client.query<OrdersData>({
     query: gql`${query}`,
     variables,
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/api/getProduct/index.ts
+++ b/packages/commercetools/api-client/src/api/getProduct/index.ts
@@ -1,16 +1,16 @@
 import gql from 'graphql-tag';
-import { apolloClient, CustomQueryFn, getSettings } from './../../index';
-import { ProductQueryResult } from './../../types/GraphQL';
+import { CustomQueryFn, getSettings } from '../../index';
+import { ProductQueryResult } from '../../types/GraphQL';
 import defaultQuery from './defaultQuery';
-import { buildProductWhere } from './../../helpers/search';
-import { getCustomQuery } from './../../helpers/queries';
+import { buildProductWhere } from '../../helpers/search';
+import { getCustomQuery } from '../../helpers/queries';
 
 export interface ProductData {
   products: ProductQueryResult;
 }
 
 const getProduct = async (params, customQueryFn?: CustomQueryFn) => {
-  const { locale, acceptLanguage, currency, country } = getSettings();
+  const { locale, acceptLanguage, currency, country, client } = getSettings();
   const defaultVariables = {
     where: buildProductWhere(params),
     skus: params.skus,
@@ -22,7 +22,7 @@ const getProduct = async (params, customQueryFn?: CustomQueryFn) => {
     country
   };
   const { query, variables } = getCustomQuery(customQueryFn, { defaultQuery, defaultVariables });
-  const request = await apolloClient.query<ProductData>({
+  const request = await client.query<ProductData>({
     query: gql`${query}`,
     variables,
     // temporary, seems like bug in apollo:

--- a/packages/commercetools/api-client/src/api/getShippingMethods/index.ts
+++ b/packages/commercetools/api-client/src/api/getShippingMethods/index.ts
@@ -1,6 +1,6 @@
-import { apolloClient, CustomQueryFn, getCustomQuery, getSettings } from '../../index';
+import { CustomQueryFn, getCustomQuery, getSettings } from '../../index';
 import defaultQuery from './defaultQuery';
-import { ShippingMethod } from './../../types/GraphQL';
+import { ShippingMethod } from '../../types/GraphQL';
 import gql from 'graphql-tag';
 
 interface ShippingMethodData {
@@ -8,12 +8,12 @@ interface ShippingMethodData {
 }
 
 const getShippingMethods = async (cartId?: string, customQueryFn?: CustomQueryFn) => {
-  const { acceptLanguage } = getSettings();
+  const { acceptLanguage, client } = getSettings();
   const defaultVariables = {
     acceptLanguage, cartId
   };
   const { query, variables } = getCustomQuery(customQueryFn, { defaultQuery, defaultVariables });
-  return await apolloClient.query<ShippingMethodData>({
+  return await client.query<ShippingMethodData>({
     query: gql`${query}`,
     variables,
     fetchPolicy: 'no-cache'

--- a/packages/commercetools/api-client/src/api/updateCart/index.ts
+++ b/packages/commercetools/api-client/src/api/updateCart/index.ts
@@ -1,5 +1,5 @@
 import { CartUpdateAction, MyCartUpdateAction } from '../../types/GraphQL';
-import { apolloClient, getSettings } from '../../index';
+import { getSettings } from '../../index';
 import { CustomQueryFn } from './../../types/Api';
 import defaultQuery from './defaultMutation';
 import gql from 'graphql-tag';
@@ -12,7 +12,7 @@ interface UpdateCart {
 }
 
 const updateCart = async (params: UpdateCart, customQueryFn?: CustomQueryFn) => {
-  const { locale, acceptLanguage } = getSettings();
+  const { locale, acceptLanguage, client } = getSettings();
   const defaultVariables = params
     ? {
       locale,
@@ -23,7 +23,7 @@ const updateCart = async (params: UpdateCart, customQueryFn?: CustomQueryFn) => 
 
   const { query, variables } = getCustomQuery(customQueryFn, { defaultQuery, defaultVariables });
 
-  const request = await apolloClient.mutate({
+  const request = await client.mutate({
     mutation: gql`${query}`,
     variables,
     fetchPolicy: 'no-cache'

--- a/packages/core/docs/commercetools/changelog.md
+++ b/packages/core/docs/commercetools/changelog.md
@@ -3,6 +3,7 @@
 ## 0.2.5 - not released
 
 - `customQuery` for checkout composables ([#5025](https://github.com/DivanteLtd/vue-storefront/issues/5025))
+- api-client apollo client no longer shared between requests ([#5056](https://github.com/DivanteLtd/vue-storefront/pull/5056))
 
 ## 0.2.4
 


### PR DESCRIPTION
### Short Description and Why It's Useful
Currently if 2 requests are made in within a short space of time, the second request can replace the apolloClient of the first request while the first request is still in progress. This can cause problems if you are extending the apollo client and accessing the request.

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

