### PR TITLE
Set logger levels based on NODE_ENV

### DIFF
--- a/packages/commercetools/theme/nuxt.config.js
+++ b/packages/commercetools/theme/nuxt.config.js
@@ -49,9 +49,6 @@ export default {
     '@nuxtjs/pwa',
     ['@vue-storefront/nuxt', {
       coreDevelopment: true,
-      logger: {
-        verbosity: 'debug'
-      },
       useRawSource: {
         dev: [
           '@vue-storefront/commercetools',

--- a/packages/core/core/src/utils/logger/index.ts
+++ b/packages/core/core/src/utils/logger/index.ts
@@ -1,6 +1,22 @@
 import { VSFLogger } from './../../types';
 import defaultLogger from './defaultLogger';
 
+const defaultModes = {
+  // Test
+  test: 'none',
+
+  // Development
+  dev: 'warn',
+  development: 'warn',
+
+  // Production
+  prod: 'error',
+  production: 'error',
+
+  // Fallback
+  default: 'warn'
+};
+
 let Logger: VSFLogger = defaultLogger;
 
 type LoggerImplementation = VSFLogger | ((verbosity: string) => VSFLogger);
@@ -52,7 +68,7 @@ const registerLogger = (loggerImplementation: LoggerImplementation, verbosity: s
   }
 };
 
-registerLogger(defaultLogger, 'error');
+registerLogger(defaultLogger, defaultModes[process.env.NODE_ENV] || defaultModes.default);
 
 export {
   Logger,

--- a/packages/core/docs/commercetools/changelog.md
+++ b/packages/core/docs/commercetools/changelog.md
@@ -7,6 +7,7 @@
 - enabled "modern mode" in `yarn build` command ([#5203](https://github.com/DivanteLtd/vue-storefront/issues/5203))
 - added missing order getter to get item price ([#5231](https://github.com/DivanteLtd/vue-storefront/issues/5231))
 - retry updating the cart with new version if previous request failed due to a version mismatch ([#5264](https://github.com/DivanteLtd/vue-storefront/issues/5264))
+- removed logging level from nuxt.config.js to use defaults from core ([#5304](https://github.com/DivanteLtd/vue-storefront/issues/5304))
 
 ## 0.2.6
 

--- a/packages/core/docs/contributing/changelog.md
+++ b/packages/core/docs/contributing/changelog.md
@@ -7,6 +7,7 @@
 - added new performance options to `@vue-storefront/nuxt` package ([#5195](https://github.com/DivanteLtd/vue-storefront/issues/5195))
 - open active category and highlight current subcategory on the Category page ([#5244](https://github.com/DivanteLtd/vue-storefront/issues/5244))
 - added missing order getter to get item price ([#5231](https://github.com/DivanteLtd/vue-storefront/issues/5231))
+- changed default logging level to 'warn' and 'error' in development and production mode respectively ([#5304](https://github.com/DivanteLtd/vue-storefront/issues/5304))
 
 ## 2.0.12
 

--- a/packages/core/docs/general/logging.md
+++ b/packages/core/docs/general/logging.md
@@ -26,11 +26,18 @@ registerLogger(myLogger, verbosity);
 
 Additionally, you can also set the `verbosity` level which tells the app, what you want to log and what communications you want to ignore. By default we have the following verbosity levels:
 
-- `debug` - log everything, including debug calls, information, warnings, and errors (all of the logger functions can be called)
-- `info` - log information, warnings, and errors (debug function calling is skipped)
-- `warn` - log warnings and errors (debug and info functions are skipped)
-- `error` - log only errors (debug, warn and info functions are skipped)
-- `none` - don't log anything
+- `debug` - log everything, including debug calls, information, warnings, and errors (all of the logger functions can be called),
+- `info` - log information, warnings, and errors (debug function calling is skipped),
+- `warn` - log warnings and errors (debug and info functions are skipped),
+- `error` - log only errors (debug, warn and info functions are skipped),
+- `none` - don't log anything.
+
+If not explicitely changed, logging level depends on current environment variable `NODE_ENV`:
+
+- `development` or `dev` defaults to `warn`,
+- `production` or `prod` defaults to `error`,
+- `test` defaults to `none`,
+- any other defaults to `warn`
 
 If for some reason you need to write your completely custom logger, with your own verbosity reaction as well, you can pass a function to the `registerLogger` instead. This function returns the logger object and as an argument, you have access to the `verbosity` level.
 
@@ -45,9 +52,6 @@ const logger = (verbosity) => {
    error: (message: any, ...args) => console.error('[VSF][error]', message, ...args),
  }
 }
-
-const verbosity = 'error'
-
 
 registerLogger(logger, verbosity);
 ```

--- a/packages/core/docs/general/logging.md
+++ b/packages/core/docs/general/logging.md
@@ -53,14 +53,14 @@ const logger = (verbosity) => {
  }
 }
 
-registerLogger(logger, verbosity);
+registerLogger(logger, 'error');
 ```
 
 ## Configuring with nuxt
 
 If you are using our nuxt module, setting up the logger is much simpler. All you have to do is just provide the configuration to the module:
 
-```
+```json
 ['@vue-storefront/nuxt', {
   coreDevelopment: true,
   logger: { // new section here


### PR DESCRIPTION
### Short Description and Why It's Useful
Set logger levels based on NODE_ENV.

### Which Environment This Relates To
Check your case. In case of any doubts please read about [Release Cycle](https://docs.vuestorefront.io/guide/basics/release-cycle.html)

- [ ] Test version (https://test.storefrontcloud.io) - this is a new feature or improvement for Vue Storefront. I've created branch from `develop` branch and want to merge it back to `develop`
- [X] RC version (https://next.storefrontcloud.io) - this is a stabilisation fix for Release Candidate of Vue Storefront. I've created branch from `release` branch and want to merge it back to `release`
- [ ] Stable version (https://demo.storefrontcloud.io) - this is an important fix for current stable version. I've created branch from `hotfix` or `master` branch and want to merge it back to `hotfix`

### Upgrade Notes and Changelog
- [ ] No upgrade steps required (100% backward compatibility and no breaking changes)
- [X] I've updated the [Upgrade notes](https://github.com/DivanteLtd/vue-storefront/blob/develop/docs/guide/upgrade-notes/README.md) and [Changelog](https://github.com/DivanteLtd/vue-storefront/blob/develop/CHANGELOG.md) on how to port existing Vue Storefront sites with this new feature
