### PR TITLE
feat: optional compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow array of localForage fallback drivers in config - @didkan (#5097)
 - Added unit tests for for modules.ts - @TamTran72111 (#5109)
 - Added `lazyVisibility` mixin - performance optimization - @gibkigonzo (#5182)
-- `config.server.compression` property for disabling gzip compression
+- `config.server.compression` property for disabling gzip compression (#5183)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow array of localForage fallback drivers in config - @didkan (#5097)
 - Added unit tests for for modules.ts - @TamTran72111 (#5109)
 - Added `lazyVisibility` mixin - performance optimization - @gibkigonzo (#5182)
+- `config.server.compression` property for disabling gzip compression
 
 ### Fixed
 

--- a/config/default.json
+++ b/config/default.json
@@ -10,6 +10,7 @@
       "minifyJS": true,
       "minifyCSS": true
     },
+    "compression": true,
     "useOutputCacheTagging": false,
     "useOutputCache": false,
     "outputCacheDefaultTtl": 86400,

--- a/src/modules/compress/server.ts
+++ b/src/modules/compress/server.ts
@@ -1,9 +1,12 @@
 import { serverHooks } from '@vue-storefront/core/server/hooks'
+import config from 'config'
 
-const compression = require('compression')
-serverHooks.afterApplicationInitialized(({ app, isProd }) => {
-  if (isProd) {
-    console.log('Output Compression is enabled')
-    app.use(compression({ enabled: isProd }))
-  }
-})
+if (config.server.compression) {
+  const compression = require('compression')
+  serverHooks.afterApplicationInitialized(({ app, isProd }) => {
+    if (isProd) {
+      console.log('Output Compression is enabled')
+      app.use(compression({ enabled: isProd }))
+    }
+  })
+}


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Optional compression configurable via config. If someone wants to use brotli compression instead of gzip - she/he will need to disable dis compression and apply Brotli on the server

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

