### PR TITLE
Don't cache TS results

### DIFF
--- a/.changeset/rare-avocados-act.md
+++ b/.changeset/rare-avocados-act.md
@@ -1,0 +1,5 @@
+---
+"@vue-storefront/rollup-config": patch
+---
+
+- [CHANGED] Always clear rollup-plugin-typescript2 cache when building. If you built once with an error, you'd always get an error even if you fixed the underlying code issue that caused the build to fail. This could be fixed by removing node_modules/.cache, but it's better to never create the cache at all.

--- a/engineering-toolkit/rollup-config/src/apiClient.ts
+++ b/engineering-toolkit/rollup-config/src/apiClient.ts
@@ -25,7 +25,7 @@ export function generateServerConfig(pkg: any) {
       nodeResolve({
         extensions,
       }),
-      typescript(),
+      typescript({ clean: true }),
       commonjs({
         extensions,
       }),

--- a/engineering-toolkit/rollup-config/src/base.ts
+++ b/engineering-toolkit/rollup-config/src/base.ts
@@ -26,7 +26,7 @@ export function generateBaseConfig(pkg: any) {
       nodeResolve({
         extensions,
       }),
-      typescript(),
+      typescript({ clean: true }),
     ],
   };
 }

--- a/engineering-toolkit/rollup-config/src/sdk.ts
+++ b/engineering-toolkit/rollup-config/src/sdk.ts
@@ -16,6 +16,6 @@ export function generateSDKConfig(pkg: any) {
       },
     ],
     external: [...Object.keys(pkg.dependencies || {})],
-    plugins: [typescript()],
+    plugins: [typescript({ clean: true })],
   };
 }


### PR DESCRIPTION
This is EXTREMELY annyoing that if you run build once and it fails, the failed build will be cached. Now even if you fix the underlying issue and rebuild, the result will still be cached and you'll be getting a build error even though you fixed everything.

This wastes a lot of time and it must be the third time I've come across this.