### PR TITLE
add lazyVisibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `setConfig` plugin for cypress - @gibkigonzo (#5047)
 - Allow array of localForage fallback drivers in config - @didkan (#5097)
 - Added unit tests for for modules.ts - @TamTran72111 (#5109)
+- Added `lazyVisibility` mixin - performance optimization - @gibkigonzo (#5182)
 
 ### Fixed
 

--- a/core/mixins/createLazyVisibility.js
+++ b/core/mixins/createLazyVisibility.js
@@ -9,11 +9,11 @@ const getMethodName = (scope) => camelCase(`${scope}LazyVisibility`)
  * Options:
  * - scope - changing scope will change method and data names. For example:
  * { scope: 'product' } will result in 'productLazyVisibility' and 'productLazyVisibilityMetadata'
- * - once - will result in making call only once (in other case call will be repeated each time when route is changed)
+ * - onRouteChange - will be repeated each time when route is changed (by default it's called only once)
  */
 const createLazyVisibilityMixin = ({
   scope = '',
-  once = false
+  onRouteChange = false
 } = {}) => ({
   data () {
     return {
@@ -31,7 +31,7 @@ const createLazyVisibilityMixin = ({
         if (!isVisible) return
 
         // make call only once
-        if (this[getMainPropName(scope)].loaded && once) return
+        if (this[getMainPropName(scope)].loaded && !onRouteChange) return
 
         // reset state because route is changed (component may be same)
         if (this[getMainPropName(scope)].path !== this.$route.path) {

--- a/core/mixins/createLazyVisibility.js
+++ b/core/mixins/createLazyVisibility.js
@@ -1,0 +1,55 @@
+import camelCase from 'lodash-es/camelCase'
+
+const getMainPropName = (scope) => camelCase(`${scope}LazyVisibilityMetadata`)
+const getMethodName = (scope) => camelCase(`${scope}LazyVisibility`)
+
+/**
+ * Creates mixin that exposes method 'lazyVisibility' and data 'lazyVisibilityMetadata'
+ * If you want to use it multiple times in one component then you need to create it with different scope.
+ * Options:
+ * - scope - changing scope will change method and data names. For example:
+ * { scope: 'product' } will result in 'productLazyVisibility' and 'productLazyVisibilityMetadata'
+ * - once - will result in making call only once (in other case call will be repeated each time when route is changed)
+ */
+const createLazyVisibilityMixin = ({
+  scope = '',
+  once = false
+} = {}) => ({
+  data () {
+    return {
+      [getMainPropName(scope)]: {
+        loading: false,
+        loaded: false,
+        path: ''
+      }
+    }
+  },
+  methods: {
+    [getMethodName(scope)] (callback) {
+      return async (isVisible) => {
+        // we don't care if component is NOT visible
+        if (!isVisible) return
+
+        // make call only once
+        if (this[getMainPropName(scope)].loaded && once) return
+
+        // reset state because route is changed (component may be same)
+        if (this[getMainPropName(scope)].path !== this.$route.path) {
+          this[getMainPropName(scope)].loading = false
+          this[getMainPropName(scope)].loaded = false
+        }
+
+        // make call
+        if (!this[getMainPropName(scope)].loaded && !this[getMainPropName(scope)].loading) {
+          this[getMainPropName(scope)].path = this.$route.path
+          this[getMainPropName(scope)].loading = true
+          await callback()
+          this[getMainPropName(scope)].loading = false
+          this[getMainPropName(scope)].loaded = true
+        }
+      }
+    }
+  }
+})
+
+export default createLazyVisibilityMixin


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Added `lazyVisibility` mixin. When we will use it with `VueObserveVisibility` then it can gives us a way to load data only when it's needed.
Right now we create content on server side and less relevant actions are triggered on client side.
It is still not fully optimal, because in most cases we don't see content that depends on that client actions.

For example https://github.com/DivanteLtd/vsf-default/pull/50:
On homepage we render new collection, then we use `config.lazyHydrateFor` to get rid of product from new collection to reduce index.html size. Now we need to load products data on client side because we need to hydrate this part of page. But we don't need to make it until user will see those products. Here `lazyVisibility` can be used.

Before:
![Peek 2020-11-13 12-46](https://user-images.githubusercontent.com/42383376/99069235-42c9f100-25ae-11eb-95f9-7193dcb5681c.gif)

After:
![Peek 2020-11-13 12-44](https://user-images.githubusercontent.com/42383376/99069246-465d7800-25ae-11eb-8a72-fa4c5eb9ea1f.gif)


Other examples:
- reviews on PDP
- related products on PDP

TODO: add docs

### Screenshots of Visual Changes before/after (if There Are Any)
<!-- if you made any changes in the UI layer please provide before/after screenshots -->

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

