### PR TITLE
Removed the hardcoded values to define the width/height of the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Reduce initial client-side bundle-size by lazy-loading `i18n` translations - @cewald (#4821)
 
+### Fixed
+- Removed the hardcoded values (#5090)
+
 ## [1.12.2] - 2020.07.28
 
 ### Added

--- a/core/modules/catalog/helpers/index.ts
+++ b/core/modules/catalog/helpers/index.ts
@@ -106,8 +106,8 @@ export function attributeImages (product) {
       if (product[attribute]) {
         attributeImages.push({
           'src': getThumbnailPath(product[attribute], config.products.gallery.width, config.products.gallery.height),
-          'loading': getThumbnailPath(product[attribute], 310, 300),
-          'error': getThumbnailPath(product[attribute], 310, 300)
+          'loading': getThumbnailPath(product[attribute], config.products.thumbnails.width, config.products.thumbnails.height),
+          'error': getThumbnailPath(product[attribute], config.products.thumbnails.width, config.products.thumbnails.height)
         })
       }
     }


### PR DESCRIPTION
### Related Issues
#5090 

closes #5090 

### Short Description and Why It's Useful
We should use the values from the config file and should not use the hardcoded values while defining the width and height.

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

