### PR TITLE
Allow array of localForage fallback drivers in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add sort options to `CategoryService` class to be able to add a sorting in `storefront-query-builder` style - @cewald (#4926)
 - Added handling redirection on server side and update docs about it - @gibkigonzo (#4647)
 - Added `setConfig` plugin for cypress - @gibkigonzo (#5047)
+- Allow array of localForage fallback drivers in config - @didkan (#5097)
 
 ### Fixed
 

--- a/core/lib/storage-manager.ts
+++ b/core/lib/storage-manager.ts
@@ -7,14 +7,16 @@ import config from 'config'
 function _prepareCacheStorage (key, localized = !config.storeViews.commonCache, storageQuota = 0) {
   const storeView = currentStoreView()
   const dbNamePrefix = storeView && storeView.storeCode ? storeView.storeCode + '-' : ''
-  const cacheDriver = config.localForage && config.localForage.defaultDrivers[key]
+  const cacheDrivers = [].concat(
+    config.localForage && config.localForage.defaultDrivers[key]
     ? config.localForage.defaultDrivers[key]
     : 'LOCALSTORAGE'
+  )
 
   return new UniversalStorage(localForage.createInstance({
     name: localized ? `${dbNamePrefix}shop` : 'shop',
     storeName: key,
-    driver: localForage[cacheDriver]
+    driver: cacheDrivers.map(driver => localForage[driver])
   }), true, storageQuota)
 }
 

--- a/docs/guide/basics/configuration.md
+++ b/docs/guide/basics/configuration.md
@@ -592,6 +592,7 @@ Starting with Vue Storefront v1.6, we changed the default order-placing behavior
 
 We're using [localForage](https://github.com/localForage/localForage) library to providing the persistence layer to Vue Storefront. `localForage` provides the compatibility fallbacks for the users not equipped with some specific storage methods (for example indexedDb). However, we may want to enforce some specific storage methods in the config. This is the place to set it up.
 It is possible to define a specific fallback sequence (as shown in the `elasticCache` property above), if for some reason the default mode of fallback directly to `LOCALSTORAGE` is not wanted.
+(https://localforage.github.io/localForage/#settings-api-setdriver)
 
 ## Users
 

--- a/docs/guide/basics/configuration.md
+++ b/docs/guide/basics/configuration.md
@@ -579,7 +579,7 @@ Starting with Vue Storefront v1.6, we changed the default order-placing behavior
     "categories": "INDEXEDDB",
     "attributes": "INDEXEDDB",
     "products": "INDEXEDDB",
-    "elasticCache": "INDEXEDDB",
+    "elasticCache": ["INDEXEDDB", "WEBSQL", "LOCALSTORAGE"],
     "claims": "LOCALSTORAGE",
     "compare": "INDEXEDDB",
     "syncTasks": "INDEXEDDB",
@@ -591,6 +591,7 @@ Starting with Vue Storefront v1.6, we changed the default order-placing behavior
 ```
 
 We're using [localForage](https://github.com/localForage/localForage) library to providing the persistence layer to Vue Storefront. `localForage` provides the compatibility fallbacks for the users not equipped with some specific storage methods (for example indexedDb). However, we may want to enforce some specific storage methods in the config. This is the place to set it up.
+It is possible to define a specific fallback sequence (as shown in the `elasticCache` property above), if for some reason the default mode of fallback directly to `LOCALSTORAGE` is not wanted.
 
 ## Users
 


### PR DESCRIPTION
### Short Description and Why It's Useful
Since implementing Sentry I have found a ton of errors such as `No available storage method found.`.
Researching those errors I found that `localForage` is only configured with one driver. This means that clients that don't support that one driver will not work with `localForage`. The recommended config is using an array of drivers so that there are fallback drivers when the first one is not supported.

The current implementation in VSF does not allow for using an array in the `localForage` config, due to how `/core/lib/storage-manager.ts` is implemented.
This PR tries to fix that.

Before this fix the `localForage` config could look like this:
```
"localForage": {
  "defaultDrivers": {
    "elasticCache": "INDEXEDDB"
  }
}
```
After this fix we can use an array of fallback drivers like this:
```
"localForage": {
  "defaultDrivers": {
    "elasticCache": ["INDEXEDDB", "WEBSQL", "LOCALSTORAGE"]
  }
}
```

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

