### PR TITLE
Default placeholder not displayed on product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Reduce initial client-side bundle-size by lazy-loading `i18n` translations - @cewald (#4821)
 
+### Fixed
+- Display default placeholder on the Product page (#5088)
+
 ## [1.12.2] - 2020.07.28
 
 ### Added

--- a/core/modules/catalog/helpers/getProductGallery.ts
+++ b/core/modules/catalog/helpers/getProductGallery.ts
@@ -15,7 +15,7 @@ export default function getProductGallery (product: Product) {
   }
 
   const productGallery = uniqBy(configurableChildrenImages(product).concat(getMediaGallery(product)), 'src')
-    .filter(f => f.src)
+    .filter(f => f.src && f.src !== config.images.productPlaceholder)
 
   return productGallery
 }

--- a/core/modules/catalog/helpers/getProductGallery.ts
+++ b/core/modules/catalog/helpers/getProductGallery.ts
@@ -15,7 +15,7 @@ export default function getProductGallery (product: Product) {
   }
 
   const productGallery = uniqBy(configurableChildrenImages(product).concat(getMediaGallery(product)), 'src')
-    .filter(f => f.src && f.src !== config.images.productPlaceholder)
+    .filter(f => f.src)
 
   return productGallery
 }

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -112,6 +112,13 @@ export function attributeImages (product) {
       }
     }
   }
+  if (attributeImages.length <= 0) {
+    attributeImages.push({
+      'src': getThumbnailPath(product['image'], config.products.gallery.width, config.products.gallery.height),
+      'loading': getThumbnailPath(product['image'], 310, 300),
+      'error': getThumbnailPath(product['image'], 310, 300)
+    })
+  }
   return attributeImages
 }
 /**

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -112,13 +112,6 @@ export function attributeImages (product) {
       }
     }
   }
-  if (!attributeImages.length) {
-    attributeImages.push({
-      src: getThumbnailPath(product.image, config.products.gallery.width, config.products.gallery.height),
-      loading: getThumbnailPath(product.image, config.products.thumbnails.width, config.products.thumbnails.height),
-      error: getThumbnailPath(product.image, config.products.thumbnails.width, config.products.thumbnails.height)
-    })
-  }
   return attributeImages
 }
 /**

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -105,18 +105,18 @@ export function attributeImages (product) {
     for (let attribute of config.products.gallery.imageAttributes) {
       if (product[attribute]) {
         attributeImages.push({
-          'src': getThumbnailPath(product[attribute], config.products.gallery.width, config.products.gallery.height),
-          'loading': getThumbnailPath(product[attribute], 310, 300),
-          'error': getThumbnailPath(product[attribute], 310, 300)
+          src: getThumbnailPath(product[attribute], config.products.gallery.width, config.products.gallery.height),
+          loading: getThumbnailPath(product[attribute], config.products.thumbnails.width, config.products.thumbnails.height),
+          error: getThumbnailPath(product[attribute], config.products.thumbnails.width, config.products.thumbnails.height)
         })
       }
     }
   }
-  if (attributeImages.length <= 0) {
+  if (!attributeImages.length) {
     attributeImages.push({
-      'src': getThumbnailPath(product['image'], config.products.gallery.width, config.products.gallery.height),
-      'loading': getThumbnailPath(product['image'], 310, 300),
-      'error': getThumbnailPath(product['image'], 310, 300)
+      src: getThumbnailPath(product.image, config.products.gallery.width, config.products.gallery.height),
+      loading: getThumbnailPath(product.image, config.products.thumbnails.width, config.products.thumbnails.height),
+      error: getThumbnailPath(product.image, config.products.thumbnails.width, config.products.thumbnails.height)
     })
   }
   return attributeImages

--- a/core/modules/catalog/store/product/actions.ts
+++ b/core/modules/catalog/store/product/actions.ts
@@ -274,6 +274,13 @@ const actions: ActionTree<ProductState, RootState> = {
 
   setProductGallery (context, { product }) {
     const productGallery = getProductGallery(product)
+    if (productGallery.length <= 0) {
+      productGallery.push({
+        src: config.images.productPlaceholder,
+        loading: config.images.productPlaceholder,
+        error: config.images.productPlaceholder
+      })
+    }
     context.commit(types.PRODUCT_SET_GALLERY, productGallery)
   },
   async loadProductBreadcrumbs ({ dispatch, rootGetters }, { product } = {}) {


### PR DESCRIPTION
### Related Issues
#5087 

closes #5087 

### Short Description and Why It's Useful
If a product does not contain an image, then on the product page default placeholder should be displayed, but currently, the product gallery is blank.


### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

