### PR TITLE
Add support for HTTP/2 push for JS assets

### DIFF
--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -2,16 +2,6 @@ import webpack from 'webpack';
 
 export default {
   mode: 'universal',
-  render: {
-    http2: {
-      push: true,
-      pushAssets: (request, response, publicPath, preloadFiles) => {
-        return preloadFiles
-          .filter(({ asType }) => asType === 'script')
-          .map(({ file, asType }) => `<${publicPath}${file}>; rel=preload; as=${asType}`);
-      }
-    }
-  },
   server: {
     port: 3000,
     host: '0.0.0.0'

--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -2,6 +2,16 @@ import webpack from 'webpack';
 
 export default {
   mode: 'universal',
+  render: {
+    http2: {
+      push: true,
+      pushAssets: (request, response, publicPath, preloadFiles) => {
+        return preloadFiles
+          .filter(({ asType }) => asType === 'script')
+          .map(({ file, asType }) => `<${publicPath}${file}>; rel=preload; as=${asType}`);
+      }
+    }
+  },
   server: {
     port: 3000,
     host: '0.0.0.0'

--- a/packages/core/nuxt-module/lib/module.js
+++ b/packages/core/nuxt-module/lib/module.js
@@ -3,7 +3,7 @@ const path = require('path')
 const fs = require("fs")
 const consola = require('consola')
 const chalk = require('chalk');
-const { mergeWith, isArray } = require('lodash')
+const { merge, mergeWith, isArray } = require('lodash')
 
 const log = {
   info: (message) => consola.info(chalk.bold('VSF'), message),
@@ -22,18 +22,18 @@ const resolveDependencyFromWorkingDir = name => {
 
 module.exports = function VueStorefrontNuxtModule (moduleOptions) {
   const isProd = process.env.NODE_ENV === 'production';
-  const isSfuiInstalled = fs.existsSync(resolveDependencyFromWorkingDir('@storefront-ui/vue'));
+  const defaultRawSources = fs.existsSync(resolveDependencyFromWorkingDir('@storefront-ui/vue'))
+    ? ['@storefront-ui/vue', '@storefront-ui/shared']
+    : [];
+
   const defaultOptions = {
     coreDevelopment: false,
+    performance : {
+      httpPush: true
+    },
     useRawSource: {
-      prod: isSfuiInstalled ? [
-        '@storefront-ui/vue',
-        '@storefront-ui/shared'
-      ] : [],
-      dev: isSfuiInstalled ? [
-        '@storefront-ui/vue',
-        '@storefront-ui/shared'
-      ] : []
+      prod: defaultRawSources,
+      dev: defaultRawSources
     }
   }
 
@@ -45,36 +45,42 @@ module.exports = function VueStorefrontNuxtModule (moduleOptions) {
 
   log.info(chalk.green('Starting Vue Storefront Nuxt Module'))
 
+  // Add meta data
   this.options.head.meta.push({
     name: 'generator',
     content: 'Vue Storefront 2'
-  })
+  });
+
+  // Enable HTTP/2 push for JS files
+  if (options.performance.httpPush) {
+    this.options.render = merge(this.options.render, {
+      http2: {
+        push: true,
+        pushAssets: (request, response, publicPath, preloadFiles) => {
+          return preloadFiles
+            .filter(({ asType }) => asType === 'script')
+            .map(({ file, asType }) => `<${publicPath}${file}>; rel=preload; as=${asType}`);
+        }
+      }
+    });
+  }
   
+  // SSR plugin
   this.addPlugin(path.resolve(__dirname, 'plugins/ssr.js'))
   log.success('Installed Vue Storefront SSR plugin');
 
+  // Logger plugin
   this.addPlugin({
     src: path.resolve(__dirname, 'plugins/logger.js'),
     options: moduleOptions.logger || {}
   })
   log.success('Installed VSF Logger plugin');
 
+  // Composition API plugin
   this.addModule('@nuxtjs/composition-api')
   log.success('Installed nuxt Composition API Module');
 
-  //-------------------------------------
-
-  // Using symlinks in lerna somehow breaks composition API behavior as a singleton.
-  if (options.coreDevelopment === true) {
-    log.info(`Vue Storefront core development mode is on ${chalk.italic('[coreDevelopment]')}`)
-    if (moduleOptions.coreDevelopment) global.coreDev = true
-    this.extendBuild(config => {
-      config.resolve.alias['@vue/composition-api'] = resolveDependencyFromWorkingDir('@vue/composition-api');
-    });
-  }
-
-  //------------------------------------
-
+  // Use raw sources in development mode
   const useRawSource = (package) => {
     const pkgPath = resolveDependencyFromWorkingDir(`${package}/package.json`);
     const pkg = require(pkgPath);
@@ -86,12 +92,9 @@ module.exports = function VueStorefrontNuxtModule (moduleOptions) {
     }
     this.options.build.transpile.push(package)
     log.info(`Using raw source/ESM for ${chalk.bold(pkg.name)} ${chalk.italic('[useRawSource]')}`)
-  }
+  };
 
-  // always use raw source on core development mode
-  options.useRawSource[isProd || options.coreDevelopment ? 'prod' : 'dev'].map(package => {
-    useRawSource(package);
-  });
+  options.useRawSource[isProd || options.coreDevelopment ? 'prod' : 'dev'].map(package => useRawSource(package));
 }
 
 module.exports.meta = require('../package.json')

--- a/packages/core/nuxt-module/lib/plugins/composition-api.js
+++ b/packages/core/nuxt-module/lib/plugins/composition-api.js
@@ -1,4 +1,3 @@
-
 import Vue from 'vue'
 import VueCompositionApi from '@vue/composition-api'
 

--- a/packages/core/nuxt-module/lib/plugins/logger.js
+++ b/packages/core/nuxt-module/lib/plugins/logger.js
@@ -1,4 +1,3 @@
-
 import { registerLogger } from '@vue-storefront/core'
 
 const loggerPlugin = () => {


### PR DESCRIPTION
# Short Description and Why It's Useful
This PR adds support for HTTP/2 push headers for JS scripts. Tests confirm minor speed improvements (main scripts are requested about 1 second faster on simulated "Slow 3G" connection compared to using only `preload`).

I found our deployed previews (which I used for testing) to be somewhat inconsistent, compared to `vsf-next-demo` page. That's why I did some tests on the latter, which can be compared later, when this PR is merged.

"Before" tests from:
* Dulles, VA - https://www.webpagetest.org/result/201112_Di16_9728e2c1cab8d0099a13f65dbe4e02ee/
* Frankfurt, Germany - https://www.webpagetest.org/result/201113_Di77_1b79de263372beecf7a684571a435b0f/

Closes #5170.

### Which Environment This Relates To
- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [X] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature