### PR TITLE
Context implementation

### DIFF
--- a/packages/commercetools/api-client/src/api/customerSignMeIn/index.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeIn/index.ts
@@ -5,7 +5,8 @@ import { SignInResponse } from './../../types/Api';
 import createAccessToken from './../../helpers/createAccessToken';
 
 const customerSignMeIn = async (draft: CustomerSignMeInDraft): Promise<SignInResponse> => {
-  const { locale, acceptLanguage, currentToken, auth, client } = getSettings();
+  const settings = getSettings();
+  const { locale, acceptLanguage, currentToken, auth, client } = settings;
   const loginResponse = await client.mutate({
     mutation: CustomerSignMeInMutation,
     variables: { draft, locale, acceptLanguage },
@@ -13,7 +14,7 @@ const customerSignMeIn = async (draft: CustomerSignMeInDraft): Promise<SignInRes
   }) as SignInResponse;
 
   const customerCredentials = { username: draft.email, password: draft.password };
-  const token = await createAccessToken({ currentToken, customerCredentials });
+  const token = await createAccessToken(settings, { currentToken, customerCredentials });
   auth.onTokenChange(token);
 
   return loginResponse;

--- a/packages/commercetools/api-client/src/api/customerSignMeUp/index.ts
+++ b/packages/commercetools/api-client/src/api/customerSignMeUp/index.ts
@@ -5,6 +5,7 @@ import { SignInResponse } from '../../types/Api';
 import createAccessToken from '../../helpers/createAccessToken';
 
 const customerSignMeUp = async (draft: CustomerSignMeUpDraft): Promise<SignInResponse> => {
+  const settings = getSettings();
   const { locale, acceptLanguage, currentToken, auth, client } = getSettings();
   const registerResponse = await client.mutate({
     mutation: CustomerSignMeUpMutation,
@@ -13,7 +14,7 @@ const customerSignMeUp = async (draft: CustomerSignMeUpDraft): Promise<SignInRes
   }) as SignInResponse;
 
   const customerCredentials = { username: draft.email, password: draft.password };
-  const token = await createAccessToken({ currentToken, customerCredentials });
+  const token = await createAccessToken(settings, { currentToken, customerCredentials });
   auth.onTokenChange(token);
 
   return registerResponse;

--- a/packages/commercetools/api-client/src/helpers/createAccessToken/index.ts
+++ b/packages/commercetools/api-client/src/helpers/createAccessToken/index.ts
@@ -1,7 +1,6 @@
 import SdkAuth, { TokenProvider } from '@commercetools/sdk-auth';
-import { Token, ApiConfig } from '../../types/setup';
+import { Token, ApiConfig, Config } from '../../types/setup';
 import { FlowOptions } from '../../types/Api';
-import { getSettings } from './../../index';
 import { isTokenActive, isTokenUserSession } from './../token';
 
 const createAuthClient = (config: ApiConfig): SdkAuth =>
@@ -16,8 +15,8 @@ const createAuthClient = (config: ApiConfig): SdkAuth =>
     scopes: config.scopes
   });
 
