### PR TITLE
Don't throw exception from nuxt-module if SFUI doesn't exists

### DIFF
--- a/packages/core/nuxt-module/lib/module.js
+++ b/packages/core/nuxt-module/lib/module.js
@@ -16,7 +16,7 @@ const resolveDependencyFromWorkingDir = name => {
   try {
     return require.resolve(name, { paths: [ process.cwd() ] })
   } catch (error) {
-    return '';
+    return false;
   }
 };
 

--- a/packages/core/nuxt-module/lib/module.js
+++ b/packages/core/nuxt-module/lib/module.js
@@ -12,7 +12,13 @@ const log = {
   error: (message) => consola.error(chalk.bold('VSF'), message)
 }
 
-const resolveDependencyFromWorkingDir = name => require.resolve(name, { paths: [ process.cwd() ] });
+const resolveDependencyFromWorkingDir = name => {
+  try {
+    return require.resolve(name, { paths: [ process.cwd() ] })
+  } catch (error) {
+    return '';
+  }
+};
 
 module.exports = function VueStorefrontNuxtModule (moduleOptions) {
   const isProd = process.env.NODE_ENV === 'production';

--- a/packages/core/nuxt-module/package.json
+++ b/packages/core/nuxt-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/nuxt",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "",
   "main": "lib/module.js",
   "scripts": {


### PR DESCRIPTION
### Which Environment This Relates To
- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [X] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [X] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature