### PR TITLE
ES-1393 Fix /readyz returning 503 if readinessProbes not defined in options

### DIFF
--- a/.changeset/curly-gifts-hang.md
+++ b/.changeset/curly-gifts-hang.md
@@ -1,0 +1,7 @@
+---
+"@vue-storefront/middleware": patch
+---
+
+- **[FIXED]** Fix /readyz returning 503 if readinessProbes not passed in middleware.config.ts
+
+Before this fix, sending a GET request to `http://localhost:4000/readyz` would return { "status": "error" } and a HTTP 503 status. This happened only when `readinessProbes` wasn't added to middleware options (the default behavior)

--- a/packages/middleware/src/terminus.ts
+++ b/packages/middleware/src/terminus.ts
@@ -30,7 +30,7 @@ export const createReadyzHandler =
   };
 
 export const createTerminusOptions = (
-  readinessChecks: ReadinessProbe[]
+  readinessChecks: ReadinessProbe[] = []
 ): TerminusOptions => {
   return {
     useExit0: true,


### PR DESCRIPTION
ES-1393

This wouldn't happen if the package had null checks enabled