### PR TITLE
Pass NODE_AUTH_TOKEN token in CD workflow

### DIFF
--- a/.github/workflows/cd-integrations.yml
+++ b/.github/workflows/cd-integrations.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: yarn --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.VERDACCIO_AUTH_TOKEN }}
 
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
Add token in CD as well, otherwise it won't run in release action