### PR TITLE
update turbo from canary version to stable latest 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ts-jest": "^29.0.2",
     "ts-node": "^8.4.1",
     "tslib": "^2.1.0",
-    "turbo": "^2.0.10-canary.1",
+    "turbo": "^2.3.0",
     "typescript": "^5",
     "webpack-bundle-analyzer": "^3.5.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11667,47 +11667,47 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turbo-darwin-64@2.0.10-canary.1:
-  version "2.0.10-canary.1"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-2.0.10-canary.1.tgz#f3341140c46069c6ddd5ff2b3b61b5bdde283d4e"
-  integrity sha512-8OvpcXm+DSpkoLhKSujSZwlpiMbO9/fOnvYL2GnSKilNO8h5Wt3C5lIlkPpSTqE40TQrfcYwtzlDJA1rxWHOTQ==
+turbo-darwin-64@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-2.3.0.tgz#cf82cf4a816a267c65a71d2d3ec1baef5c6b0f78"
+  integrity sha512-pji+D49PhFItyQjf2QVoLZw2d3oRGo8gJgKyOiRzvip78Rzie74quA8XNwSg/DuzM7xx6gJ3p2/LylTTlgZXxQ==
 
-turbo-darwin-arm64@2.0.10-canary.1:
-  version "2.0.10-canary.1"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-2.0.10-canary.1.tgz#e97305fd5d0ceb5fedabbc827ea331cd50fb748e"
-  integrity sha512-+EZgqUqTles5oOi8T6a4MwZye/Mk5+jD5l5ga4NIxSJwRUXe3l3z2UXNw4yWK8B+CnZSxeQsxa0Z/FCKO1sySg==
+turbo-darwin-arm64@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-2.3.0.tgz#3e058a4e41130abce9df49a1fb5e271af85a1d99"
+  integrity sha512-AJrGIL9BO41mwDF/IBHsNGwvtdyB911vp8f5mbNo1wG66gWTvOBg7WCtYQBvCo11XTenTfXPRSsAb7w3WAZb6w==
 
-turbo-linux-64@2.0.10-canary.1:
-  version "2.0.10-canary.1"
-  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-2.0.10-canary.1.tgz#1e8df5c640e3d92d49ad10e4751ef2578c7df9d4"
-  integrity sha512-jsMwBIVgyiArB8JW8aOoLN1Lnkn5rJ+4Ppa4bQxn10rhdA0k4dejcAoW7Evz6mGf+chiQEEMErEhHTl8bZx3ZQ==
+turbo-linux-64@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-2.3.0.tgz#0aefff6047faed0ffdbf0980d5dd4f11ace51d65"
+  integrity sha512-jZqW6vc2sPJT3M/3ZmV1Cg4ecQVPqsbHncG/RnogHpBu783KCSXIndgxvUQNm9qfgBYbZDBnP1md63O4UTElhw==
 
-turbo-linux-arm64@2.0.10-canary.1:
-  version "2.0.10-canary.1"
-  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-2.0.10-canary.1.tgz#4811ab430cd9574cc05f0496387909bab0c214fb"
-  integrity sha512-HkPG8WMhfemacJ3MCibW8lMTfhvj94dLIRqRKL4PHVTIVtHDZk3COwNFGVgLR9gyVDuUatYkvBtD1A+q7aLmjw==
+turbo-linux-arm64@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-2.3.0.tgz#a00db7c7a88400cc0357bfeac2beb383a35e255e"
+  integrity sha512-HUbDLJlvd/hxuyCNO0BmEWYQj0TugRMvSQeG8vHJH+Lq8qOgDAe7J0K73bFNbZejZQxW3C3XEiZFB3pnpO78+A==
 
-turbo-windows-64@2.0.10-canary.1:
-  version "2.0.10-canary.1"
-  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-2.0.10-canary.1.tgz#b49bcb49bf657a4aef6b916aa3c4216af15df1bf"
-  integrity sha512-wdRZ539U1AxcBLn7mYX8AlmqLE2meEwyJjlDQ/uz1U8smBWZGK7fK24JWPR2ye9qmiUXj4dHtCZ6gWry6U20fA==
+turbo-windows-64@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-2.3.0.tgz#f082688f17c73d345efbdc43fb589b1df70cd53f"
+  integrity sha512-c5rxrGNTYDWX9QeMzWLFE9frOXnKjHGEvQMp1SfldDlbZYsloX9UKs31TzUThzfTgTiz8NYuShaXJ2UvTMnV/g==
 
-turbo-windows-arm64@2.0.10-canary.1:
-  version "2.0.10-canary.1"
-  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-2.0.10-canary.1.tgz#5a1911477943e2cd35c4f20f5ae1bc44b3b87801"
-  integrity sha512-nyJozwh6eEYao0sn+ro44m5fkgYS6tqWu2wLu6GmDHvS54Mq8tWSUDccyOj07yuMu84NTcwsyhZkywXMalgMmg==
+turbo-windows-arm64@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-2.3.0.tgz#42d77fe99f72b4862bb4cbbb0cb5dca73427270a"
+  integrity sha512-7qfUuYhfIVb1AZgs89DxhXK+zZez6O2ocmixEQ4hXZK7ytnBt5vaz2zGNJJKFNYIL5HX1C3tuHolnpNgDNCUIg==
 
-turbo@^2.0.10-canary.1:
-  version "2.0.10-canary.1"
-  resolved "https://registry.yarnpkg.com/turbo/-/turbo-2.0.10-canary.1.tgz#2e0e78db6ff992606ee54e892f0cb0a6523657f5"
-  integrity sha512-9nhtpFLEgHP1bN4/C5yNtvqG2L7Uuz2ZFyXVZgmRbT1LpOVs3U0+0mfhmVT0j6x5pnelYssIFgY0IH0RvMb4ZA==
+turbo@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-2.3.0.tgz#01e7841fafdd870564e1ad376b42dbc8a71d52b3"
+  integrity sha512-/uOq5o2jwRPyaUDnwBpOR5k9mQq4c3wziBgWNWttiYQPmbhDtrKYPRBxTvA2WpgQwRIbt8UM612RMN8n/TvmHA==
   optionalDependencies:
-    turbo-darwin-64 "2.0.10-canary.1"
-    turbo-darwin-arm64 "2.0.10-canary.1"
-    turbo-linux-64 "2.0.10-canary.1"
-    turbo-linux-arm64 "2.0.10-canary.1"
-    turbo-windows-64 "2.0.10-canary.1"
-    turbo-windows-arm64 "2.0.10-canary.1"
+    turbo-darwin-64 "2.3.0"
+    turbo-darwin-arm64 "2.3.0"
+    turbo-linux-64 "2.3.0"
+    turbo-linux-arm64 "2.3.0"
+    turbo-windows-64 "2.3.0"
+    turbo-windows-arm64 "2.3.0"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
back in the day the canary version was the first version where the turbo team fixed a bug where the CI would freeze in github actions and run forever

that bugfix was since released in a stable version, so it's ok to now use a regular stable version (whichever is latest)