### PR TITLE
fix(commercetools): [useCheckout] set loading to false when api client throws

### DIFF
--- a/packages/commercetools/composables/src/useCheckout/createLoadShippingMethods.ts
+++ b/packages/commercetools/composables/src/useCheckout/createLoadShippingMethods.ts
@@ -8,9 +8,12 @@ const createLoadShippingMethods = ({ factoryParams, setShippingMethod, cartField
   if (!isShippingAddressCompleted.value) return;
   loading.value.shippingMethods = true;
 
-  const shippingMethodsResponse = await getShippingMethods(cartFields.cart.value.id, customQuery);
-  shippingMethods.value = shippingMethodsResponse.data.shippingMethods;
-  loading.value.shippingMethods = false;
+  try {
+    const shippingMethodsResponse = await getShippingMethods(cartFields.cart.value.id, customQuery);
+    shippingMethods.value = shippingMethodsResponse.data.shippingMethods;
+  } finally {
+    loading.value.shippingMethods = false;
+  }
 };
 
 export default createLoadShippingMethods;

--- a/packages/commercetools/composables/src/useCheckout/createPlaceOrder.ts
+++ b/packages/commercetools/composables/src/useCheckout/createPlaceOrder.ts
@@ -8,11 +8,13 @@ const createPlaceOrder = ({ cartFields }, customQuery?: CustomQuery) => async ()
   loading.value.order = true;
   const { id, version } = cartFields.cart.value;
 
-  const orderResponse = await createMyOrderFromCart({ id, version }, customQuery);
-  const { order } = orderResponse.data;
-
-  loading.value.order = false;
-  return order;
+  try {
+    const orderResponse = await createMyOrderFromCart({ id, version }, customQuery);
+    const { order } = orderResponse.data;
+    return order;
+  } finally {
+    loading.value.order = false;
+  }
 };
 
 export default createPlaceOrder;

--- a/packages/commercetools/composables/src/useCheckout/createSetBillingDetails.ts
+++ b/packages/commercetools/composables/src/useCheckout/createSetBillingDetails.ts
@@ -22,17 +22,20 @@ const createSetBillingDetails = ({ factoryParams, cartFields, setCart }) => asyn
   if (!options.save) return;
   loading.value.billingAddress = true;
 
-  const cartResponse = await updateCart({
-    id: cartFields.cart.value.id,
-    version: cartFields.cart.value.version,
-    actions: [
-      cartActions.setBillingAddressAction(billingDetails.value)
-    ]
-  }, customQuery);
+  try {
+    const cartResponse = await updateCart({
+      id: cartFields.cart.value.id,
+      version: cartFields.cart.value.version,
+      actions: [
+        cartActions.setBillingAddressAction(billingDetails.value)
+      ]
+    }, customQuery);
 
-  setCart(cartResponse.data.cart);
-  initFields(cartResponse.data.cart);
-  loading.value.billingAddress = false;
+    setCart(cartResponse.data.cart);
+    initFields(cartResponse.data.cart);
+  } finally {
+    loading.value.billingAddress = false;
+  }
 };
 
 export default createSetBillingDetails;

--- a/packages/commercetools/composables/src/useCheckout/createSetPersonalDetails.ts
+++ b/packages/commercetools/composables/src/useCheckout/createSetPersonalDetails.ts
@@ -12,18 +12,21 @@ const createSetPersonalDetails = ({ factoryParams, setShippingDetails, cartField
   if (!options.save) return;
   loading.value.personalDetails = true;
 
-  const cartResponse = await updateCart({
-    id: cartFields.cart.value.id,
-    version: cartFields.cart.value.version,
-    actions: [
-      cartActions.setCustomerEmail(personalDetails.value.email)
-    ]
-  }, customQuery);
+  try {
+    const cartResponse = await updateCart({
+      id: cartFields.cart.value.id,
+      version: cartFields.cart.value.version,
+      actions: [
+        cartActions.setCustomerEmail(personalDetails.value.email)
+      ]
+    }, customQuery);
 
-  setCart(cartResponse.data.cart);
-  initFields(cartResponse.data.cart);
-  setShippingDetails({ firstName, lastName });
-  loading.value.personalDetails = false;
+    setCart(cartResponse.data.cart);
+    initFields(cartResponse.data.cart);
+    setShippingDetails({ firstName, lastName });
+  } finally {
+    loading.value.personalDetails = false;
+  }
 };
 
 export default createSetPersonalDetails;

--- a/packages/commercetools/composables/src/useCheckout/createSetShippingDetails.ts
+++ b/packages/commercetools/composables/src/useCheckout/createSetShippingDetails.ts
@@ -25,18 +25,21 @@ const createSetShippingDetails = ({ factoryParams, cartFields, setCart }) => asy
 
   loading.value.shippingAddress = true;
 
-  const cartResponse = await updateCart({
-    id: cartFields.cart.value.id,
-    version: cartFields.cart.value.version,
-    actions: [
-      cartActions.setShippingMethodAction(),
-      cartActions.setShippingAddressAction(shippingDetails.value)
-    ]
-  }, customQuery);
+  try {
+    const cartResponse = await updateCart({
+      id: cartFields.cart.value.id,
+      version: cartFields.cart.value.version,
+      actions: [
+        cartActions.setShippingMethodAction(),
+        cartActions.setShippingAddressAction(shippingDetails.value)
+      ]
+    }, customQuery);
 
-  setCart(cartResponse.data.cart);
-  initFields(cartResponse.data.cart);
-  loading.value.shippingAddress = false;
+    setCart(cartResponse.data.cart);
+    initFields(cartResponse.data.cart);
+  } finally {
+    loading.value.shippingAddress = false;
+  }
 };
 
 export default createSetShippingDetails;

--- a/packages/commercetools/composables/src/useCheckout/createSetShippingMethod.ts
+++ b/packages/commercetools/composables/src/useCheckout/createSetShippingMethod.ts
@@ -11,17 +11,20 @@ const setShippingMethod = ({ factoryParams, cartFields, setCart }) => async (met
   if (!options.save) return;
   loading.value.shippingMethod = true;
 
-  const cartResponse = await updateCart({
-    id: cartFields.cart.value.id,
-    version: cartFields.cart.value.version,
-    actions: [
-      cartActions.setShippingMethodAction(method.id)
-    ]
-  }, customQuery);
+  try {
+    const cartResponse = await updateCart({
+      id: cartFields.cart.value.id,
+      version: cartFields.cart.value.version,
+      actions: [
+        cartActions.setShippingMethodAction(method.id)
+      ]
+    }, customQuery);
 
-  setCart(cartResponse.data.cart);
-  initFields(cartResponse.data.cart);
-  loading.value.shippingMethod = false;
+    setCart(cartResponse.data.cart);
+    initFields(cartResponse.data.cart);
+  } finally {
+    loading.value.shippingMethod = false;
+  }
 };
 
 export default setShippingMethod;

--- a/packages/core/docs/commercetools/changelog.md
+++ b/packages/core/docs/commercetools/changelog.md
@@ -3,6 +3,7 @@
 ## 0.2.6 - not released
 
 - removed `chosenShippingMethod` defaulting ([#5073](https://github.com/DivanteLtd/vue-storefront/issues/5073))
+- fix `useCheckout` - set loading fields to false when api-client throws ([#5096](https://github.com/DivanteLtd/vue-storefront/pull/5096))
 
 ## 0.2.5
 


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

Currently any time the API client throws, loading state for that action remains set to `true`. This should not happen given that when the api client method throws then we know for sure loading something is definitely over (failed, but over).
