### PR TITLE
Handle cart version missmatch

### DIFF
--- a/packages/commercetools/api-client/src/api/updateCart/index.ts
+++ b/packages/commercetools/api-client/src/api/updateCart/index.ts
@@ -12,6 +12,7 @@ interface UpdateCart {
   id: string;
   version: number;
   actions: CartUpdateAction[] | MyCartUpdateAction[];
+  versionFallback?: boolean;
 }
 
 const updateCart = async (context, params: UpdateCart, customQueryFn?: CustomQueryFn) => {
@@ -35,7 +36,8 @@ const updateCart = async (context, params: UpdateCart, customQueryFn?: CustomQue
 
     return request;
   } catch (error) {
-    if (!error.toString().includes(VERSION_MISSMATCH_STRING)) {
+    const retry = params.versionFallback ?? true;
+    if (!(error.toString().includes(VERSION_MISSMATCH_STRING) && retry)) {
       throw error;
     }
 

--- a/packages/commercetools/api-client/src/api/updateCart/index.ts
+++ b/packages/commercetools/api-client/src/api/updateCart/index.ts
@@ -1,8 +1,12 @@
+import { Logger } from '@vue-storefront/core';
+import getMe from '../getMe';
 import { CartUpdateAction, MyCartUpdateAction } from '../../types/GraphQL';
 import { CustomQueryFn } from './../../types/Api';
 import defaultQuery from './defaultMutation';
 import gql from 'graphql-tag';
 import { getCustomQuery } from './../../helpers/queries';
+
+const VERSION_MISSMATCH_STRING = 'different version than expected';
 
 interface UpdateCart {
   id: string;
@@ -10,8 +14,8 @@ interface UpdateCart {
   actions: CartUpdateAction[] | MyCartUpdateAction[];
 }
 
-const updateCart = async ({ config, client }, params: UpdateCart, customQueryFn?: CustomQueryFn) => {
-  const { locale, acceptLanguage } = config;
+const updateCart = async (context, params: UpdateCart, customQueryFn?: CustomQueryFn) => {
+  const { locale, acceptLanguage } = context.config;
   const defaultVariables = params
     ? {
       locale,
@@ -22,13 +26,27 @@ const updateCart = async ({ config, client }, params: UpdateCart, customQueryFn?
 
   const { query, variables } = getCustomQuery(customQueryFn, { defaultQuery, defaultVariables });
 
-  const request = await client.mutate({
-    mutation: gql`${query}`,
-    variables,
-    fetchPolicy: 'no-cache'
-  });
+  try {
+    const request = await context.client.mutate({
+      mutation: gql`${query}`,
+      variables,
+      fetchPolicy: 'no-cache'
+    });
 
-  return request;
+    return request;
+  } catch (error) {
+    if (!error.toString().includes(VERSION_MISSMATCH_STRING)) {
+      throw error;
+    }
+
+    Logger.debug('Cart version missmatch. Fetching new version and retrying.');
+
+    const { data } = await getMe(context, { customer: false });
+    return updateCart(context, {
+      ...params,
+      version: data.me.activeCart.version
+    });
+  }
 };
 
 export default updateCart;

--- a/packages/core/docs/commercetools/changelog.md
+++ b/packages/core/docs/commercetools/changelog.md
@@ -5,6 +5,7 @@
 - [BREAKING] removed `availableFilters` and `availableSortingOptions` from `useProduct` ([#4856](https://github.com/DivanteLtd/vue-storefront/issues/4856))
 - [IMPORTANT] removed `@import "~@storefront-ui/vue/styles";` from all components, because SFUI variables and mixins are now available globally and imports will drastically increase bundle size ([#5195](https://github.com/DivanteLtd/vue-storefront/issues/5195))
 - enabled "modern mode" in `yarn build` command ([#5203](https://github.com/DivanteLtd/vue-storefront/issues/5203))
+- retry updating the cart with new version if previous request failed due to a version mismatch ([#5264](https://github.com/DivanteLtd/vue-storefront/issues/5264))
 
 ## 0.2.6
 


### PR DESCRIPTION
### Short Description and Why It's Useful
This PR adds support for detecting if the cart update failed due to a version mismatch. If so, request will be resent with the updated version number.

### Which Environment This Relates To
- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [X] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [x] No upgrade steps required (100% backward compatibility and no breaking changes)
- [ ] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature