### PR TITLE
Create method in proper directory

### DIFF
--- a/packages/cli/src/domains/add/endpoint/helpers/frameworkPages/nuxt-page.ts
+++ b/packages/cli/src/domains/add/endpoint/helpers/frameworkPages/nuxt-page.ts
@@ -3,7 +3,7 @@ import { existsDirectory } from "../../../../../utils";
 import { getNuxtPageCode } from "..";
 
 export const writeNuxtPageMethod = async (endpoint: string) => {
-  const nuxtPagesPath = "./playground/app/pages";
+  const nuxtPagesPath = "./playground/app/pages/methods";
 
   const folderExists = await existsDirectory(nuxtPagesPath);
 


### PR DESCRIPTION
Using npx @vue-storefront/cli  add endpoint getSomething is creating the nuxt component in the pages directory.  As a result, added methods don't appear in the playground. It seems like it should be created in the pages/methods directory. 

Also reported in this issue https://github.com/vuestorefront/integration-boilerplate/issues/18 