-const getCurrentToken = (options: FlowOptions = {}) => {
-  const { currentToken } = getSettings();
+const getCurrentToken = (settings: Config, options: FlowOptions = {}) => {
+  const { currentToken } = settings;
 
   if (currentToken) {
     return currentToken;
@@ -26,8 +25,8 @@ const getCurrentToken = (options: FlowOptions = {}) => {
   return options.currentToken;
 };
 
-const getTokenFlow = async (sdkAuth: SdkAuth, options: FlowOptions = {}) => {
-  const currentToken = getCurrentToken(options);
+const getTokenFlow = async (settings: Config, sdkAuth: SdkAuth, options: FlowOptions = {}) => {
+  const currentToken = getCurrentToken(settings, options);
 
   if (options.customerCredentials) {
     return sdkAuth.customerPasswordFlow(options.customerCredentials);
@@ -52,10 +51,10 @@ const getTokenFlow = async (sdkAuth: SdkAuth, options: FlowOptions = {}) => {
   return sdkAuth.clientCredentialsFlow();
 };
 
-const createAccessToken = async (options: FlowOptions = {}): Promise<Token> => {
-  const { api } = getSettings();
+const createAccessToken = async (settings: Config, options: FlowOptions = {}): Promise<Token> => {
+  const { api } = settings;
   const sdkAuth = createAuthClient(api);
-  const tokenInfo = await getTokenFlow(sdkAuth, options);
+  const tokenInfo = await getTokenFlow(settings, sdkAuth, options);
   const tokenProvider = new TokenProvider({ sdkAuth }, tokenInfo);
 
   return tokenProvider.getTokenInfo();

--- a/packages/commercetools/api-client/src/helpers/createCommerceToolsLink/index.ts
+++ b/packages/commercetools/api-client/src/helpers/createCommerceToolsLink/index.ts
@@ -3,19 +3,19 @@ import { setContext } from 'apollo-link-context';
 import { ApolloLink } from 'apollo-link';
 import fetch from 'isomorphic-fetch';
 import createAccessToken from './../createAccessToken';
-import { getSettings } from './../../index';
 import { onError } from 'apollo-link-error';
+import { Config } from '../../types/setup';
 
 const restrictedOperations = [
   'getMe',
   'createCart'
 ];
 
-const createCommerceToolsLink = (): ApolloLink => {
-  const { api, currentToken, auth } = getSettings();
+const createCommerceToolsLink = (settings: Config): ApolloLink => {
+  const { api, currentToken, auth } = settings;
   const httpLink = createHttpLink({ uri: api.uri, fetch });
   const authLink = setContext(async (req, { headers }) => {
-    const token = await createAccessToken({
+    const token = await createAccessToken(settings, {
       currentToken,
       requireUserSession: restrictedOperations.includes(req.operationName)
     });

--- a/packages/commercetools/api-client/src/index.ts
+++ b/packages/commercetools/api-client/src/index.ts
@@ -25,20 +25,23 @@ import createAccessToken from './helpers/createAccessToken';
 import { apiClientFactory } from '@vue-storefront/core';
 import { Config, ConfigurableConfig } from './types/setup';
 
-let apolloClient: ApolloClient<any> = null;
-
 const onSetup = (config: Config) => {
-  config.languageMap = config.languageMap || {};
-  config.acceptLanguage = config.languageMap[config.locale] || config.acceptLanguage;
-  apolloClient = new ApolloClient({
-    link: createCommerceToolsLink(),
-    cache: new InMemoryCache(),
-    ...config.customOptions
-  });
-  config.client = apolloClient;
+  const languageMap = config.languageMap || {};
+
+  return {
+    ...config,
+    languageMap,
+    acceptLanguage: languageMap[config.locale] || config.acceptLanguage,
+    client: new ApolloClient({
+      link: createCommerceToolsLink(config),
+      cache: new InMemoryCache(),
+      ...config.customOptions
+    })
+  };
 };
 
 const { setup, update, getSettings } = apiClientFactory<Config, ConfigurableConfig>({
+  tag: 'ct',
   onSetup,
   defaultSettings: {
     locale: 'en',
@@ -57,7 +60,6 @@ const { setup, update, getSettings } = apiClientFactory<Config, ConfigurableConf
 export {
   getSettings,
   createAccessToken,
-  apolloClient,
   setup,
   update,
   getProduct,

--- a/packages/commercetools/composables/nuxt/plugin.js
+++ b/packages/commercetools/composables/nuxt/plugin.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import { setup } from '@vue-storefront/commercetools-api';
 import { mapConfigToSetupObject, CT_TOKEN_COOKIE_NAME } from '@vue-storefront/commercetools/nuxt/helpers'
+import { registerIntegration } from '@vue-storefront/core';
 
 const moduleOptions = JSON.parse('<%= JSON.stringify(options) %>');
 
@@ -11,14 +12,14 @@ import { CT_TOKEN_MIDDLEWARE_SLUG } from '@vue-storefront/commercetools/nuxt/hel
 Middleware[CT_TOKEN_MIDDLEWARE_SLUG] = ctTokenMiddleware(moduleOptions);
 <% } %>
 
-export default ({ app }) => {
+export default registerIntegration(({ app, vsf }) => {
   const currentToken = app.$cookies.get(CT_TOKEN_COOKIE_NAME);
 
   const onTokenChange = (token) => {
     try {
       if (!process.server) {
         app.$cookies.set(CT_TOKEN_COOKIE_NAME, token);
-        setup({ currentToken: token });
+        vsf.configure(setup({ currentToken: token }));
       }
     } catch (e) {
       // Cookies on is set after request has sent.
@@ -27,10 +28,10 @@ export default ({ app }) => {
 
   const onTokenRemove = () => {
     app.$cookies.remove(CT_TOKEN_COOKIE_NAME);
-    setup({ currentToken: null, forceToken: true });
+    vsf.configure(setup({ currentToken: null, forceToken: true }));
   };
 
-  setup(
+  vsf.configure(setup(
     mapConfigToSetupObject({
       moduleOptions,
       app,
@@ -42,5 +43,5 @@ export default ({ app }) => {
         }
       }
     })
-  )
-};
+  ))
+});

--- a/packages/commercetools/composables/nuxt/token-middleware.js
+++ b/packages/commercetools/composables/nuxt/token-middleware.js
@@ -4,7 +4,7 @@ import { mapConfigToSetupObject, CT_TOKEN_COOKIE_NAME } from '@vue-storefront/co
 export default moduleOptions => async ({ app }) => {
   if (!process.server) return;
 
-  const newToken = await createAccessToken();
+  const newToken = await createAccessToken(app.context.$ct);
   app.$cookies.set(CT_TOKEN_COOKIE_NAME, newToken);
   setup(mapConfigToSetupObject({ moduleOptions, app }));
 };

--- a/packages/core/core/src/factories/apiClientFactory.ts
+++ b/packages/core/core/src/factories/apiClientFactory.ts
@@ -2,17 +2,39 @@ import merge from 'lodash-es/merge';
 import { Logger } from './../utils';
 
 interface FactoryParams<T> {
+  tag: string;
   defaultSettings: any;
-  onSetup: (config: T) => void;
+  onSetup: (config: T) => T;
 }
 
+const isNuxt = () => {
+  if (typeof window !== 'undefined') {
+    // @ts-ignore
+    return '$nuxt' in window;
+  }
+
+  // @ts-ignore
+  return 'nuxt' in global.__VUE_SSR_CONTEXT__;
+};
+
+const getSettingsForNuxt = (tag) => {
+  if (typeof window !== 'undefined') {
+    // @ts-ignore
+    return window.$nuxt.context['$' + tag];
+  }
+  // @ts-ignore
+  return global.__VUE_SSR_CONTEXT__.req['$' + tag];
+};
+
 export function apiClientFactory<ALL_SETTINGS, CONFIGURABLE_SETTINGS>(factoryParams: FactoryParams<ALL_SETTINGS>) {
-  let settings = { ...factoryParams.defaultSettings };
+  const tag = factoryParams.tag;
+  let settingsMemory = { ...factoryParams.defaultSettings };
   let setupCalled = false;
   return {
     setup (config: ALL_SETTINGS) {
-      settings = merge(factoryParams.defaultSettings, config);
-      factoryParams.onSetup(settings);
+      const mergedSettings = merge(factoryParams.defaultSettings, config);
+      const settings = factoryParams.onSetup ? factoryParams.onSetup(mergedSettings) : mergedSettings;
+      settingsMemory = { ...settings };
 
       Logger.debug('apiClientFactory.setup', settings);
 
@@ -21,13 +43,24 @@ export function apiClientFactory<ALL_SETTINGS, CONFIGURABLE_SETTINGS>(factoryPar
         Logger.warn('"setup" function is being called multiple times. If you want to update config, please use "update" instead.');
       }
       setupCalled = true;
+
+      return { settings, tag };
     },
     update (config: CONFIGURABLE_SETTINGS) {
-      settings = merge(settings, config);
-      factoryParams.onSetup(settings);
+      const mergedSettings = merge(factoryParams.defaultSettings, config);
+      const settings = factoryParams.onSetup ? factoryParams.onSetup(mergedSettings as any) : mergedSettings;
+      settingsMemory = { ...settings };
 
       Logger.debug('apiClientFactory.update', settings);
+
+      return { settings, tag };
     },
-    getSettings: (): ALL_SETTINGS => Object.freeze({ ...settings })
+    getSettings: (): ALL_SETTINGS => {
+      if (isNuxt()) {
+        return getSettingsForNuxt(tag);
+      }
+
+      return settingsMemory;
+    }
   };
 }

--- a/packages/core/core/src/utils/index.ts
+++ b/packages/core/core/src/utils/index.ts
@@ -5,6 +5,7 @@ import { sharedRef } from './shared';
 import wrap from './wrap';
 import { Logger, registerLogger } from './logger';
 import mask from './logger/mask';
+import { registerIntegration } from './nuxt';
 
 export {
   wrap,
@@ -14,5 +15,6 @@ export {
   sharedRef,
   Logger,
   registerLogger,
-  mask
+  mask,
+  registerIntegration
 };

--- a/packages/core/core/src/utils/nuxt/index.ts
+++ b/packages/core/core/src/utils/nuxt/index.ts
@@ -1,0 +1,11 @@
+export const registerIntegration = (fn) => (ctx, inject) => {
+  const configure = ({ settings, tag }) => {
+    if ((process as any).server) {
+      ctx.req['$' + tag] = settings;
+    }
+
+    inject(tag, settings);
+  };
+
+  return fn({ ...ctx, vsf: { configure } }, inject);
+};


### PR DESCRIPTION
- `getSettings` works as previously but it reads configuration from the context
- to register an integration you have to use `registerIntegration`

```js
import { registerIntegration } from '@vue-storefront/core';
import { setup } from '@vue-storefront/some-integration';

export default registerIntegration(({ app, vsf }) => {
   // it's a regular nuxt plugin 
   vsf.configure(setup({ config here ))
})
```
of course `@vue-storefront/comercetools/nuxt` does the job for you
- calling `apiClientFactory` requires and extra param called `tag` - it's a string identifier of the configuration in the context (we can have many configurations in the context, so we need a tag them)