### PR TITLE
Don't output coverage results to stdout

### DIFF
--- a/.changeset/five-gifts-work.md
+++ b/.changeset/five-gifts-work.md
@@ -1,0 +1,5 @@
+---
+"@vue-storefront/jest-config": patch
+---
+
+Don't output coverage results to stdout

--- a/engineering-toolkit/jest-config/src/index.js
+++ b/engineering-toolkit/jest-config/src/index.js
@@ -5,10 +5,11 @@ module.exports = {
   baseConfig: {
     preset: "ts-jest",
     transform: {
-      "^.+\\.(j|t)s$": ["ts-jest", { isolatedModules: true }]
+      "^.+\\.(j|t)s$": ["ts-jest", { isolatedModules: true }],
     },
     coverageDirectory: "./coverage/",
     collectCoverageFrom: ["src/**/*.ts"],
+    coverageRepoters: ["clover", "json", "lcov" /* "text" */],
     testMatch: ["<rootDir>/**/__tests__/**/*spec.[jt]s?(x)"],
   },
 };


### PR DESCRIPTION
Change the default value of coverageReporters from ["clover", "json", "lcov", "text"] to not include "text"

https://jestjs.io/docs/configuration#coveragereporters-arraystring--string-options