### PR TITLE
add return types for beforeOutputRendered response mutator hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed / Improved
 
+- Add return types for `beforeOutputRendered` response mutator hook in `hooks.ts` - @lsliwaradioluz (#5242)
 - Add support for boolean filter aggregations in ES7 - @cewald (#4887)
 - Remove vue-lazyload from core - @jahvi (#5045)
 - Remove unnecessary async and Logger import - @jahvi (#5039)

--- a/core/server/hooks.ts
+++ b/core/server/hooks.ts
@@ -66,7 +66,7 @@ const {
 const {
   hook: beforeOutputRenderedResponseHook,
   executor: beforeOutputRenderedResponseExecutor
-} = createMutatorHook<any, any>()
+} = createMutatorHook<any, string | { output: string }>();
 
 const {
   hook: afterOutputRenderedResponseHook,

--- a/core/server/hooks.ts
+++ b/core/server/hooks.ts
@@ -66,7 +66,7 @@ const {
 const {
   hook: beforeOutputRenderedResponseHook,
   executor: beforeOutputRenderedResponseExecutor
-} = createMutatorHook<any, string | { output: string }>();
+} = createMutatorHook<any, string | { output: string, [key: string]: any }>();
 
 const {
   hook: afterOutputRenderedResponseHook,


### PR DESCRIPTION
### Related Issues

closes #5202

### Short Description and Why It's Useful

We have to add return types for beforeOutputRenderedResponse. Otherwise, developers might forget to return value (e.g. they want only to operate on headers) - with types they will be instantly informed about that!

### Screenshots of Visual Changes before/after (if There Are Any)
No visual changes were made

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [x] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [ ] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with description of your change

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vue-storefront/blob/master/CONTRIBUTING.md)

