### PR TITLE
Router Refresh fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   add 'beforeUserProfileUpdate' which allows to modify user object before update - gibkigonzo (#4427)
 - replace lodash with lodash-es for client files - gibkigonzo (#5019)
 - add default personal detail loading on shipment step in checkout when user is logged - (#5040)  
+- Got rid of inifnity redirect or page-not-found on refresh category/product view  
 
 ### Changed / Improved
 

--- a/core/package.json
+++ b/core/package.json
@@ -29,7 +29,7 @@
     "vue-meta": "^2.3.3",
     "vue-observe-visibility": "^0.4.1",
     "vue-offline": "^1.0.8",
-    "vue-router": "^3.0.1",
+    "vue-router": "3.1.6",
     "vue-server-renderer": "^2.6.11",
     "vuelidate": "^0.7.5",
     "vuex": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "vue-no-ssr": "^0.2.2",
     "vue-observe-visibility": "^0.4.1",
     "vue-offline": "^1.0.8",
-    "vue-router": "^3.0.1",
+    "vue-router": "3.1.6",
     "vue-server-renderer": "^2.6.11",
     "vuelidate": "^0.7.5",
     "vuex": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17081,7 +17081,12 @@ vue-offline@^1.0.8:
   resolved "https://registry.yarnpkg.com/vue-offline/-/vue-offline-1.0.204.tgz#9c9c0e98fc29cb3334b57848dd4c6f6cd9607d6d"
   integrity sha512-4dYUE81k9tLSPbx7qlJDyKw2QNdNL7aJMuBAfrAhtCjZdZsiXoaS56QApZaTh8BV3yG6sbTdbAD6hDaEYHe3EQ==
 
-vue-router@^3.0.1, vue-router@^3.1.3:
+vue-progressbar@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/vue-progressbar/-/vue-progressbar-0.7.5.tgz#414730892252b1e45582d4979dec93038e007f79"
+  integrity sha512-VeNG/inMsFbvdCTS7lJ1gjDAKSUZdqkhW9gS1tb0we1rqFKxR+BCEiVUgw5C84vODKb14M2GWHTw0WVdpoVg6g==
+
+vue-router@3.1.6, vue-router@^3.1.3:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.1.6.tgz#45f5a3a3843e31702c061dd829393554e4328f89"
   integrity sha512-GYhn2ynaZlysZMkFE5oCHRUTqE8BWs/a9YbKpNLi0i7xD6KG1EzDqpHQmv1F5gXjr8kL5iIVS8EOtRaVUEXTqA==


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Developers who got bigger than 3.1.6 version of Vue Router (mostly 3.4.x) got infinity redirect or page-not-found view after a refresh even though route exists client side. Requesting certain version in the package.json solves the problem

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [x] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [ ] No upgrade steps required (100% backward compatibility and no breaking changes)
- [x] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

