### PR TITLE
fix: boilerplate - on ProductPage inside SfSelect remove SfPproductOption component

### DIFF
--- a/packages/core/nuxt-theme-module/theme/pages/Product.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Product.vue
@@ -68,7 +68,7 @@
               :key="size.value"
               :value="size.value"
             >
-              <SfProductOption :label="size.label" />
+              <span>{{size.label}}</span>
             </SfSelectOption>
           </SfSelect>
           <!-- TODO: add color picker after PR done by SFUI team -->
@@ -201,7 +201,6 @@ import {
   SfPrice,
   SfRating,
   SfSelect,
-  SfProductOption,
   SfAddToCart,
   SfTabs,
   SfGallery,
@@ -289,7 +288,6 @@ export default {
     SfPrice,
     SfRating,
     SfSelect,
-    SfProductOption,
     SfAddToCart,
     SfTabs,
     SfGallery,

--- a/packages/core/nuxt-theme-module/theme/pages/Product.vue
+++ b/packages/core/nuxt-theme-module/theme/pages/Product.vue
@@ -68,13 +68,13 @@
               :key="size.value"
               :value="size.value"
             >
-              <span>{{size.label}}</span>
+              {{size.label}}
             </SfSelectOption>
           </SfSelect>
           <!-- TODO: add color picker after PR done by SFUI team -->
-          <div class="product__colors desktop-only">
+          <div v-if="options.color" class="product__colors desktop-only">
             <p class="product__color-label">Color:</p>
-            <div v-if="options.color">
+            <div>
               <!-- TODO: handle selected logic differently as the selected prop for SfColor is a boolean -->
               <SfColor
                 data-cy="product-color_update"


### PR DESCRIPTION
### Related Issues
closes #5095

### Short Description and Why It's Useful
Replace SfProductOption from SfSelect with span element to avoid SSR mismatch.

### Screenshots of Visual Changes before/after (if There Are Any)
![image](https://user-images.githubusercontent.com/32042425/98300723-f97c0f00-1fb9-11eb-8b50-4e681005f98b.png)


### Which Environment This Relates To

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [x] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

