### PR TITLE
Don't compile TS in tests

### DIFF
--- a/.changeset/moody-buttons-exercise.md
+++ b/.changeset/moody-buttons-exercise.md
@@ -1,0 +1,5 @@
+---
+"@vue-storefront/jest-config": patch
+---
+
+- [CHANGED] Do not run TS compilation in tests to improve test suite run times

--- a/engineering-toolkit/jest-config/src/index.js
+++ b/engineering-toolkit/jest-config/src/index.js
@@ -5,7 +5,7 @@ module.exports = {
   baseConfig: {
     preset: "ts-jest",
     transform: {
-      "^.+\\.(j|t)s$": "ts-jest",
+      "^.+\\.(j|t)s$": ["ts-jest", { isolatedModules: true }]
     },
     coverageDirectory: "./coverage/",
     collectCoverageFrom: ["src/**/*.ts"],


### PR DESCRIPTION
This drops the test running time in the enterprise CI from 320s on an M1 Mac to 70s

In GitHub actions, it saves 1m and 5m of runtime on Node 16 and Node 18 respectively